### PR TITLE
fixed account + org settings links

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -7,7 +7,7 @@ const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
   DATABASE_URL: z.string().url(),
   CODESEARCH_URL: z.string().url().optional(),
-  UI_PROXY_URL: z.string().url(),
+  UI_PROXY_URL: z.string().url().default("http://localhost:3002"),
   AUTH_SECRET: z.string().min(32, "AUTH_SECRET must be at least 32 characters"),
   AUTH_BASE_URL: z.string().url().default("https://localhost:3000"),
   AUTH_ISSUER: z.string().min(1).optional(),

--- a/apps/ui/src/lib/auth-client.ts
+++ b/apps/ui/src/lib/auth-client.ts
@@ -4,6 +4,7 @@ import { organizationClient, twoFactorClient } from "better-auth/client/plugins"
 import { createAuthClient } from "better-auth/react"
 
 export const authClient = createAuthClient({
+  baseURL: typeof window !== "undefined" ? window.location.origin : "http://localhost:3000",
   basePath: "/.auth/api/v1/auth",
   plugins: [
     organizationClient(),

--- a/apps/ui/src/providers.tsx
+++ b/apps/ui/src/providers.tsx
@@ -35,7 +35,12 @@ export function Providers({ children }: { children: ReactNode }) {
             window.location.replace(href)
           }}
           persistClient={false}
-          organization={orgSlug ? { slug: orgSlug } : undefined}
+          account={{ basePath: "/.auth/account" }}
+          organization={
+            orgSlug
+              ? { slug: orgSlug, basePath: "/.auth/organization" }
+              : { basePath: "/.auth/organization" }
+          }
           onSessionChange={() => {
             void router.invalidate()
           }}

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as DotauthConsentRouteImport } from './routes/[.]auth.consent'
 import { Route as DotauthAccountRouteImport } from './routes/[.]auth.account'
 import { Route as DotauthAuthViewRouteImport } from './routes/[.]auth.$authView'
 import { Route as OrgSlugRepositoriesRouteImport } from './routes/$orgSlug.repositories'
+import { Route as DotauthOrganizationOrganizationViewRouteImport } from './routes/[.]auth.organization.$organizationView'
 import { Route as DotauthAccountAccountViewRouteImport } from './routes/[.]auth.account.$accountView'
 import { Route as OrgSlugOrganizationOrganizationViewRouteImport } from './routes/$orgSlug.organization.$organizationView'
 
@@ -60,6 +61,12 @@ const OrgSlugRepositoriesRoute = OrgSlugRepositoriesRouteImport.update({
   path: '/$orgSlug/repositories',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DotauthOrganizationOrganizationViewRoute =
+  DotauthOrganizationOrganizationViewRouteImport.update({
+    id: '/.auth/organization/$organizationView',
+    path: '/.auth/organization/$organizationView',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const DotauthAccountAccountViewRoute =
   DotauthAccountAccountViewRouteImport.update({
     id: '/$accountView',
@@ -84,6 +91,7 @@ export interface FileRoutesByFullPath {
   '/$orgSlug/': typeof OrgSlugIndexRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
   '/.auth/account/$accountView': typeof DotauthAccountAccountViewRoute
+  '/.auth/organization/$organizationView': typeof DotauthOrganizationOrganizationViewRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -96,6 +104,7 @@ export interface FileRoutesByTo {
   '/$orgSlug': typeof OrgSlugIndexRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
   '/.auth/account/$accountView': typeof DotauthAccountAccountViewRoute
+  '/.auth/organization/$organizationView': typeof DotauthOrganizationOrganizationViewRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -109,6 +118,7 @@ export interface FileRoutesById {
   '/$orgSlug/': typeof OrgSlugIndexRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
   '/.auth/account/$accountView': typeof DotauthAccountAccountViewRoute
+  '/.auth/organization/$organizationView': typeof DotauthOrganizationOrganizationViewRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -123,6 +133,7 @@ export interface FileRouteTypes {
     | '/$orgSlug/'
     | '/$orgSlug/organization/$organizationView'
     | '/.auth/account/$accountView'
+    | '/.auth/organization/$organizationView'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -135,6 +146,7 @@ export interface FileRouteTypes {
     | '/$orgSlug'
     | '/$orgSlug/organization/$organizationView'
     | '/.auth/account/$accountView'
+    | '/.auth/organization/$organizationView'
   id:
     | '__root__'
     | '/'
@@ -147,6 +159,7 @@ export interface FileRouteTypes {
     | '/$orgSlug/'
     | '/$orgSlug/organization/$organizationView'
     | '/.auth/account/$accountView'
+    | '/.auth/organization/$organizationView'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -159,6 +172,7 @@ export interface RootRouteChildren {
   DotauthSignInRoute: typeof DotauthSignInRoute
   OrgSlugIndexRoute: typeof OrgSlugIndexRoute
   OrgSlugOrganizationOrganizationViewRoute: typeof OrgSlugOrganizationOrganizationViewRoute
+  DotauthOrganizationOrganizationViewRoute: typeof DotauthOrganizationOrganizationViewRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -219,6 +233,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrgSlugRepositoriesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/.auth/organization/$organizationView': {
+      id: '/.auth/organization/$organizationView'
+      path: '/.auth/organization/$organizationView'
+      fullPath: '/.auth/organization/$organizationView'
+      preLoaderRoute: typeof DotauthOrganizationOrganizationViewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/.auth/account/$accountView': {
       id: '/.auth/account/$accountView'
       path: '/$accountView'
@@ -259,6 +280,8 @@ const rootRouteChildren: RootRouteChildren = {
   OrgSlugIndexRoute: OrgSlugIndexRoute,
   OrgSlugOrganizationOrganizationViewRoute:
     OrgSlugOrganizationOrganizationViewRoute,
+  DotauthOrganizationOrganizationViewRoute:
+    DotauthOrganizationOrganizationViewRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)


### PR DESCRIPTION
Problem:
Both menu links to user's org and user's account were hitting 404s.

**Account settings link**: The UserButton was generating /account/settings by default. AuthUIProviderTanstack now knows account pages live at /.auth/account, so it now generates /.auth/account/settings - which matches the existing route [.]auth.account.$accountView.tsx.

**Org settings link**: The OrganizationSwitcher was generating /organization/settings by default. I pointed its basePath to /.auth/organization, so it now generates /.auth/organization/settings. Since there was no route there, we added a thin redirect route [.]auth.organization.$organizationView.tsx that looks up the user's active org and forwards to /$orgSlug/organization/$organizationView - which is where OrganizationView already lives.

Is this approach OK?