### PR TITLE
security tab fixes, checks on change pw, and console log for reset pw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 AGENTS.md
 apps/backend/tsconfig.tsbuildinfo
 apps/codesearch/.env.local
+core

--- a/apps/backend/src/auth/config.ts
+++ b/apps/backend/src/auth/config.ts
@@ -83,6 +83,9 @@ export function createBetterAuth() {
     },
     emailAndPassword: {
       enabled: true,
+      sendResetPassword: async ({ user, url }) => {
+        console.log(`[auth] Password reset requested for ${user.email} — reset URL: ${url}`)
+      },
     },
     socialProviders: {
       github:

--- a/apps/ui/src/providers.tsx
+++ b/apps/ui/src/providers.tsx
@@ -35,6 +35,8 @@ export function Providers({ children }: { children: ReactNode }) {
             window.location.replace(href)
           }}
           persistClient={false}
+          credentials={{ forgotPassword: true }}
+          twoFactor={["totp"]}
           account={{ basePath: "/.auth/account" }}
           organization={
             orgSlug

--- a/apps/ui/src/routes/[.]auth.account.tsx
+++ b/apps/ui/src/routes/[.]auth.account.tsx
@@ -1,32 +1,5 @@
-import { AccountView } from "@daveyplate/better-auth-ui"
-import { createFileRoute } from "@tanstack/react-router"
-import { AppShell } from "@/components/AppShell"
-import { authClient, useSession } from "@/lib/auth-client"
+import { createFileRoute, Outlet } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/.auth/account")({
-  component: AccountPage,
+  component: () => <Outlet />,
 })
-
-function AccountPage() {
-  const { data: session, isPending: sessionPending } = useSession()
-  const { data: activeOrganization, isPending: activeOrgPending } =
-    authClient.useActiveOrganization()
-
-  return (
-    <AppShell>
-      <main className="mx-auto max-w-2xl px-2 py-2 text-zinc-100 sm:px-6 sm:py-10">
-        <h1 className="text-2xl font-semibold">Account</h1>
-        {sessionPending || activeOrgPending ? null : (
-          <p className="mt-4 text-sm text-zinc-300">
-            Signed in as {session?.user.email ?? session?.user.name ?? "unknown"}
-            {" · "}
-            Active org: {activeOrganization?.slug ?? "none"}
-          </p>
-        )}
-        <div className="mt-8">
-          <AccountView pathname="settings" />
-        </div>
-      </main>
-    </AppShell>
-  )
-}

--- a/apps/ui/src/routes/[.]auth.organization.$organizationView.tsx
+++ b/apps/ui/src/routes/[.]auth.organization.$organizationView.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute, Navigate } from "@tanstack/react-router"
+import { useListOrganizations, useSession } from "@/lib/auth-client"
+import { useUserPreferences } from "@/lib/user-preferences"
+
+export const Route = createFileRoute("/.auth/organization/$organizationView")({
+  component: OrgSettingsRedirect,
+})
+
+function OrgSettingsRedirect() {
+  const { organizationView } = Route.useParams()
+  const { data: session, isPending: sessionPending } = useSession()
+  const { data: organizations, isPending: orgsPending } = useListOrganizations()
+  const [preferences] = useUserPreferences()
+
+  if (sessionPending || orgsPending) return null
+  if (!session) return <Navigate to="/.auth/sign-in" replace />
+
+  const storedSlug = preferences.selectedOrganizationSlug
+  const matchingOrg = storedSlug
+    ? organizations?.find((org) => org.slug === storedSlug)
+    : undefined
+  const targetOrg = matchingOrg ?? organizations?.[0]
+
+  if (!targetOrg) return <Navigate to="/" replace />
+
+  return (
+    <Navigate
+      to="/$orgSlug/organization/$organizationView"
+      params={{ orgSlug: targetOrg.slug, organizationView }}
+      replace
+    />
+  )
+}

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -8,6 +8,9 @@ import tsconfigPaths from "vite-tsconfig-paths"
 const config = defineConfig({
   server: {
     allowedHosts: ["ui-bun", "localhost", "127.0.0.1"],
+    watch: {
+      usePolling: true,
+    },
   },
   plugins: [
     devtools(),


### PR DESCRIPTION
**Backend (auth/config.ts)**: Password reset now logs the reset link to the terminal instead of trying to send an email. Lets you test the full flow - we can choose the library later.

**UI (providers.tsx)**: Told the auth UI that credentials (email/password) and 2FA (TOTP) are enabled — this is what makes the Security tab show actual content now

**UI ([.]auth.account.tsx)**: The account page was hardcoded to always show the Settings view, which meant clicking Security did nothing. Fixed it to let the child route decide what to show.

**UI ([.]auth.organization.$organizationView.tsx) (new file)**: The auth UI generates an org settings link without knowing the org's slug, but the app needs the slug in the URL. This redirect looks up the active org and forwards you to the right place.

**UI (vite.config.ts)**: Vite's live-reload (HMR) wasn't working inside Docker on Mac. Added polling so file changes are detected properly - this is what caused the "changes aren't showing up" problem I had.


<img width="861" height="755" alt="CleanShot 2026-03-03 at 23 15 06" src="https://github.com/user-attachments/assets/24031cd0-434d-4613-b202-f62c84b34b0e" />
<img width="1296" height="77" alt="CleanShot 2026-03-03 at 23 14 30" src="https://github.com/user-attachments/assets/4f5786b7-57db-4d76-ab08-0c9b3d2d6fae" />
