### PR TITLE
Graph nav

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -9,7 +9,7 @@ const envSchema = z.object({
   CODESEARCH_URL: z.string().url().optional(),
   UI_PROXY_URL: z.string().url().default("http://localhost:3002"),
   AUTH_SECRET: z.string().min(32, "AUTH_SECRET must be at least 32 characters"),
-  AUTH_BASE_URL: z.string().url().default("https://localhost:3000"),
+  AUTH_BASE_URL: z.string().url().default("http://localhost:3000"),
   AUTH_ISSUER: z.string().min(1).optional(),
   AUTH_ALLOWED_ORIGINS: z.string().optional(),
   AUTH_TOKEN_AUDIENCE_CODESEARCH: z.string().min(1).optional(),

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -9,7 +9,7 @@ const envSchema = z.object({
   CODESEARCH_URL: z.string().url().optional(),
   UI_PROXY_URL: z.string().url().default("http://localhost:3002"),
   AUTH_SECRET: z.string().min(32, "AUTH_SECRET must be at least 32 characters"),
-  AUTH_BASE_URL: z.string().url().default("http://localhost:3000"),
+  AUTH_BASE_URL: z.string().url().default("https://localhost:3000"),
   AUTH_ISSUER: z.string().min(1).optional(),
   AUTH_ALLOWED_ORIGINS: z.string().optional(),
   AUTH_TOKEN_AUDIENCE_CODESEARCH: z.string().min(1).optional(),

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -23,6 +23,7 @@
     "@base-ui/react": "^1.2.0",
     "@better-auth/oauth-provider": "^1.4.18",
     "@better-auth/passkey": "^1.4.18",
+    "@cosmograph/react": "^2.1.0",
     "@daveyplate/better-auth-tanstack": "^1.3.6",
     "@daveyplate/better-auth-ui": "^3.3.15",
     "@scure/base": "^2.0.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -40,6 +40,7 @@
     "@tanstack/react-router-devtools": "^1.162.4",
     "@tanstack/react-router-ssr-query": "^1.162.4",
     "@tanstack/react-start": "^1.162.4",
+    "@tanstack/react-virtual": "^3.13.21",
     "@tanstack/router-plugin": "^1.162.4",
     "ai": "^6.0.105",
     "better-auth": "^1.4.18",

--- a/apps/ui/src/components/SideNav/SideNav.tsx
+++ b/apps/ui/src/components/SideNav/SideNav.tsx
@@ -6,6 +6,8 @@ import {
   IconHome,
   IconGitBranch,
   IconMessageCircle,
+  IconNetwork,
+  IconTag,
 } from "@tabler/icons-react"
 import { SideNavItem } from "./SideNavItem"
 import { SideNavLogo } from "./SideNavLogo"
@@ -93,6 +95,24 @@ export function SideNav() {
             params={{ orgSlug }}
             label="Chat"
             icon={<IconMessageCircle />}
+            expanded={expanded}
+          />
+        </li>
+        <li>
+          <SideNavItem
+            to="/$orgSlug/graph"
+            params={{ orgSlug }}
+            label="Graph"
+            icon={<IconNetwork />}
+            expanded={expanded}
+          />
+        </li>
+        <li>
+          <SideNavItem
+            to="/$orgSlug/entities"
+            params={{ orgSlug }}
+            label="Entities"
+            icon={<IconTag />}
             expanded={expanded}
           />
         </li>

--- a/apps/ui/src/components/SideNav/SideNavItem.tsx
+++ b/apps/ui/src/components/SideNav/SideNavItem.tsx
@@ -9,6 +9,8 @@ type SideNavItemProps = {
     | "/$orgSlug/account/$accountView"
     | "/$orgSlug/repositories"
     | "/$orgSlug/chat"
+    | "/$orgSlug/graph"
+    | "/$orgSlug/entities"
   params: { orgSlug: string | null; accountView?: string }
   label: string
   icon: ReactNode

--- a/apps/ui/src/features/entities/EntityBrowser.tsx
+++ b/apps/ui/src/features/entities/EntityBrowser.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from "react"
+import { useState, useMemo, useRef, useEffect } from "react"
+import { useWindowVirtualizer } from "@tanstack/react-virtual"
 import { IconSearch, IconTrash, IconChevronDown, IconChevronRight } from "@tabler/icons-react"
 import { Modal } from "@/components/ui/Modal"
 import { AlertDialog } from "@/components/ui/AlertDialog"
@@ -8,28 +9,34 @@ import {
   ENTITY_COLORS,
   type EntityType,
   type GraphNode,
+  type GraphLink,
 } from "@/features/graph/stub-data"
 import { toast } from "sonner"
 
-const TYPE_ORDER: EntityType[] = [
-  "Repository",
-  "File",
-  "Class",
-  "Function",
-  "Concept",
-]
+const TYPE_ORDER: EntityType[] = ["Repository", "File", "Class", "Function", "Concept"]
 
-function getRelationships(nodeId: string) {
-  const outgoing = STUB_LINKS.filter((l) => l.source === nodeId)
-  const incoming = STUB_LINKS.filter((l) => l.target === nodeId)
-  return { outgoing, incoming }
+// Pre-compute O(1) lookup maps at module level — never recomputed
+const NODE_MAP = new Map<string, GraphNode>(STUB_NODES.map((n) => [n.id, n]))
+
+const OUTGOING_MAP = new Map<string, GraphLink[]>()
+const INCOMING_MAP = new Map<string, GraphLink[]>()
+for (const link of STUB_LINKS) {
+  if (!OUTGOING_MAP.has(link.source)) OUTGOING_MAP.set(link.source, [])
+  OUTGOING_MAP.get(link.source)!.push(link)
+  if (!INCOMING_MAP.has(link.target)) INCOMING_MAP.set(link.target, [])
+  INCOMING_MAP.get(link.target)!.push(link)
 }
 
-function nodeById(id: string): GraphNode | undefined {
-  return STUB_NODES.find((n) => n.id === id)
-}
+// Pre-compute per-node relationship counts
+const REL_COUNT_MAP = new Map<string, number>(
+  STUB_NODES.map((n) => [
+    n.id,
+    (OUTGOING_MAP.get(n.id)?.length ?? 0) + (INCOMING_MAP.get(n.id)?.length ?? 0),
+  ]),
+)
 
 export function EntityBrowser() {
+  const listRef = useRef<HTMLDivElement>(null)
   const [search, setSearch] = useState("")
   const [typeFilter, setTypeFilter] = useState<EntityType | "All">("All")
   const [expandedId, setExpandedId] = useState<string | null>(null)
@@ -51,6 +58,26 @@ export function EntityBrowser() {
     )
   }, [search, typeFilter, deletedIds])
 
+  const typeCounts = useMemo(() => {
+    const counts: Partial<Record<EntityType | "All", number>> = { All: filtered.length }
+    for (const node of filtered) counts[node.type] = (counts[node.type] ?? 0) + 1
+    return counts
+  }, [filtered])
+
+  const virtualizer = useWindowVirtualizer({
+    count: filtered.length,
+    estimateSize: () => 56,
+    overscan: 10,
+    scrollMargin: listRef.current?.offsetTop ?? 0,
+    measureElement:
+      typeof window !== "undefined" ? (el) => el.getBoundingClientRect().height : undefined,
+  })
+
+  // Re-measure when the expanded row changes height
+  useEffect(() => {
+    virtualizer.measure()
+  }, [expandedId, virtualizer])
+
   const handleDelete = (node: GraphNode) => {
     setDeletedIds((prev) => new Set([...prev, node.id]))
     setNodeToDelete(null)
@@ -58,16 +85,11 @@ export function EntityBrowser() {
     toast.success(`Entity "${node.name}" deleted`)
   }
 
-  const typeCounts = useMemo(() => {
-    const counts: Partial<Record<EntityType | "All", number>> = { All: filtered.length }
-    for (const node of filtered) {
-      counts[node.type] = (counts[node.type] ?? 0) + 1
-    }
-    return counts
-  }, [filtered])
+  const items = virtualizer.getVirtualItems()
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+    <div className="px-6 py-8">
+      {/* Header + search */}
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold text-zinc-100">Entities</h1>
@@ -75,9 +97,7 @@ export function EntityBrowser() {
             Browse and manage knowledge graph nodes for this organisation
           </p>
         </div>
-
-        {/* Search */}
-        <div className="relative w-full sm:w-64">
+        <div className="relative w-full sm:w-72">
           <IconSearch
             className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500"
             aria-hidden="true"
@@ -110,10 +130,7 @@ export function EntityBrowser() {
               ].join(" ")}
             >
               {color && (
-                <span
-                  className="inline-block h-2 w-2 rounded-full"
-                  style={{ backgroundColor: color }}
-                />
+                <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: color }} />
               )}
               {type}
               <span className="tabular-nums opacity-60">({count})</span>
@@ -124,24 +141,36 @@ export function EntityBrowser() {
 
       {/* Entity list */}
       {filtered.length === 0 ? (
-        <p className="mt-12 text-center text-sm text-zinc-500">
-          No entities match your search.
-        </p>
+        <p className="mt-12 text-center text-sm text-zinc-500">No entities match your search.</p>
       ) : (
-        <div className="divide-y divide-white/6 rounded-xl border border-white/8 bg-zinc-900/50">
-          {filtered.map((node) => {
+        <div
+          className="rounded-xl border border-white/8 bg-zinc-900/50"
+          style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+          ref={listRef}
+        >
+          {items.map((virtualRow) => {
+            const node = filtered[virtualRow.index]
             const isExpanded = expandedId === node.id
-            const { outgoing, incoming } = getRelationships(node.id)
-            const relCount = outgoing.length + incoming.length
+            const relCount = REL_COUNT_MAP.get(node.id) ?? 0
 
             return (
-              <div key={node.id}>
+              <div
+                key={virtualRow.key}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
+                }}
+                className={virtualRow.index > 0 ? "border-t border-white/6" : undefined}
+              >
                 <div className="flex items-center gap-3 px-4 py-3 hover:bg-white/[0.02]">
                   {/* Expand toggle */}
                   <button
-                    onClick={() =>
-                      setExpandedId(isExpanded ? null : node.id)
-                    }
+                    onClick={() => setExpandedId(isExpanded ? null : node.id)}
                     className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:text-zinc-300"
                     aria-label={isExpanded ? "Collapse" : "Expand relationships"}
                   >
@@ -160,21 +189,24 @@ export function EntityBrowser() {
 
                   {/* Name + description */}
                   <div className="min-w-0 flex-1">
-                    <p className="truncate font-mono text-sm text-zinc-100">
-                      {node.name}
-                    </p>
+                    <p className="truncate font-mono text-sm text-zinc-100">{node.name}</p>
                     {node.description && (
-                      <p className="truncate text-xs text-zinc-500">
-                        {node.description}
-                      </p>
+                      <p className="truncate text-xs text-zinc-500">{node.description}</p>
                     )}
                   </div>
+
+                  {/* Repository */}
+                  {node.repository && (
+                    <span className="hidden shrink-0 truncate text-xs text-zinc-500 sm:block sm:max-w-[180px]">
+                      {node.repository}
+                    </span>
+                  )}
 
                   {/* Type badge */}
                   <TypeBadge type={node.type} />
 
                   {/* Relationship count */}
-                  <span className="shrink-0 text-xs tabular-nums text-zinc-500">
+                  <span className="w-16 shrink-0 text-right text-xs tabular-nums text-zinc-500">
                     {relCount} rel{relCount !== 1 ? "s" : ""}
                   </span>
 
@@ -188,13 +220,9 @@ export function EntityBrowser() {
                   </button>
                 </div>
 
-                {/* Relationship panel */}
                 {isExpanded && (
                   <div className="border-t border-white/6 bg-zinc-950/50 px-4 py-3">
-                    <RelationshipPanel
-                      outgoing={outgoing}
-                      incoming={incoming}
-                    />
+                    <RelationshipPanel nodeId={node.id} />
                   </div>
                 )}
               </div>
@@ -217,7 +245,7 @@ export function EntityBrowser() {
             cancelLabel="Cancel"
             onAction={() => handleDelete(nodeToDelete)}
           >
-            Delete <span className="font-mono font-medium">"{nodeToDelete.name}"</span>?
+            Delete <span className="font-mono font-medium">"{nodeToDelete.name}"</span>?{" "}
             This will remove the node and all its relationships from the knowledge graph.
           </AlertDialog>
         </Modal>
@@ -241,83 +269,64 @@ function TypeBadge({ type }: { type: EntityType }) {
   )
 }
 
-function RelationshipPanel({
-  outgoing,
-  incoming,
-}: {
-  outgoing: ReturnType<typeof getRelationships>["outgoing"]
-  incoming: ReturnType<typeof getRelationships>["incoming"]
-}) {
+function RelationshipPanel({ nodeId }: { nodeId: string }) {
+  const outgoing = OUTGOING_MAP.get(nodeId) ?? []
+  const incoming = INCOMING_MAP.get(nodeId) ?? []
+
   if (outgoing.length === 0 && incoming.length === 0) {
-    return (
-      <p className="text-xs text-zinc-600">No relationships.</p>
-    )
+    return <p className="text-xs text-zinc-600">No relationships.</p>
   }
 
   return (
     <div className="flex flex-col gap-4 sm:flex-row sm:gap-8">
       {outgoing.length > 0 && (
-        <div className="min-w-0 flex-1">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500">
-            Outgoing
-          </p>
-          <ul className="space-y-1">
-            {outgoing.map((link, i) => {
-              const target = nodeById(link.target)
-              return (
-                <li key={i} className="flex items-center gap-2 text-xs">
-                  <RelBadge type={link.type} />
-                  {target && (
-                    <span
-                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
-                      style={{ backgroundColor: ENTITY_COLORS[target.type] }}
-                    />
-                  )}
-                  <span className="truncate font-mono text-zinc-300">
-                    {target?.name ?? link.target}
-                  </span>
-                  {target && (
-                    <span className="shrink-0 text-zinc-600">
-                      ({target.type})
-                    </span>
-                  )}
-                </li>
-              )
-            })}
-          </ul>
-        </div>
+        <RelationshipList title="Outgoing" links={outgoing} idKey="target" />
       )}
-
       {incoming.length > 0 && (
-        <div className="min-w-0 flex-1">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500">
-            Incoming
-          </p>
-          <ul className="space-y-1">
-            {incoming.map((link, i) => {
-              const source = nodeById(link.source)
-              return (
-                <li key={i} className="flex items-center gap-2 text-xs">
-                  <RelBadge type={link.type} />
-                  {source && (
-                    <span
-                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
-                      style={{ backgroundColor: ENTITY_COLORS[source.type] }}
-                    />
-                  )}
-                  <span className="truncate font-mono text-zinc-300">
-                    {source?.name ?? link.source}
-                  </span>
-                  {source && (
-                    <span className="shrink-0 text-zinc-600">
-                      ({source.type})
-                    </span>
-                  )}
-                </li>
-              )
-            })}
-          </ul>
-        </div>
+        <RelationshipList title="Incoming" links={incoming} idKey="source" />
+      )}
+    </div>
+  )
+}
+
+function RelationshipList({
+  title,
+  links,
+  idKey,
+}: {
+  title: string
+  links: GraphLink[]
+  idKey: "source" | "target"
+}) {
+  const MAX_SHOWN = 50
+  const shown = links.slice(0, MAX_SHOWN)
+
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500">{title}</p>
+      <ul className="space-y-1">
+        {shown.map((link, i) => {
+          const peerId = link[idKey]
+          const peer = NODE_MAP.get(peerId)
+          return (
+            <li key={i} className="flex items-center gap-2 text-xs">
+              <RelBadge type={link.type} />
+              {peer && (
+                <span
+                  className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: ENTITY_COLORS[peer.type] }}
+                />
+              )}
+              <span className="truncate font-mono text-zinc-300">{peer?.name ?? peerId}</span>
+              {peer && <span className="shrink-0 text-zinc-600">({peer.type})</span>}
+            </li>
+          )
+        })}
+      </ul>
+      {links.length > MAX_SHOWN && (
+        <p className="mt-1 text-xs text-zinc-600">
+          +{(links.length - MAX_SHOWN).toLocaleString()} more
+        </p>
       )}
     </div>
   )
@@ -328,9 +337,7 @@ function RelBadge({ type }: { type: "related_to" | "mentions" }) {
     <span
       className={[
         "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-mono font-medium",
-        type === "related_to"
-          ? "bg-teal-500/15 text-teal-400"
-          : "bg-blue-500/15 text-blue-400",
+        type === "related_to" ? "bg-teal-500/15 text-teal-400" : "bg-blue-500/15 text-blue-400",
       ].join(" ")}
     >
       {type}

--- a/apps/ui/src/features/entities/EntityBrowser.tsx
+++ b/apps/ui/src/features/entities/EntityBrowser.tsx
@@ -1,0 +1,339 @@
+import { useState, useMemo } from "react"
+import { IconSearch, IconTrash, IconChevronDown, IconChevronRight } from "@tabler/icons-react"
+import { Modal } from "@/components/ui/Modal"
+import { AlertDialog } from "@/components/ui/AlertDialog"
+import {
+  STUB_NODES,
+  STUB_LINKS,
+  ENTITY_COLORS,
+  type EntityType,
+  type GraphNode,
+} from "@/features/graph/stub-data"
+import { toast } from "sonner"
+
+const TYPE_ORDER: EntityType[] = [
+  "Repository",
+  "File",
+  "Class",
+  "Function",
+  "Concept",
+]
+
+function getRelationships(nodeId: string) {
+  const outgoing = STUB_LINKS.filter((l) => l.source === nodeId)
+  const incoming = STUB_LINKS.filter((l) => l.target === nodeId)
+  return { outgoing, incoming }
+}
+
+function nodeById(id: string): GraphNode | undefined {
+  return STUB_NODES.find((n) => n.id === id)
+}
+
+export function EntityBrowser() {
+  const [search, setSearch] = useState("")
+  const [typeFilter, setTypeFilter] = useState<EntityType | "All">("All")
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [nodeToDelete, setNodeToDelete] = useState<GraphNode | null>(null)
+  const [deletedIds, setDeletedIds] = useState<Set<string>>(new Set())
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return STUB_NODES.filter((n) => {
+      if (deletedIds.has(n.id)) return false
+      if (typeFilter !== "All" && n.type !== typeFilter) return false
+      if (q && !n.name.toLowerCase().includes(q) && !n.description?.toLowerCase().includes(q))
+        return false
+      return true
+    }).sort(
+      (a, b) =>
+        TYPE_ORDER.indexOf(a.type) - TYPE_ORDER.indexOf(b.type) ||
+        a.name.localeCompare(b.name),
+    )
+  }, [search, typeFilter, deletedIds])
+
+  const handleDelete = (node: GraphNode) => {
+    setDeletedIds((prev) => new Set([...prev, node.id]))
+    setNodeToDelete(null)
+    if (expandedId === node.id) setExpandedId(null)
+    toast.success(`Entity "${node.name}" deleted`)
+  }
+
+  const typeCounts = useMemo(() => {
+    const counts: Partial<Record<EntityType | "All", number>> = { All: filtered.length }
+    for (const node of filtered) {
+      counts[node.type] = (counts[node.type] ?? 0) + 1
+    }
+    return counts
+  }, [filtered])
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-zinc-100">Entities</h1>
+          <p className="mt-1 text-sm text-zinc-400">
+            Browse and manage knowledge graph nodes for this organisation
+          </p>
+        </div>
+
+        {/* Search */}
+        <div className="relative w-full sm:w-64">
+          <IconSearch
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500"
+            aria-hidden="true"
+          />
+          <input
+            type="search"
+            placeholder="Search entities…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-9 w-full rounded-lg border border-white/10 bg-zinc-900 pl-9 pr-3 text-sm text-zinc-100 placeholder-zinc-500 outline-none focus:border-teal-500/60 focus:ring-1 focus:ring-teal-500/30"
+          />
+        </div>
+      </div>
+
+      {/* Type filter pills */}
+      <div className="mb-4 flex flex-wrap gap-2">
+        {(["All", ...TYPE_ORDER] as const).map((type) => {
+          const count = typeCounts[type] ?? 0
+          const isActive = typeFilter === type
+          const color = type !== "All" ? ENTITY_COLORS[type] : undefined
+          return (
+            <button
+              key={type}
+              onClick={() => setTypeFilter(type)}
+              className={[
+                "flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                isActive
+                  ? "border-transparent bg-teal-500/20 text-teal-300"
+                  : "border-white/10 text-zinc-400 hover:border-white/20 hover:text-zinc-200",
+              ].join(" ")}
+            >
+              {color && (
+                <span
+                  className="inline-block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: color }}
+                />
+              )}
+              {type}
+              <span className="tabular-nums opacity-60">({count})</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Entity list */}
+      {filtered.length === 0 ? (
+        <p className="mt-12 text-center text-sm text-zinc-500">
+          No entities match your search.
+        </p>
+      ) : (
+        <div className="divide-y divide-white/6 rounded-xl border border-white/8 bg-zinc-900/50">
+          {filtered.map((node) => {
+            const isExpanded = expandedId === node.id
+            const { outgoing, incoming } = getRelationships(node.id)
+            const relCount = outgoing.length + incoming.length
+
+            return (
+              <div key={node.id}>
+                <div className="flex items-center gap-3 px-4 py-3 hover:bg-white/[0.02]">
+                  {/* Expand toggle */}
+                  <button
+                    onClick={() =>
+                      setExpandedId(isExpanded ? null : node.id)
+                    }
+                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:text-zinc-300"
+                    aria-label={isExpanded ? "Collapse" : "Expand relationships"}
+                  >
+                    {isExpanded ? (
+                      <IconChevronDown className="h-4 w-4" />
+                    ) : (
+                      <IconChevronRight className="h-4 w-4" />
+                    )}
+                  </button>
+
+                  {/* Type dot */}
+                  <span
+                    className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: ENTITY_COLORS[node.type] }}
+                  />
+
+                  {/* Name + description */}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-mono text-sm text-zinc-100">
+                      {node.name}
+                    </p>
+                    {node.description && (
+                      <p className="truncate text-xs text-zinc-500">
+                        {node.description}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Type badge */}
+                  <TypeBadge type={node.type} />
+
+                  {/* Relationship count */}
+                  <span className="shrink-0 text-xs tabular-nums text-zinc-500">
+                    {relCount} rel{relCount !== 1 ? "s" : ""}
+                  </span>
+
+                  {/* Delete */}
+                  <button
+                    onClick={() => setNodeToDelete(node)}
+                    aria-label={`Delete ${node.name}`}
+                    className="shrink-0 rounded p-1 text-zinc-600 transition-colors hover:bg-red-500/15 hover:text-red-400"
+                  >
+                    <IconTrash className="h-4 w-4" />
+                  </button>
+                </div>
+
+                {/* Relationship panel */}
+                {isExpanded && (
+                  <div className="border-t border-white/6 bg-zinc-950/50 px-4 py-3">
+                    <RelationshipPanel
+                      outgoing={outgoing}
+                      incoming={incoming}
+                    />
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Delete confirmation */}
+      {nodeToDelete && (
+        <Modal
+          isOpen={!!nodeToDelete}
+          onOpenChange={(open) => !open && setNodeToDelete(null)}
+          isDismissable
+        >
+          <AlertDialog
+            title="Delete entity"
+            variant="destructive"
+            actionLabel="Delete"
+            cancelLabel="Cancel"
+            onAction={() => handleDelete(nodeToDelete)}
+          >
+            Delete <span className="font-mono font-medium">"{nodeToDelete.name}"</span>?
+            This will remove the node and all its relationships from the knowledge graph.
+          </AlertDialog>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+function TypeBadge({ type }: { type: EntityType }) {
+  return (
+    <span
+      className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+      style={{
+        backgroundColor: `${ENTITY_COLORS[type]}18`,
+        color: ENTITY_COLORS[type],
+        border: `1px solid ${ENTITY_COLORS[type]}33`,
+      }}
+    >
+      {type}
+    </span>
+  )
+}
+
+function RelationshipPanel({
+  outgoing,
+  incoming,
+}: {
+  outgoing: ReturnType<typeof getRelationships>["outgoing"]
+  incoming: ReturnType<typeof getRelationships>["incoming"]
+}) {
+  if (outgoing.length === 0 && incoming.length === 0) {
+    return (
+      <p className="text-xs text-zinc-600">No relationships.</p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:gap-8">
+      {outgoing.length > 0 && (
+        <div className="min-w-0 flex-1">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500">
+            Outgoing
+          </p>
+          <ul className="space-y-1">
+            {outgoing.map((link, i) => {
+              const target = nodeById(link.target)
+              return (
+                <li key={i} className="flex items-center gap-2 text-xs">
+                  <RelBadge type={link.type} />
+                  {target && (
+                    <span
+                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: ENTITY_COLORS[target.type] }}
+                    />
+                  )}
+                  <span className="truncate font-mono text-zinc-300">
+                    {target?.name ?? link.target}
+                  </span>
+                  {target && (
+                    <span className="shrink-0 text-zinc-600">
+                      ({target.type})
+                    </span>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+
+      {incoming.length > 0 && (
+        <div className="min-w-0 flex-1">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500">
+            Incoming
+          </p>
+          <ul className="space-y-1">
+            {incoming.map((link, i) => {
+              const source = nodeById(link.source)
+              return (
+                <li key={i} className="flex items-center gap-2 text-xs">
+                  <RelBadge type={link.type} />
+                  {source && (
+                    <span
+                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: ENTITY_COLORS[source.type] }}
+                    />
+                  )}
+                  <span className="truncate font-mono text-zinc-300">
+                    {source?.name ?? link.source}
+                  </span>
+                  {source && (
+                    <span className="shrink-0 text-zinc-600">
+                      ({source.type})
+                    </span>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function RelBadge({ type }: { type: "related_to" | "mentions" }) {
+  return (
+    <span
+      className={[
+        "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-mono font-medium",
+        type === "related_to"
+          ? "bg-teal-500/15 text-teal-400"
+          : "bg-blue-500/15 text-blue-400",
+      ].join(" ")}
+    >
+      {type}
+    </span>
+  )
+}

--- a/apps/ui/src/features/entities/EntityBrowser.tsx
+++ b/apps/ui/src/features/entities/EntityBrowser.tsx
@@ -73,10 +73,15 @@ export function EntityBrowser() {
       typeof window !== "undefined" ? (el) => el.getBoundingClientRect().height : undefined,
   })
 
+  // Keep a stable ref to measure() so the effect below doesn't need the
+  // virtualizer object itself as a dependency (it changes identity each render).
+  const measureRef = useRef(virtualizer.measure.bind(virtualizer))
+  measureRef.current = virtualizer.measure.bind(virtualizer)
+
   // Re-measure when the expanded row changes height
   useEffect(() => {
-    virtualizer.measure()
-  }, [expandedId, virtualizer])
+    measureRef.current()
+  }, [expandedId])
 
   const handleDelete = (node: GraphNode) => {
     setDeletedIds((prev) => new Set([...prev, node.id]))

--- a/apps/ui/src/features/entities/EntityBrowser.tsx
+++ b/apps/ui/src/features/entities/EntityBrowser.tsx
@@ -15,6 +15,11 @@ import { toast } from "sonner"
 
 const TYPE_ORDER: EntityType[] = ["Repository", "File", "Class", "Function", "Concept"]
 
+// Sorted list of unique repository names for the repo filter dropdown
+const ALL_REPOS = [
+  ...new Set(STUB_NODES.filter((n) => n.repository).map((n) => n.repository!)),
+].sort()
+
 // Pre-compute O(1) lookup maps at module level — never recomputed
 const NODE_MAP = new Map<string, GraphNode>(STUB_NODES.map((n) => [n.id, n]))
 
@@ -39,6 +44,7 @@ export function EntityBrowser() {
   const listRef = useRef<HTMLDivElement>(null)
   const [search, setSearch] = useState("")
   const [typeFilter, setTypeFilter] = useState<EntityType | "All">("All")
+  const [repoFilter, setRepoFilter] = useState("All")
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [nodeToDelete, setNodeToDelete] = useState<GraphNode | null>(null)
   const [deletedIds, setDeletedIds] = useState<Set<string>>(new Set())
@@ -48,6 +54,7 @@ export function EntityBrowser() {
     return STUB_NODES.filter((n) => {
       if (deletedIds.has(n.id)) return false
       if (typeFilter !== "All" && n.type !== typeFilter) return false
+      if (repoFilter !== "All" && n.repository !== repoFilter) return false
       if (q && !n.name.toLowerCase().includes(q) && !n.description?.toLowerCase().includes(q))
         return false
       return true
@@ -56,7 +63,7 @@ export function EntityBrowser() {
         TYPE_ORDER.indexOf(a.type) - TYPE_ORDER.indexOf(b.type) ||
         a.name.localeCompare(b.name),
     )
-  }, [search, typeFilter, deletedIds])
+  }, [search, typeFilter, repoFilter, deletedIds])
 
   const typeCounts = useMemo(() => {
     const counts: Partial<Record<EntityType | "All", number>> = { All: filtered.length }
@@ -102,18 +109,38 @@ export function EntityBrowser() {
             Browse and manage knowledge graph nodes for this organisation
           </p>
         </div>
-        <div className="relative w-full sm:w-72">
-          <IconSearch
-            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500"
-            aria-hidden="true"
-          />
-          <input
-            type="search"
-            placeholder="Search entities…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="h-9 w-full rounded-lg border border-white/10 bg-zinc-900 pl-9 pr-3 text-sm text-zinc-100 placeholder-zinc-500 outline-none focus:border-teal-500/60 focus:ring-1 focus:ring-teal-500/30"
-          />
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+          <div className="relative">
+            <IconSearch
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500"
+              aria-hidden="true"
+            />
+            <input
+              type="search"
+              placeholder="Search entities…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="h-9 w-full rounded-lg border border-white/10 bg-zinc-900 pl-9 pr-3 text-sm text-zinc-100 placeholder-zinc-500 outline-none focus:border-teal-500/60 focus:ring-1 focus:ring-teal-500/30 sm:w-64"
+            />
+          </div>
+          <div className="relative">
+            <select
+              value={repoFilter}
+              onChange={(e) => setRepoFilter(e.target.value)}
+              className="h-9 w-full appearance-none rounded-lg border border-white/10 bg-zinc-900 pl-3 pr-8 text-sm text-zinc-300 outline-none focus:border-teal-500/60 sm:w-52"
+            >
+              <option value="All">All repositories</option>
+              {ALL_REPOS.map((repo) => (
+                <option key={repo} value={repo}>
+                  {repo}
+                </option>
+              ))}
+            </select>
+            <IconChevronDown
+              className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500"
+              aria-hidden="true"
+            />
+          </div>
         </div>
       </div>
 
@@ -150,7 +177,7 @@ export function EntityBrowser() {
       ) : (
         <div
           className="rounded-xl border border-white/8 bg-zinc-900/50"
-          style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+          style={{ height: virtualizer.getTotalSize(), minHeight: "60vh", position: "relative" }}
           ref={listRef}
         >
           {items.map((virtualRow) => {

--- a/apps/ui/src/features/entities/index.ts
+++ b/apps/ui/src/features/entities/index.ts
@@ -1,0 +1,1 @@
+export { EntityBrowser } from "./EntityBrowser"

--- a/apps/ui/src/features/graph/GraphVisualization.tsx
+++ b/apps/ui/src/features/graph/GraphVisualization.tsx
@@ -55,6 +55,9 @@ export function GraphVisualization() {
         onGraphRebuilt: ({ pointsCount, linksCount }) => {
           setStats({ nodeCount: pointsCount, edgeCount: linksCount })
         },
+        onSimulationEnd: () => {
+          cosmographRef.current?.fitView(600)
+        },
       })
     }
 
@@ -208,6 +211,11 @@ export function GraphVisualization() {
           ⤢
         </MapControlButton>
       </div>
+
+      {/* Black-out overlay when search is active but has no results */}
+      {searchQuery.trim() && matchCount === 0 && (
+        <div className="pointer-events-none absolute inset-0 z-[5] bg-zinc-950/95" />
+      )}
 
       <Cosmograph ref={cosmographRef} {...config} />
     </div>

--- a/apps/ui/src/features/graph/GraphVisualization.tsx
+++ b/apps/ui/src/features/graph/GraphVisualization.tsx
@@ -12,6 +12,17 @@ type GraphStats = {
   edgeCount: number
 }
 
+function getMatchingIds(query: string): string[] {
+  const q = query.toLowerCase()
+  return STUB_NODES.filter(
+    (n) =>
+      n.name.toLowerCase().includes(q) ||
+      n.type.toLowerCase().includes(q) ||
+      (n.description?.toLowerCase().includes(q) ?? false) ||
+      (n.repository?.toLowerCase().includes(q) ?? false),
+  ).map((n) => n.id)
+}
+
 export function GraphVisualization() {
   const cosmographRef = useRef<CosmographRef>(undefined)
   const [config, setConfig] = useState<CosmographConfig>({})
@@ -81,14 +92,7 @@ export function GraphVisualization() {
     }
 
     searchDebounceRef.current = setTimeout(async () => {
-      const q = searchQuery.toLowerCase()
-      const matchingIds = STUB_NODES.filter(
-        (n) =>
-          n.name.toLowerCase().includes(q) ||
-          n.type.toLowerCase().includes(q) ||
-          (n.description?.toLowerCase().includes(q) ?? false) ||
-          (n.repository?.toLowerCase().includes(q) ?? false),
-      ).map((n) => n.id)
+      const matchingIds = getMatchingIds(searchQuery)
 
       setMatchCount(matchingIds.length)
 
@@ -182,20 +186,12 @@ export function GraphVisualization() {
       <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1">
         {matchCount !== null && matchCount > 0 && (
           <MapControlButton
-            onClick={async () => {
-              const ids = STUB_NODES
-                .filter((n) => {
-                  const q = searchQuery.toLowerCase()
-                  return (
-                    n.name.toLowerCase().includes(q) ||
-                    n.type.toLowerCase().includes(q) ||
-                    (n.description?.toLowerCase().includes(q) ?? false) ||
-                    (n.repository?.toLowerCase().includes(q) ?? false)
-                  )
+            onClick={() => {
+              cosmographRef.current
+                ?.getPointIndicesByIds(getMatchingIds(searchQuery))
+                .then((indices) => {
+                  if (indices) cosmographRef.current?.fitViewByIndices(indices, 600)
                 })
-                .map((n) => n.id)
-              const indices = await cosmographRef.current?.getPointIndicesByIds(ids)
-              if (indices) cosmographRef.current?.fitViewByIndices(indices, 600)
             }}
             label="Fit to selection"
           >

--- a/apps/ui/src/features/graph/GraphVisualization.tsx
+++ b/apps/ui/src/features/graph/GraphVisualization.tsx
@@ -73,8 +73,8 @@ export function GraphVisualization() {
         linkDefaultWidth: 1,
         backgroundColor: "transparent",
         selectPointOnClick: "single",
-        pointGreyoutOpacity: 0.04,
-        linkGreyoutOpacity: 0.02,
+        pointGreyoutOpacity: 0.18,
+        linkGreyoutOpacity: 0.08,
         onGraphRebuilt: ({ pointsCount, linksCount }) => {
           setStats({ nodeCount: pointsCount, edgeCount: linksCount })
         },

--- a/apps/ui/src/features/graph/GraphVisualization.tsx
+++ b/apps/ui/src/features/graph/GraphVisualization.tsx
@@ -5,22 +5,27 @@ import {
   type CosmographConfig,
   type CosmographRef,
 } from "@cosmograph/react"
-import { ENTITY_COLORS, STUB_LINKS, STUB_NODES } from "./stub-data"
+import { ENTITY_COLORS, STUB_LINKS, STUB_NODES, type EntityType } from "./stub-data"
 
 type GraphStats = {
   nodeCount: number
   edgeCount: number
 }
 
-function getMatchingIds(query: string): string[] {
+function getMatchingIds(
+  query: string,
+  nodes: typeof STUB_NODES = STUB_NODES,
+): string[] {
   const q = query.toLowerCase()
-  return STUB_NODES.filter(
-    (n) =>
-      n.name.toLowerCase().includes(q) ||
-      n.type.toLowerCase().includes(q) ||
-      (n.description?.toLowerCase().includes(q) ?? false) ||
-      (n.repository?.toLowerCase().includes(q) ?? false),
-  ).map((n) => n.id)
+  return nodes
+    .filter(
+      (n) =>
+        n.name.toLowerCase().includes(q) ||
+        n.type.toLowerCase().includes(q) ||
+        (n.description?.toLowerCase().includes(q) ?? false) ||
+        (n.repository?.toLowerCase().includes(q) ?? false),
+    )
+    .map((n) => n.id)
 }
 
 export function GraphVisualization() {
@@ -29,15 +34,17 @@ export function GraphVisualization() {
   const [stats, setStats] = useState<GraphStats>({ nodeCount: 0, edgeCount: 0 })
   const [searchQuery, setSearchQuery] = useState("")
   const [matchCount, setMatchCount] = useState<number | null>(null)
+  const [hiddenTypes, setHiddenTypes] = useState<Set<EntityType>>(new Set())
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Guard so fitView only runs once on initial layout — not on every subsequent
+  // simulation restart triggered by selectPoints/unselectAllPoints calls.
+  const hasInitialFitRef = useRef(false)
 
   useEffect(() => {
     async function load() {
       const result = await prepareCosmographData(
         {
-          points: {
-            pointIdBy: "id",
-          },
+          points: { pointIdBy: "id" },
           links: {
             linkSourceBy: "source",
             linkTargetsBy: ["target"],
@@ -60,14 +67,16 @@ export function GraphVisualization() {
         linkDefaultWidth: 1,
         backgroundColor: "transparent",
         selectPointOnClick: "single",
-        // Dim non-selected nodes/edges when a selection is active
         pointGreyoutOpacity: 0.04,
         linkGreyoutOpacity: 0.02,
         onGraphRebuilt: ({ pointsCount, linksCount }) => {
           setStats({ nodeCount: pointsCount, edgeCount: linksCount })
         },
         onSimulationEnd: () => {
-          cosmographRef.current?.fitView(600)
+          if (!hasInitialFitRef.current) {
+            hasInitialFitRef.current = true
+            cosmographRef.current?.fitView(600)
+          }
         },
       })
     }
@@ -78,43 +87,82 @@ export function GraphVisualization() {
   const clearSearch = useCallback(() => {
     setSearchQuery("")
     setMatchCount(null)
-    cosmographRef.current?.unselectAllPoints()
-  }, [])
+    // Only fully unselect if there are no type filters keeping a selection active
+    if (hiddenTypes.size === 0) {
+      cosmographRef.current?.unselectAllPoints()
+    }
+  }, [hiddenTypes.size])
 
-  // Debounced search: filter nodes client-side, then pass indices to Cosmograph
+  // Combined filter effect: search (debounced) + type visibility (immediate)
   useEffect(() => {
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
 
-    if (!searchQuery.trim()) {
+    const hasSearch = searchQuery.trim().length > 0
+    const hasTypeFilter = hiddenTypes.size > 0
+
+    if (!hasSearch && !hasTypeFilter) {
       cosmographRef.current?.unselectAllPoints()
       setMatchCount(null)
       return
     }
 
-    searchDebounceRef.current = setTimeout(async () => {
-      const matchingIds = getMatchingIds(searchQuery)
+    async function apply() {
+      const visibleNodes =
+        hiddenTypes.size > 0
+          ? STUB_NODES.filter((n) => !hiddenTypes.has(n.type))
+          : STUB_NODES
 
-      setMatchCount(matchingIds.length)
+      const ids = hasSearch ? getMatchingIds(searchQuery, visibleNodes) : visibleNodes.map((n) => n.id)
 
-      if (matchingIds.length === 0) {
+      if (hasSearch) setMatchCount(ids.length)
+
+      if (ids.length === 0) {
         cosmographRef.current?.unselectAllPoints()
         return
       }
 
-      const indices = await cosmographRef.current?.getPointIndicesByIds(matchingIds)
+      const indices = await cosmographRef.current?.getPointIndicesByIds(ids)
       if (!indices) return
 
       cosmographRef.current?.selectPoints(indices)
-      // Zoom to results when set is small enough to be useful
-      if (matchingIds.length <= 200) {
+      if (hasSearch && ids.length <= 200) {
         cosmographRef.current?.fitViewByIndices(indices, 600)
       }
-    }, 280)
+    }
+
+    if (hasSearch) {
+      // Debounce text input; type toggles apply immediately
+      searchDebounceRef.current = setTimeout(apply, 280)
+    } else {
+      apply()
+    }
 
     return () => {
       if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
     }
-  }, [searchQuery])
+  }, [searchQuery, hiddenTypes])
+
+  const toggleType = useCallback((type: EntityType) => {
+    setHiddenTypes((prev) => {
+      const next = new Set(prev)
+      if (next.has(type)) next.delete(type)
+      else next.add(type)
+      return next
+    })
+  }, [])
+
+  // Compute active selection IDs for "Fit to selection" (respects both filters)
+  function getSelectionIds() {
+    const visibleNodes =
+      hiddenTypes.size > 0
+        ? STUB_NODES.filter((n) => !hiddenTypes.has(n.type))
+        : STUB_NODES
+    return searchQuery.trim()
+      ? getMatchingIds(searchQuery, visibleNodes)
+      : visibleNodes.map((n) => n.id)
+  }
+
+  const hasActiveFilter = searchQuery.trim().length > 0 || hiddenTypes.size > 0
 
   return (
     <div className="relative h-full w-full">
@@ -126,7 +174,7 @@ export function GraphVisualization() {
 
       {/* Search */}
       <div className="absolute left-1/2 top-4 z-10 -translate-x-1/2">
-        <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-zinc-900/90 px-3 py-2 backdrop-blur focus-within:border-teal-500/40">
+        <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-zinc-900 px-3 py-2 focus-within:border-teal-500/40">
           <svg
             className="h-3.5 w-3.5 shrink-0 text-zinc-500"
             fill="none"
@@ -151,14 +199,22 @@ export function GraphVisualization() {
           {searchQuery && (
             <div className="flex shrink-0 items-center gap-2">
               <span className="text-xs tabular-nums text-zinc-400">
-                {matchCount === null ? "…" : `${matchCount.toLocaleString()} match${matchCount !== 1 ? "es" : ""}`}
+                {matchCount === null
+                  ? "…"
+                  : `${matchCount.toLocaleString()} match${matchCount !== 1 ? "es" : ""}`}
               </span>
               <button
                 onClick={clearSearch}
                 aria-label="Clear search"
                 className="text-zinc-500 transition-colors hover:text-zinc-200"
               >
-                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <svg
+                  className="h-3 w-3"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                >
                   <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
@@ -167,36 +223,74 @@ export function GraphVisualization() {
         </div>
       </div>
 
-      {/* Legend */}
-      <div className="pointer-events-none absolute right-4 top-4 z-10 flex flex-col gap-2 rounded-lg border border-white/8 bg-zinc-900/80 p-3 backdrop-blur">
-        {(Object.entries(ENTITY_COLORS) as [keyof typeof ENTITY_COLORS, string][]).map(
-          ([type, color]) => (
-            <div key={type} className="flex items-center gap-2">
+      {/* Legend — click to toggle type visibility */}
+      <div className="absolute right-4 top-4 z-10 flex flex-col gap-0.5 rounded-lg border border-white/8 bg-zinc-900 p-3">
+        <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">
+          Node types
+        </p>
+        {(Object.entries(ENTITY_COLORS) as [EntityType, string][]).map(([type, color]) => {
+          const isHidden = hiddenTypes.has(type)
+          return (
+            <button
+              key={type}
+              onClick={() => toggleType(type)}
+              className={[
+                "flex items-center gap-2 rounded px-1 py-0.5 transition-opacity hover:bg-white/5",
+                isHidden ? "opacity-35" : "",
+              ].join(" ")}
+              aria-pressed={!isHidden}
+              aria-label={`${isHidden ? "Show" : "Hide"} ${type} nodes`}
+            >
               <span
-                className="inline-block h-2.5 w-2.5 rounded-full"
-                style={{ backgroundColor: color }}
+                className="inline-block h-2.5 w-2.5 shrink-0 rounded-full transition-colors"
+                style={{ backgroundColor: isHidden ? "#52525b" : color }}
               />
-              <span className="text-xs text-zinc-300">{type}</span>
-            </div>
-          ),
+              <span
+                className={[
+                  "text-xs transition-colors",
+                  isHidden ? "text-zinc-600 line-through" : "text-zinc-300",
+                ].join(" ")}
+              >
+                {type}
+              </span>
+            </button>
+          )
+        })}
+        {hiddenTypes.size > 0 && (
+          <button
+            onClick={() => setHiddenTypes(new Set())}
+            className="mt-1.5 text-left text-[10px] text-teal-500 hover:text-teal-400"
+          >
+            Show all
+          </button>
         )}
       </div>
 
       {/* Map controls */}
       <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1">
-        {matchCount !== null && matchCount > 0 && (
+        {hasActiveFilter && (matchCount === null || matchCount > 0) && (
           <MapControlButton
             onClick={() => {
               cosmographRef.current
-                ?.getPointIndicesByIds(getMatchingIds(searchQuery))
+                ?.getPointIndicesByIds(getSelectionIds())
                 .then((indices) => {
                   if (indices) cosmographRef.current?.fitViewByIndices(indices, 600)
                 })
             }}
             label="Fit to selection"
           >
-            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+            <svg
+              className="h-3.5 w-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15"
+              />
             </svg>
           </MapControlButton>
         )}
@@ -208,7 +302,7 @@ export function GraphVisualization() {
         </MapControlButton>
       </div>
 
-      {/* Black-out overlay when search is active but has no results */}
+      {/* Black-out overlay when search has no results */}
       {searchQuery.trim() && matchCount === 0 && (
         <div className="pointer-events-none absolute inset-0 z-[5] bg-zinc-950/95" />
       )}
@@ -220,7 +314,7 @@ export function GraphVisualization() {
 
 function MetricChip({ label, value }: { label: string; value: number }) {
   return (
-    <div className="rounded-lg border border-white/8 bg-zinc-900/80 px-3 py-2 backdrop-blur">
+    <div className="rounded-lg border border-white/8 bg-zinc-900 px-3 py-2">
       <p className="text-xs text-zinc-400">{label}</p>
       <p className="font-mono text-lg font-semibold tabular-nums text-zinc-100">
         {value.toLocaleString()}
@@ -242,7 +336,7 @@ function MapControlButton({
     <button
       onClick={onClick}
       aria-label={label}
-      className="flex h-8 w-8 items-center justify-center rounded border border-white/10 bg-zinc-900/90 text-sm text-zinc-300 backdrop-blur transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+      className="flex h-8 w-8 items-center justify-center rounded border border-white/10 bg-zinc-900 text-sm text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
     >
       {children}
     </button>

--- a/apps/ui/src/features/graph/GraphVisualization.tsx
+++ b/apps/ui/src/features/graph/GraphVisualization.tsx
@@ -5,7 +5,13 @@ import {
   type CosmographConfig,
   type CosmographRef,
 } from "@cosmograph/react"
-import { ENTITY_COLORS, STUB_LINKS, STUB_NODES, type EntityType } from "./stub-data"
+import {
+  ENTITY_COLORS,
+  STUB_LINKS,
+  STUB_NODES,
+  type EntityType,
+  type GraphNodeForRender,
+} from "./stub-data"
 
 type GraphStats = {
   nodeCount: number

--- a/apps/ui/src/features/graph/GraphVisualization.tsx
+++ b/apps/ui/src/features/graph/GraphVisualization.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from "react"
+import {
+  Cosmograph,
+  prepareCosmographData,
+  type CosmographConfig,
+  type CosmographRef,
+} from "@cosmograph/react"
+import { ENTITY_COLORS, STUB_LINKS, STUB_NODES } from "./stub-data"
+
+type GraphStats = {
+  nodeCount: number
+  edgeCount: number
+}
+
+export function GraphVisualization() {
+  const cosmographRef = useRef<CosmographRef>(undefined)
+  const [config, setConfig] = useState<CosmographConfig>({})
+  const [stats, setStats] = useState<GraphStats>({ nodeCount: 0, edgeCount: 0 })
+
+  useEffect(() => {
+    async function load() {
+      const result = await prepareCosmographData(
+        {
+          points: {
+            pointIdBy: "id",
+          },
+          links: {
+            linkSourceBy: "source",
+            linkTargetsBy: ["target"],
+          },
+        },
+        STUB_NODES,
+        STUB_LINKS,
+      )
+      if (!result) return
+
+      const { points, links, cosmographConfig } = result
+
+      setConfig({
+        ...cosmographConfig,
+        points,
+        links,
+        // Use the pre-computed `color` field on each node
+        pointColorBy: "color",
+        // Use the pre-computed `size` field on each node
+        pointSizeBy: "size",
+        // Link appearance
+        linkDefaultColor: "rgba(255,255,255,0.10)",
+        linkDefaultWidth: 1,
+        // Background transparent (page bg shows through)
+        backgroundColor: "transparent",
+        // Single-click selection
+        selectPointOnClick: "single",
+        // Callback to surface counts from rebuilt graph
+        onGraphRebuilt: ({ pointsCount, linksCount }) => {
+          setStats({ nodeCount: pointsCount, edgeCount: linksCount })
+        },
+      })
+    }
+
+    load()
+  }, [])
+
+  return (
+    <div className="relative h-full w-full">
+      {/* Metrics */}
+      <div className="pointer-events-none absolute left-4 top-4 z-10 flex gap-3">
+        <MetricChip label="Nodes" value={stats.nodeCount || STUB_NODES.length} />
+        <MetricChip label="Edges" value={stats.edgeCount || STUB_LINKS.length} />
+      </div>
+
+      {/* Legend */}
+      <div className="pointer-events-none absolute right-4 top-4 z-10 flex flex-col gap-2 rounded-lg border border-white/8 bg-zinc-900/80 p-3 backdrop-blur">
+        {(Object.entries(ENTITY_COLORS) as [keyof typeof ENTITY_COLORS, string][]).map(
+          ([type, color]) => (
+            <div key={type} className="flex items-center gap-2">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: color }}
+              />
+              <span className="text-xs text-zinc-300">{type}</span>
+            </div>
+          ),
+        )}
+      </div>
+
+      {/* Map controls */}
+      <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1">
+        <MapControlButton
+          onClick={() => cosmographRef.current?.fitView(400)}
+          label="Fit view"
+        >
+          ⤢
+        </MapControlButton>
+      </div>
+
+      <Cosmograph ref={cosmographRef} {...config} />
+    </div>
+  )
+}
+
+function MetricChip({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-white/8 bg-zinc-900/80 px-3 py-2 backdrop-blur">
+      <p className="text-xs text-zinc-400">{label}</p>
+      <p className="font-mono text-lg font-semibold tabular-nums text-zinc-100">
+        {value.toLocaleString()}
+      </p>
+    </div>
+  )
+}
+
+function MapControlButton({
+  onClick,
+  label,
+  children,
+}: {
+  onClick: () => void
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={label}
+      className="flex h-8 w-8 items-center justify-center rounded border border-white/10 bg-zinc-900/90 text-sm text-zinc-300 backdrop-blur transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+    >
+      {children}
+    </button>
+  )
+}

--- a/apps/ui/src/features/graph/GraphVisualization.tsx
+++ b/apps/ui/src/features/graph/GraphVisualization.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import {
   Cosmograph,
   prepareCosmographData,
@@ -16,6 +16,9 @@ export function GraphVisualization() {
   const cosmographRef = useRef<CosmographRef>(undefined)
   const [config, setConfig] = useState<CosmographConfig>({})
   const [stats, setStats] = useState<GraphStats>({ nodeCount: 0, edgeCount: 0 })
+  const [searchQuery, setSearchQuery] = useState("")
+  const [matchCount, setMatchCount] = useState<number | null>(null)
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     async function load() {
@@ -40,18 +43,15 @@ export function GraphVisualization() {
         ...cosmographConfig,
         points,
         links,
-        // Use the pre-computed `color` field on each node
         pointColorBy: "color",
-        // Use the pre-computed `size` field on each node
         pointSizeBy: "size",
-        // Link appearance
         linkDefaultColor: "rgba(255,255,255,0.10)",
         linkDefaultWidth: 1,
-        // Background transparent (page bg shows through)
         backgroundColor: "transparent",
-        // Single-click selection
         selectPointOnClick: "single",
-        // Callback to surface counts from rebuilt graph
+        // Dim non-selected nodes/edges when a selection is active
+        pointGreyoutOpacity: 0.04,
+        linkGreyoutOpacity: 0.02,
         onGraphRebuilt: ({ pointsCount, linksCount }) => {
           setStats({ nodeCount: pointsCount, edgeCount: linksCount })
         },
@@ -61,12 +61,103 @@ export function GraphVisualization() {
     load()
   }, [])
 
+  const clearSearch = useCallback(() => {
+    setSearchQuery("")
+    setMatchCount(null)
+    cosmographRef.current?.unselectAllPoints()
+  }, [])
+
+  // Debounced search: filter nodes client-side, then pass indices to Cosmograph
+  useEffect(() => {
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
+
+    if (!searchQuery.trim()) {
+      cosmographRef.current?.unselectAllPoints()
+      setMatchCount(null)
+      return
+    }
+
+    searchDebounceRef.current = setTimeout(async () => {
+      const q = searchQuery.toLowerCase()
+      const matchingIds = STUB_NODES.filter(
+        (n) =>
+          n.name.toLowerCase().includes(q) ||
+          n.type.toLowerCase().includes(q) ||
+          (n.description?.toLowerCase().includes(q) ?? false) ||
+          (n.repository?.toLowerCase().includes(q) ?? false),
+      ).map((n) => n.id)
+
+      setMatchCount(matchingIds.length)
+
+      if (matchingIds.length === 0) {
+        cosmographRef.current?.unselectAllPoints()
+        return
+      }
+
+      const indices = await cosmographRef.current?.getPointIndicesByIds(matchingIds)
+      if (!indices) return
+
+      cosmographRef.current?.selectPoints(indices)
+      // Zoom to results when set is small enough to be useful
+      if (matchingIds.length <= 200) {
+        cosmographRef.current?.fitViewByIndices(indices, 600)
+      }
+    }, 280)
+
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
+    }
+  }, [searchQuery])
+
   return (
     <div className="relative h-full w-full">
       {/* Metrics */}
       <div className="pointer-events-none absolute left-4 top-4 z-10 flex gap-3">
         <MetricChip label="Nodes" value={stats.nodeCount || STUB_NODES.length} />
         <MetricChip label="Edges" value={stats.edgeCount || STUB_LINKS.length} />
+      </div>
+
+      {/* Search */}
+      <div className="absolute left-1/2 top-4 z-10 -translate-x-1/2">
+        <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-zinc-900/90 px-3 py-2 backdrop-blur focus-within:border-teal-500/40">
+          <svg
+            className="h-3.5 w-3.5 shrink-0 text-zinc-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1 0 6.5 6.5a7.5 7.5 0 0 0 10.15 10.15z"
+            />
+          </svg>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => e.key === "Escape" && clearSearch()}
+            placeholder="Search nodes by name, type, or repo…"
+            className="w-64 bg-transparent text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none"
+          />
+          {searchQuery && (
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="text-xs tabular-nums text-zinc-400">
+                {matchCount === null ? "…" : `${matchCount.toLocaleString()} match${matchCount !== 1 ? "es" : ""}`}
+              </span>
+              <button
+                onClick={clearSearch}
+                aria-label="Clear search"
+                className="text-zinc-500 transition-colors hover:text-zinc-200"
+              >
+                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Legend */}
@@ -86,6 +177,30 @@ export function GraphVisualization() {
 
       {/* Map controls */}
       <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1">
+        {matchCount !== null && matchCount > 0 && (
+          <MapControlButton
+            onClick={async () => {
+              const ids = STUB_NODES
+                .filter((n) => {
+                  const q = searchQuery.toLowerCase()
+                  return (
+                    n.name.toLowerCase().includes(q) ||
+                    n.type.toLowerCase().includes(q) ||
+                    (n.description?.toLowerCase().includes(q) ?? false) ||
+                    (n.repository?.toLowerCase().includes(q) ?? false)
+                  )
+                })
+                .map((n) => n.id)
+              const indices = await cosmographRef.current?.getPointIndicesByIds(ids)
+              if (indices) cosmographRef.current?.fitViewByIndices(indices, 600)
+            }}
+            label="Fit to selection"
+          >
+            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+            </svg>
+          </MapControlButton>
+        )}
         <MapControlButton
           onClick={() => cosmographRef.current?.fitView(400)}
           label="Fit view"

--- a/apps/ui/src/features/graph/index.ts
+++ b/apps/ui/src/features/graph/index.ts
@@ -1,0 +1,2 @@
+export { GraphVisualization } from "./GraphVisualization"
+export * from "./stub-data"

--- a/apps/ui/src/features/graph/stub-data.ts
+++ b/apps/ui/src/features/graph/stub-data.ts
@@ -31,7 +31,90 @@ export const ENTITY_COLORS: Record<EntityType, string> = {
   Concept: "#fb7185",
 }
 
-function node(
+// ─── Enterprise-scale generator ──────────────────────────────────────────────
+// Produces ~4 500 nodes and ~15 000 edges to stress-test GPU rendering.
+
+const DOMAINS = [
+  "auth", "user", "payment", "notification", "search", "analytics",
+  "reporting", "billing", "subscription", "inventory", "order", "product",
+  "catalog", "shipping", "logistics", "warehouse", "supplier", "procurement",
+  "hr", "payroll", "onboarding", "identity", "access", "audit", "compliance",
+  "fraud", "risk", "kyc", "aml", "data", "etl", "pipeline", "stream",
+  "batch", "ml", "inference", "training", "feature", "recommendation",
+  "personalisation", "content", "media", "upload", "cdn", "storage",
+  "cache", "queue", "event", "webhook", "email", "sms", "push",
+  "chat", "video", "document", "export", "import", "integration",
+  "gateway", "proxy", "router", "load-balancer", "service-mesh",
+  "config", "secrets", "vault", "telemetry", "metrics", "tracing",
+  "alerting", "incident", "deploy", "rollout", "canary", "infra",
+  "terraform", "k8s", "ci", "sdk", "cli", "admin", "dashboard",
+  "portal", "mobile-api", "graphql", "grpc", "websocket", "realtime",
+  "scheduler", "cron", "workflow", "approval", "pricing", "discount",
+  "tax", "ledger", "reconciliation", "refund", "chargeback",
+]
+
+const REPO_SUFFIXES = ["service", "api", "worker", "lib", "sdk", "core", "client"]
+
+const FILE_PREFIXES = [
+  "router", "controller", "handler", "service", "repository", "model",
+  "schema", "middleware", "config", "utils", "helpers", "validators",
+  "serializers", "events", "jobs", "tasks", "hooks", "types", "errors",
+  "constants", "migrations", "seeds", "tests",
+]
+
+const CLASS_PREFIXES = [
+  "Manager", "Service", "Repository", "Controller", "Handler",
+  "Processor", "Validator", "Serializer", "Builder", "Factory",
+  "Observer", "Adapter", "Gateway", "Client", "Provider",
+]
+
+const FUNCTION_PREFIXES = [
+  "get", "create", "update", "delete", "list", "find", "validate",
+  "process", "handle", "send", "fetch", "load", "parse", "format",
+  "transform", "calculate", "generate", "check", "verify", "resolve",
+  "build", "init", "teardown", "retry", "schedule",
+]
+
+const CONCEPTS = [
+  "CQRS", "Event Sourcing", "Domain Events", "Saga Pattern", "Outbox Pattern",
+  "Circuit Breaker", "Rate Limiting", "Idempotency", "Distributed Tracing",
+  "Service Discovery", "API Versioning", "Pagination", "Cursor Pagination",
+  "Optimistic Locking", "Pessimistic Locking", "Soft Delete", "Audit Log",
+  "Multi-tenancy", "Row-level Security", "Feature Flags", "A/B Testing",
+  "Canary Release", "Blue-Green Deploy", "Zero-downtime Migration",
+  "Data Sharding", "Read Replica", "Write-ahead Log", "Change Data Capture",
+  "Message Queue", "Dead Letter Queue", "Backpressure", "Exactly-once Delivery",
+  "JWT", "OAuth 2.0", "OIDC", "RBAC", "ABAC", "Zero Trust",
+  "Embeddings", "Vector Search", "RAG", "LLM Routing", "Prompt Caching",
+  "OpenTelemetry", "Structured Logging", "Health Check", "Graceful Shutdown",
+  "Dependency Injection", "Hexagonal Architecture", "Clean Architecture",
+  "Repository Pattern", "Unit of Work", "Specification Pattern",
+]
+
+/** Simple deterministic pseudo-random (seeded) so the graph is stable across renders */
+function seededRand(seed: number) {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) & 0xffffffff
+    return (s >>> 0) / 0xffffffff
+  }
+}
+
+function pick<T>(arr: T[], rand: () => number): T {
+  return arr[Math.floor(rand() * arr.length)]
+}
+
+function pickN<T>(arr: T[], n: number, rand: () => number): T[] {
+  const copy = [...arr]
+  const out: T[] = []
+  for (let i = 0; i < n && copy.length > 0; i++) {
+    const idx = Math.floor(rand() * copy.length)
+    out.push(copy.splice(idx, 1)[0])
+  }
+  return out
+}
+
+function makeNode(
   id: string,
   name: string,
   type: EntityType,
@@ -45,122 +128,168 @@ function node(
     description,
     repository,
     color: ENTITY_COLORS[type],
-    size: type === "Repository" ? 14 : type === "Concept" ? 10 : 7,
+    size: type === "Repository" ? 16 : type === "Concept" ? 11 : 6,
   }
 }
 
-export const STUB_NODES: GraphNode[] = [
-  // Repositories
-  node("r1", "ctxpipe-backend", "Repository", "Core API, MCP server, and graph ingestion pipeline"),
-  node("r2", "ctxpipe-ui", "Repository", "TanStack Start frontend application"),
+function generate(): { nodes: GraphNode[]; links: GraphLink[] } {
+  const rand = seededRand(0xdeadbeef)
+  const nodes: GraphNode[] = []
+  const links: GraphLink[] = []
 
-  // Files (backend)
-  node("f1", "src/app/app.ts", "File", "Hono application factory", "r1"),
-  node("f2", "src/platform/graph/client.ts", "File", "FalkorDB / Neo4j driver abstraction", "r1"),
-  node("f3", "src/auth/config.ts", "File", "Better Auth configuration", "r1"),
-  node("f4", "src/server.ts", "File", "HTTP server entry point", "r1"),
-  node("f5", "src/db/migrate.ts", "File", "Drizzle migration runner", "r1"),
-  node("f6", "src/mcp/server.ts", "File", "MCP server definition and tool registration", "r1"),
-  node("f7", "src/ingestion/pipeline.ts", "File", "Repository ingestion orchestration", "r1"),
-  node("f8", "src/ingestion/chunker.ts", "File", "Code chunking and tokenisation", "r1"),
+  // ── Concepts (shared across the org) ────────────────────────────────────
+  const conceptNodes: GraphNode[] = pickN(CONCEPTS, 55, rand).map((name, i) =>
+    makeNode(`co${i}`, name, "Concept", `Cross-cutting concern: ${name}`),
+  )
+  nodes.push(...conceptNodes)
 
-  // Files (UI)
-  node("f9", "src/routes/$orgSlug.chat.tsx", "File", "Chat route", "r2"),
-  node("f10", "src/components/SideNav/SideNav.tsx", "File", "Primary navigation", "r2"),
-  node("f11", "src/lib/api.ts", "File", "Hono RPC client", "r2"),
+  // Concepts reference each other (sparse)
+  for (let i = 0; i < conceptNodes.length; i++) {
+    if (rand() < 0.25) {
+      const j = Math.floor(rand() * conceptNodes.length)
+      if (j !== i) {
+        links.push({ source: conceptNodes[i].id, target: conceptNodes[j].id, type: "related_to" })
+      }
+    }
+  }
 
-  // Classes
-  node("c1", "GraphClient", "Class", "Manages Neo4j/FalkorDB driver lifecycle and tenant scoping", "r1"),
-  node("c2", "AuthConfig", "Class", "Better Auth server configuration", "r1"),
-  node("c3", "McpServer", "Class", "Model Context Protocol server instance", "r1"),
-  node("c4", "IngestionPipeline", "Class", "Orchestrates repository clone, chunk, embed and ingest", "r1"),
-  node("c5", "AppShell", "Class", "Root layout wrapper with SideNav", "r2"),
-  node("c6", "SideNav", "Class", "Collapsible primary navigation", "r2"),
+  // ── Repositories ──────────────────────────────────────────────────────
+  const repoCount = 100
+  const repoNodes: GraphNode[] = DOMAINS.slice(0, repoCount).map((domain, i) => {
+    const suffix = pick(REPO_SUFFIXES, rand)
+    return makeNode(
+      `r${i}`,
+      `${domain}-${suffix}`,
+      "Repository",
+      `Handles ${domain} domain — owns schema, API surface and business logic`,
+    )
+  })
+  nodes.push(...repoNodes)
 
-  // Functions
-  node("fn1", "getConfig()", "Function", "Reads graph DB connection config from environment", "r1"),
-  node("fn2", "withGraphClient()", "Function", "Scopes a graph DB driver to a request via AsyncLocalStorage", "r1"),
-  node("fn3", "resolveDriver()", "Function", "Creates or retrieves a tenant-scoped Bolt driver", "r1"),
-  node("fn4", "closeGraphDb()", "Function", "Gracefully closes all active graph DB connections", "r1"),
-  node("fn5", "ctx_advisor()", "Function", "MCP tool — queries the knowledge graph for code context", "r1"),
-  node("fn6", "ingestRepository()", "Function", "Triggers clone, chunk, embed and load for a repo", "r1"),
-  node("fn7", "chunkCode()", "Function", "Splits source files into semantically bounded chunks", "r1"),
-  node("fn8", "embedChunks()", "Function", "Generates vector embeddings for code chunks", "r1"),
-  node("fn9", "runMigrations()", "Function", "Applies pending Drizzle migrations at startup", "r1"),
-  node("fn10", "buildApp()", "Function", "Composes Hono middleware stack and routes", "r1"),
-  node("fn11", "useSession()", "Function", "Better Auth session hook", "r2"),
-  node("fn12", "prepareCosmographData()", "Function", "Indexes raw graph data for GPU rendering", "r2"),
+  // Track all functions per repo for cross-repo edges later
+  const funcsByRepo: Record<string, GraphNode[]> = {}
+  const classesByRepo: Record<string, GraphNode[]> = {}
+  let fileIdx = 0
+  let classIdx = 0
+  let funcIdx = 0
 
-  // Concepts
-  node("co1", "Authentication", "Concept", "Session management, OAuth, passkeys, 2FA"),
-  node("co2", "Graph DB", "Concept", "OpenCypher-compatible knowledge graph store"),
-  node("co3", "MCP Protocol", "Concept", "Model Context Protocol — tool calling over HTTP"),
-  node("co4", "RAG Pipeline", "Concept", "Retrieval-augmented generation over indexed code"),
-  node("co5", "Multi-tenancy", "Concept", "Per-org data isolation via graph database scoping"),
-  node("co6", "Embeddings", "Concept", "Vector representations of code chunks"),
-  node("co7", "OpenCypher", "Concept", "Graph query language used across FalkorDB, Neo4j, Memgraph"),
-]
+  // ── Per-repo entities ─────────────────────────────────────────────────
+  for (const repo of repoNodes) {
+    const fileCount = 14 + Math.floor(rand() * 10)      // 14-23 files
+    const classCount = 6 + Math.floor(rand() * 8)       // 6-13 classes
+    const funcCount = 14 + Math.floor(rand() * 10)      // 14-23 functions
+    const conceptCount = 2 + Math.floor(rand() * 4)     // 2-5 concepts per repo
 
-export const STUB_LINKS: GraphLink[] = [
-  // Files belong to repositories
-  { source: "r1", target: "f1", type: "related_to" },
-  { source: "r1", target: "f2", type: "related_to" },
-  { source: "r1", target: "f3", type: "related_to" },
-  { source: "r1", target: "f4", type: "related_to" },
-  { source: "r1", target: "f5", type: "related_to" },
-  { source: "r1", target: "f6", type: "related_to" },
-  { source: "r1", target: "f7", type: "related_to" },
-  { source: "r1", target: "f8", type: "related_to" },
-  { source: "r2", target: "f9", type: "related_to" },
-  { source: "r2", target: "f10", type: "related_to" },
-  { source: "r2", target: "f11", type: "related_to" },
+    // Files
+    const repoFiles: GraphNode[] = []
+    for (let f = 0; f < fileCount; f++) {
+      const prefix = pick(FILE_PREFIXES, rand)
+      const ext = rand() < 0.7 ? ".ts" : ".tsx"
+      const id = `f${fileIdx++}`
+      const n = makeNode(
+        id,
+        `src/${prefix}${ext}`,
+        "File",
+        `${prefix} layer for ${repo.name}`,
+        repo.id,
+      )
+      repoFiles.push(n)
+      nodes.push(n)
+      links.push({ source: repo.id, target: id, type: "related_to" })
+    }
 
-  // Classes defined in files
-  { source: "f2", target: "c1", type: "related_to" },
-  { source: "f3", target: "c2", type: "related_to" },
-  { source: "f6", target: "c3", type: "related_to" },
-  { source: "f7", target: "c4", type: "related_to" },
-  { source: "f1", target: "c5", type: "related_to" },
-  { source: "f10", target: "c6", type: "related_to" },
+    // Classes
+    const repoClasses: GraphNode[] = []
+    classesByRepo[repo.id] = repoClasses
+    for (let c = 0; c < classCount; c++) {
+      const prefix = pick(CLASS_PREFIXES, rand)
+      const domain = repo.name.split("-")[0]
+      const name = `${domain.charAt(0).toUpperCase()}${domain.slice(1)}${prefix}`
+      const id = `c${classIdx++}`
+      const file = pick(repoFiles, rand)
+      const n = makeNode(id, name, "Class", `${prefix} for ${repo.name}`, repo.id)
+      repoClasses.push(n)
+      nodes.push(n)
+      links.push({ source: file.id, target: id, type: "related_to" })
 
-  // Functions defined in files
-  { source: "f2", target: "fn1", type: "related_to" },
-  { source: "f2", target: "fn2", type: "related_to" },
-  { source: "f2", target: "fn3", type: "related_to" },
-  { source: "f2", target: "fn4", type: "related_to" },
-  { source: "f6", target: "fn5", type: "related_to" },
-  { source: "f7", target: "fn6", type: "related_to" },
-  { source: "f8", target: "fn7", type: "related_to" },
-  { source: "f8", target: "fn8", type: "related_to" },
-  { source: "f5", target: "fn9", type: "related_to" },
-  { source: "f1", target: "fn10", type: "related_to" },
-  { source: "f9", target: "fn11", type: "related_to" },
+      // Classes mention 1-3 concepts
+      const classConcepts = pickN(conceptNodes, conceptCount, rand)
+      for (const concept of classConcepts) {
+        links.push({ source: id, target: concept.id, type: "mentions" })
+      }
+    }
 
-  // Cross-function mentions
-  { source: "fn2", target: "fn3", type: "mentions" },
-  { source: "fn5", target: "fn2", type: "mentions" },
-  { source: "fn6", target: "fn7", type: "mentions" },
-  { source: "fn6", target: "fn8", type: "mentions" },
-  { source: "fn10", target: "fn9", type: "mentions" },
-  { source: "c4", target: "fn6", type: "mentions" },
-  { source: "c3", target: "fn5", type: "mentions" },
+    // Functions
+    const repoFuncs: GraphNode[] = []
+    funcsByRepo[repo.id] = repoFuncs
+    for (let fn = 0; fn < funcCount; fn++) {
+      const verb = pick(FUNCTION_PREFIXES, rand)
+      const domain = repo.name.split("-")[0]
+      const noun = domain.charAt(0).toUpperCase() + domain.slice(1)
+      const id = `fn${funcIdx++}`
+      const file = pick(repoFiles, rand)
+      const n = makeNode(id, `${verb}${noun}()`, "Function", `${verb} operation in ${repo.name}`, repo.id)
+      repoFuncs.push(n)
+      nodes.push(n)
+      links.push({ source: file.id, target: id, type: "related_to" })
+    }
 
-  // Concept relationships
-  { source: "c1", target: "co2", type: "mentions" },
-  { source: "c1", target: "co7", type: "mentions" },
-  { source: "c1", target: "co5", type: "mentions" },
-  { source: "c2", target: "co1", type: "mentions" },
-  { source: "c3", target: "co3", type: "mentions" },
-  { source: "c4", target: "co4", type: "mentions" },
-  { source: "c4", target: "co6", type: "mentions" },
-  { source: "fn5", target: "co3", type: "mentions" },
-  { source: "fn5", target: "co4", type: "mentions" },
-  { source: "fn8", target: "co6", type: "mentions" },
-  { source: "co4", target: "co6", type: "related_to" },
-  { source: "co2", target: "co7", type: "related_to" },
-  { source: "co5", target: "co2", type: "related_to" },
-  { source: "f11", target: "fn11", type: "mentions" },
-  { source: "f9", target: "f11", type: "mentions" },
-  { source: "f4", target: "f1", type: "mentions" },
-  { source: "f4", target: "f3", type: "mentions" },
-]
+    // Functions mention functions within the same repo (avg ~3 callees each)
+    for (const fn of repoFuncs) {
+      const callCount = 1 + Math.floor(rand() * 5)
+      const callees = pickN(repoFuncs.filter((f) => f.id !== fn.id), callCount, rand)
+      for (const callee of callees) {
+        links.push({ source: fn.id, target: callee.id, type: "mentions" })
+      }
+    }
+
+    // Intra-repo file imports (each file imports 1-4 other files in the same repo)
+    for (const file of repoFiles) {
+      const importCount = 1 + Math.floor(rand() * 4)
+      const imported = pickN(repoFiles.filter((f) => f.id !== file.id), importCount, rand)
+      for (const imp of imported) {
+        links.push({ source: file.id, target: imp.id, type: "mentions" })
+      }
+    }
+  }
+
+  // ── Cross-repo calls (service mesh simulation) ─────────────────────────
+  // ~18% of all functions call a function in another repo, and ~6% call a
+  // second one — simulates service clients, SDK calls, shared library usage.
+  const allFuncs = Object.values(funcsByRepo).flat()
+  const allRepoIds = repoNodes.map((r) => r.id)
+
+  for (const fn of allFuncs) {
+    const crossCalls = (rand() < 0.18 ? 1 : 0) + (rand() < 0.06 ? 1 : 0)
+    for (let x = 0; x < crossCalls; x++) {
+      const targetRepoId = pick(allRepoIds.filter((id) => id !== fn.repository), rand)
+      const targetFuncs = funcsByRepo[targetRepoId]
+      if (targetFuncs?.length) {
+        const target = pick(targetFuncs, rand)
+        links.push({ source: fn.id, target: target.id, type: "mentions" })
+      }
+    }
+  }
+
+  // ── Cross-repo class dependencies (shared libs, auth clients, etc.) ─────
+  const allClasses = Object.values(classesByRepo).flat()
+  for (const cls of allClasses) {
+    if (rand() < 0.14) {
+      const targetRepoId = pick(
+        allRepoIds.filter((id) => id !== cls.repository),
+        rand,
+      )
+      const targetClasses = classesByRepo[targetRepoId]
+      if (targetClasses?.length) {
+        const target = pick(targetClasses, rand)
+        links.push({ source: cls.id, target: target.id, type: "related_to" })
+      }
+    }
+  }
+
+  return { nodes, links }
+}
+
+const { nodes: STUB_NODES, links: STUB_LINKS } = generate()
+
+export { STUB_NODES, STUB_LINKS }

--- a/apps/ui/src/features/graph/stub-data.ts
+++ b/apps/ui/src/features/graph/stub-data.ts
@@ -12,7 +12,15 @@ export type GraphNode = {
   name: string
   type: EntityType
   description?: string
+  /** Denormalised from the BELONGS_TO relationship for query convenience */
   repository?: string
+}
+
+/**
+ * GraphNode extended with UI-only display fields required by Cosmograph.
+ * These are derived from `type` client-side and are never stored in FalkorDB.
+ */
+export type GraphNodeForRender = GraphNode & {
   color: string
   size: number
 }
@@ -120,7 +128,7 @@ function makeNode(
   type: EntityType,
   description?: string,
   repository?: string,
-): GraphNode {
+): GraphNodeForRender {
   return {
     id,
     name,
@@ -132,13 +140,13 @@ function makeNode(
   }
 }
 
-function generate(): { nodes: GraphNode[]; links: GraphLink[] } {
+function generate(): { nodes: GraphNodeForRender[]; links: GraphLink[] } {
   const rand = seededRand(0xdeadbeef)
-  const nodes: GraphNode[] = []
+  const nodes: GraphNodeForRender[] = []
   const links: GraphLink[] = []
 
   // ── Concepts (shared across the org) ────────────────────────────────────
-  const conceptNodes: GraphNode[] = pickN(CONCEPTS, 55, rand).map((name, i) =>
+  const conceptNodes: GraphNodeForRender[] = pickN(CONCEPTS, 55, rand).map((name, i) =>
     makeNode(`co${i}`, name, "Concept", `Cross-cutting concern: ${name}`),
   )
   nodes.push(...conceptNodes)
@@ -155,7 +163,7 @@ function generate(): { nodes: GraphNode[]; links: GraphLink[] } {
 
   // ── Repositories ──────────────────────────────────────────────────────
   const repoCount = 100
-  const repoNodes: GraphNode[] = DOMAINS.slice(0, repoCount).map((domain, i) => {
+  const repoNodes: GraphNodeForRender[] = DOMAINS.slice(0, repoCount).map((domain, i) => {
     const suffix = pick(REPO_SUFFIXES, rand)
     return makeNode(
       `r${i}`,
@@ -167,8 +175,8 @@ function generate(): { nodes: GraphNode[]; links: GraphLink[] } {
   nodes.push(...repoNodes)
 
   // Track all functions per repo for cross-repo edges later
-  const funcsByRepo: Record<string, GraphNode[]> = {}
-  const classesByRepo: Record<string, GraphNode[]> = {}
+  const funcsByRepo: Record<string, GraphNodeForRender[]> = {}
+  const classesByRepo: Record<string, GraphNodeForRender[]> = {}
   let fileIdx = 0
   let classIdx = 0
   let funcIdx = 0
@@ -181,7 +189,7 @@ function generate(): { nodes: GraphNode[]; links: GraphLink[] } {
     const conceptCount = 2 + Math.floor(rand() * 4)     // 2-5 concepts per repo
 
     // Files
-    const repoFiles: GraphNode[] = []
+    const repoFiles: GraphNodeForRender[] = []
     for (let f = 0; f < fileCount; f++) {
       const prefix = pick(FILE_PREFIXES, rand)
       const ext = rand() < 0.7 ? ".ts" : ".tsx"
@@ -199,7 +207,7 @@ function generate(): { nodes: GraphNode[]; links: GraphLink[] } {
     }
 
     // Classes
-    const repoClasses: GraphNode[] = []
+    const repoClasses: GraphNodeForRender[] = []
     classesByRepo[repo.id] = repoClasses
     for (let c = 0; c < classCount; c++) {
       const prefix = pick(CLASS_PREFIXES, rand)
@@ -220,7 +228,7 @@ function generate(): { nodes: GraphNode[]; links: GraphLink[] } {
     }
 
     // Functions
-    const repoFuncs: GraphNode[] = []
+    const repoFuncs: GraphNodeForRender[] = []
     funcsByRepo[repo.id] = repoFuncs
     for (let fn = 0; fn < funcCount; fn++) {
       const verb = pick(FUNCTION_PREFIXES, rand)

--- a/apps/ui/src/features/graph/stub-data.ts
+++ b/apps/ui/src/features/graph/stub-data.ts
@@ -1,0 +1,166 @@
+export type EntityType =
+  | "Repository"
+  | "File"
+  | "Function"
+  | "Class"
+  | "Concept"
+
+export type RelationshipType = "related_to" | "mentions"
+
+export type GraphNode = {
+  id: string
+  name: string
+  type: EntityType
+  description?: string
+  repository?: string
+  color: string
+  size: number
+}
+
+export type GraphLink = {
+  source: string
+  target: string
+  type: RelationshipType
+}
+
+export const ENTITY_COLORS: Record<EntityType, string> = {
+  Repository: "#f59e0b",
+  File: "#2dd4bf",
+  Function: "#60a5fa",
+  Class: "#a78bfa",
+  Concept: "#fb7185",
+}
+
+function node(
+  id: string,
+  name: string,
+  type: EntityType,
+  description?: string,
+  repository?: string,
+): GraphNode {
+  return {
+    id,
+    name,
+    type,
+    description,
+    repository,
+    color: ENTITY_COLORS[type],
+    size: type === "Repository" ? 14 : type === "Concept" ? 10 : 7,
+  }
+}
+
+export const STUB_NODES: GraphNode[] = [
+  // Repositories
+  node("r1", "ctxpipe-backend", "Repository", "Core API, MCP server, and graph ingestion pipeline"),
+  node("r2", "ctxpipe-ui", "Repository", "TanStack Start frontend application"),
+
+  // Files (backend)
+  node("f1", "src/app/app.ts", "File", "Hono application factory", "r1"),
+  node("f2", "src/platform/graph/client.ts", "File", "FalkorDB / Neo4j driver abstraction", "r1"),
+  node("f3", "src/auth/config.ts", "File", "Better Auth configuration", "r1"),
+  node("f4", "src/server.ts", "File", "HTTP server entry point", "r1"),
+  node("f5", "src/db/migrate.ts", "File", "Drizzle migration runner", "r1"),
+  node("f6", "src/mcp/server.ts", "File", "MCP server definition and tool registration", "r1"),
+  node("f7", "src/ingestion/pipeline.ts", "File", "Repository ingestion orchestration", "r1"),
+  node("f8", "src/ingestion/chunker.ts", "File", "Code chunking and tokenisation", "r1"),
+
+  // Files (UI)
+  node("f9", "src/routes/$orgSlug.chat.tsx", "File", "Chat route", "r2"),
+  node("f10", "src/components/SideNav/SideNav.tsx", "File", "Primary navigation", "r2"),
+  node("f11", "src/lib/api.ts", "File", "Hono RPC client", "r2"),
+
+  // Classes
+  node("c1", "GraphClient", "Class", "Manages Neo4j/FalkorDB driver lifecycle and tenant scoping", "r1"),
+  node("c2", "AuthConfig", "Class", "Better Auth server configuration", "r1"),
+  node("c3", "McpServer", "Class", "Model Context Protocol server instance", "r1"),
+  node("c4", "IngestionPipeline", "Class", "Orchestrates repository clone, chunk, embed and ingest", "r1"),
+  node("c5", "AppShell", "Class", "Root layout wrapper with SideNav", "r2"),
+  node("c6", "SideNav", "Class", "Collapsible primary navigation", "r2"),
+
+  // Functions
+  node("fn1", "getConfig()", "Function", "Reads graph DB connection config from environment", "r1"),
+  node("fn2", "withGraphClient()", "Function", "Scopes a graph DB driver to a request via AsyncLocalStorage", "r1"),
+  node("fn3", "resolveDriver()", "Function", "Creates or retrieves a tenant-scoped Bolt driver", "r1"),
+  node("fn4", "closeGraphDb()", "Function", "Gracefully closes all active graph DB connections", "r1"),
+  node("fn5", "ctx_advisor()", "Function", "MCP tool — queries the knowledge graph for code context", "r1"),
+  node("fn6", "ingestRepository()", "Function", "Triggers clone, chunk, embed and load for a repo", "r1"),
+  node("fn7", "chunkCode()", "Function", "Splits source files into semantically bounded chunks", "r1"),
+  node("fn8", "embedChunks()", "Function", "Generates vector embeddings for code chunks", "r1"),
+  node("fn9", "runMigrations()", "Function", "Applies pending Drizzle migrations at startup", "r1"),
+  node("fn10", "buildApp()", "Function", "Composes Hono middleware stack and routes", "r1"),
+  node("fn11", "useSession()", "Function", "Better Auth session hook", "r2"),
+  node("fn12", "prepareCosmographData()", "Function", "Indexes raw graph data for GPU rendering", "r2"),
+
+  // Concepts
+  node("co1", "Authentication", "Concept", "Session management, OAuth, passkeys, 2FA"),
+  node("co2", "Graph DB", "Concept", "OpenCypher-compatible knowledge graph store"),
+  node("co3", "MCP Protocol", "Concept", "Model Context Protocol — tool calling over HTTP"),
+  node("co4", "RAG Pipeline", "Concept", "Retrieval-augmented generation over indexed code"),
+  node("co5", "Multi-tenancy", "Concept", "Per-org data isolation via graph database scoping"),
+  node("co6", "Embeddings", "Concept", "Vector representations of code chunks"),
+  node("co7", "OpenCypher", "Concept", "Graph query language used across FalkorDB, Neo4j, Memgraph"),
+]
+
+export const STUB_LINKS: GraphLink[] = [
+  // Files belong to repositories
+  { source: "r1", target: "f1", type: "related_to" },
+  { source: "r1", target: "f2", type: "related_to" },
+  { source: "r1", target: "f3", type: "related_to" },
+  { source: "r1", target: "f4", type: "related_to" },
+  { source: "r1", target: "f5", type: "related_to" },
+  { source: "r1", target: "f6", type: "related_to" },
+  { source: "r1", target: "f7", type: "related_to" },
+  { source: "r1", target: "f8", type: "related_to" },
+  { source: "r2", target: "f9", type: "related_to" },
+  { source: "r2", target: "f10", type: "related_to" },
+  { source: "r2", target: "f11", type: "related_to" },
+
+  // Classes defined in files
+  { source: "f2", target: "c1", type: "related_to" },
+  { source: "f3", target: "c2", type: "related_to" },
+  { source: "f6", target: "c3", type: "related_to" },
+  { source: "f7", target: "c4", type: "related_to" },
+  { source: "f1", target: "c5", type: "related_to" },
+  { source: "f10", target: "c6", type: "related_to" },
+
+  // Functions defined in files
+  { source: "f2", target: "fn1", type: "related_to" },
+  { source: "f2", target: "fn2", type: "related_to" },
+  { source: "f2", target: "fn3", type: "related_to" },
+  { source: "f2", target: "fn4", type: "related_to" },
+  { source: "f6", target: "fn5", type: "related_to" },
+  { source: "f7", target: "fn6", type: "related_to" },
+  { source: "f8", target: "fn7", type: "related_to" },
+  { source: "f8", target: "fn8", type: "related_to" },
+  { source: "f5", target: "fn9", type: "related_to" },
+  { source: "f1", target: "fn10", type: "related_to" },
+  { source: "f9", target: "fn11", type: "related_to" },
+
+  // Cross-function mentions
+  { source: "fn2", target: "fn3", type: "mentions" },
+  { source: "fn5", target: "fn2", type: "mentions" },
+  { source: "fn6", target: "fn7", type: "mentions" },
+  { source: "fn6", target: "fn8", type: "mentions" },
+  { source: "fn10", target: "fn9", type: "mentions" },
+  { source: "c4", target: "fn6", type: "mentions" },
+  { source: "c3", target: "fn5", type: "mentions" },
+
+  // Concept relationships
+  { source: "c1", target: "co2", type: "mentions" },
+  { source: "c1", target: "co7", type: "mentions" },
+  { source: "c1", target: "co5", type: "mentions" },
+  { source: "c2", target: "co1", type: "mentions" },
+  { source: "c3", target: "co3", type: "mentions" },
+  { source: "c4", target: "co4", type: "mentions" },
+  { source: "c4", target: "co6", type: "mentions" },
+  { source: "fn5", target: "co3", type: "mentions" },
+  { source: "fn5", target: "co4", type: "mentions" },
+  { source: "fn8", target: "co6", type: "mentions" },
+  { source: "co4", target: "co6", type: "related_to" },
+  { source: "co2", target: "co7", type: "related_to" },
+  { source: "co5", target: "co2", type: "related_to" },
+  { source: "f11", target: "fn11", type: "mentions" },
+  { source: "f9", target: "f11", type: "mentions" },
+  { source: "f4", target: "f1", type: "mentions" },
+  { source: "f4", target: "f3", type: "mentions" },
+]

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -17,14 +17,14 @@ import { Route as DotauthConsentRouteImport } from './routes/[.]auth.consent'
 import { Route as DotauthAccountRouteImport } from './routes/[.]auth.account'
 import { Route as DotauthAuthViewRouteImport } from './routes/[.]auth.$authView'
 import { Route as OrgSlugRepositoriesRouteImport } from './routes/$orgSlug.repositories'
+import { Route as OrgSlugGraphRouteImport } from './routes/$orgSlug.graph'
+import { Route as OrgSlugEntitiesRouteImport } from './routes/$orgSlug.entities'
 import { Route as OrgSlugChatRouteImport } from './routes/$orgSlug.chat'
 import { Route as OrgSlugChatIndexRouteImport } from './routes/$orgSlug.chat.index'
 import { Route as DotauthOrganizationOrganizationViewRouteImport } from './routes/[.]auth.organization.$organizationView'
 import { Route as DotauthAccountAccountViewRouteImport } from './routes/[.]auth.account.$accountView'
 import { Route as OrgSlugOrganizationOrganizationViewRouteImport } from './routes/$orgSlug.organization.$organizationView'
 import { Route as OrgSlugChatConversationIdRouteImport } from './routes/$orgSlug.chat.$conversationId'
-import { Route as OrgSlugGraphRouteImport } from './routes/$orgSlug.graph'
-import { Route as OrgSlugEntitiesRouteImport } from './routes/$orgSlug.entities'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -66,6 +66,16 @@ const OrgSlugRepositoriesRoute = OrgSlugRepositoriesRouteImport.update({
   path: '/$orgSlug/repositories',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OrgSlugGraphRoute = OrgSlugGraphRouteImport.update({
+  id: '/$orgSlug/graph',
+  path: '/$orgSlug/graph',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OrgSlugEntitiesRoute = OrgSlugEntitiesRouteImport.update({
+  id: '/$orgSlug/entities',
+  path: '/$orgSlug/entities',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const OrgSlugChatRoute = OrgSlugChatRouteImport.update({
   id: '/$orgSlug/chat',
   path: '/$orgSlug/chat',
@@ -100,23 +110,13 @@ const OrgSlugChatConversationIdRoute =
     path: '/$conversationId',
     getParentRoute: () => OrgSlugChatRoute,
   } as any)
-const OrgSlugGraphRoute = OrgSlugGraphRouteImport.update({
-  id: '/$orgSlug/graph',
-  path: '/$orgSlug/graph',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const OrgSlugEntitiesRoute = OrgSlugEntitiesRouteImport.update({
-  id: '/$orgSlug/entities',
-  path: '/$orgSlug/entities',
-  getParentRoute: () => rootRouteImport,
-} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$orgSlug/chat': typeof OrgSlugChatRouteWithChildren
-  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
-  '/$orgSlug/graph': typeof OrgSlugGraphRoute
   '/$orgSlug/entities': typeof OrgSlugEntitiesRoute
+  '/$orgSlug/graph': typeof OrgSlugGraphRoute
+  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
@@ -131,9 +131,9 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
-  '/$orgSlug/graph': typeof OrgSlugGraphRoute
   '/$orgSlug/entities': typeof OrgSlugEntitiesRoute
+  '/$orgSlug/graph': typeof OrgSlugGraphRoute
+  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
@@ -150,9 +150,9 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$orgSlug/chat': typeof OrgSlugChatRouteWithChildren
-  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
-  '/$orgSlug/graph': typeof OrgSlugGraphRoute
   '/$orgSlug/entities': typeof OrgSlugEntitiesRoute
+  '/$orgSlug/graph': typeof OrgSlugGraphRoute
+  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
@@ -170,9 +170,9 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/$orgSlug/chat'
-    | '/$orgSlug/repositories'
-    | '/$orgSlug/graph'
     | '/$orgSlug/entities'
+    | '/$orgSlug/graph'
+    | '/$orgSlug/repositories'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
@@ -187,9 +187,9 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
-    | '/$orgSlug/repositories'
-    | '/$orgSlug/graph'
     | '/$orgSlug/entities'
+    | '/$orgSlug/graph'
+    | '/$orgSlug/repositories'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
@@ -205,9 +205,9 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/$orgSlug/chat'
-    | '/$orgSlug/repositories'
-    | '/$orgSlug/graph'
     | '/$orgSlug/entities'
+    | '/$orgSlug/graph'
+    | '/$orgSlug/repositories'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
@@ -224,9 +224,9 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OrgSlugChatRoute: typeof OrgSlugChatRouteWithChildren
-  OrgSlugRepositoriesRoute: typeof OrgSlugRepositoriesRoute
-  OrgSlugGraphRoute: typeof OrgSlugGraphRoute
   OrgSlugEntitiesRoute: typeof OrgSlugEntitiesRoute
+  OrgSlugGraphRoute: typeof OrgSlugGraphRoute
+  OrgSlugRepositoriesRoute: typeof OrgSlugRepositoriesRoute
   DotauthAuthViewRoute: typeof DotauthAuthViewRoute
   DotauthAccountRoute: typeof DotauthAccountRouteWithChildren
   DotauthConsentRoute: typeof DotauthConsentRoute
@@ -383,9 +383,9 @@ const DotauthAccountRouteWithChildren = DotauthAccountRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OrgSlugChatRoute: OrgSlugChatRouteWithChildren,
-  OrgSlugRepositoriesRoute: OrgSlugRepositoriesRoute,
-  OrgSlugGraphRoute: OrgSlugGraphRoute,
   OrgSlugEntitiesRoute: OrgSlugEntitiesRoute,
+  OrgSlugGraphRoute: OrgSlugGraphRoute,
+  OrgSlugRepositoriesRoute: OrgSlugRepositoriesRoute,
   DotauthAuthViewRoute: DotauthAuthViewRoute,
   DotauthAccountRoute: DotauthAccountRouteWithChildren,
   DotauthConsentRoute: DotauthConsentRoute,

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -23,6 +23,8 @@ import { Route as DotauthOrganizationOrganizationViewRouteImport } from './route
 import { Route as DotauthAccountAccountViewRouteImport } from './routes/[.]auth.account.$accountView'
 import { Route as OrgSlugOrganizationOrganizationViewRouteImport } from './routes/$orgSlug.organization.$organizationView'
 import { Route as OrgSlugChatConversationIdRouteImport } from './routes/$orgSlug.chat.$conversationId'
+import { Route as OrgSlugGraphRouteImport } from './routes/$orgSlug.graph'
+import { Route as OrgSlugEntitiesRouteImport } from './routes/$orgSlug.entities'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -98,11 +100,23 @@ const OrgSlugChatConversationIdRoute =
     path: '/$conversationId',
     getParentRoute: () => OrgSlugChatRoute,
   } as any)
+const OrgSlugGraphRoute = OrgSlugGraphRouteImport.update({
+  id: '/$orgSlug/graph',
+  path: '/$orgSlug/graph',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OrgSlugEntitiesRoute = OrgSlugEntitiesRouteImport.update({
+  id: '/$orgSlug/entities',
+  path: '/$orgSlug/entities',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$orgSlug/chat': typeof OrgSlugChatRouteWithChildren
   '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
+  '/$orgSlug/graph': typeof OrgSlugGraphRoute
+  '/$orgSlug/entities': typeof OrgSlugEntitiesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
@@ -118,6 +132,8 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
+  '/$orgSlug/graph': typeof OrgSlugGraphRoute
+  '/$orgSlug/entities': typeof OrgSlugEntitiesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
@@ -135,6 +151,8 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$orgSlug/chat': typeof OrgSlugChatRouteWithChildren
   '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
+  '/$orgSlug/graph': typeof OrgSlugGraphRoute
+  '/$orgSlug/entities': typeof OrgSlugEntitiesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
@@ -153,6 +171,8 @@ export interface FileRouteTypes {
     | '/'
     | '/$orgSlug/chat'
     | '/$orgSlug/repositories'
+    | '/$orgSlug/graph'
+    | '/$orgSlug/entities'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
@@ -168,6 +188,8 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/$orgSlug/repositories'
+    | '/$orgSlug/graph'
+    | '/$orgSlug/entities'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
@@ -184,6 +206,8 @@ export interface FileRouteTypes {
     | '/'
     | '/$orgSlug/chat'
     | '/$orgSlug/repositories'
+    | '/$orgSlug/graph'
+    | '/$orgSlug/entities'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
@@ -201,6 +225,8 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OrgSlugChatRoute: typeof OrgSlugChatRouteWithChildren
   OrgSlugRepositoriesRoute: typeof OrgSlugRepositoriesRoute
+  OrgSlugGraphRoute: typeof OrgSlugGraphRoute
+  OrgSlugEntitiesRoute: typeof OrgSlugEntitiesRoute
   DotauthAuthViewRoute: typeof DotauthAuthViewRoute
   DotauthAccountRoute: typeof DotauthAccountRouteWithChildren
   DotauthConsentRoute: typeof DotauthConsentRoute
@@ -267,6 +293,20 @@ declare module '@tanstack/react-router' {
       path: '/$orgSlug/repositories'
       fullPath: '/$orgSlug/repositories'
       preLoaderRoute: typeof OrgSlugRepositoriesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$orgSlug/graph': {
+      id: '/$orgSlug/graph'
+      path: '/$orgSlug/graph'
+      fullPath: '/$orgSlug/graph'
+      preLoaderRoute: typeof OrgSlugGraphRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$orgSlug/entities': {
+      id: '/$orgSlug/entities'
+      path: '/$orgSlug/entities'
+      fullPath: '/$orgSlug/entities'
+      preLoaderRoute: typeof OrgSlugEntitiesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$orgSlug/chat': {
@@ -344,6 +384,8 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OrgSlugChatRoute: OrgSlugChatRouteWithChildren,
   OrgSlugRepositoriesRoute: OrgSlugRepositoriesRoute,
+  OrgSlugGraphRoute: OrgSlugGraphRoute,
+  OrgSlugEntitiesRoute: OrgSlugEntitiesRoute,
   DotauthAuthViewRoute: DotauthAuthViewRoute,
   DotauthAccountRoute: DotauthAccountRouteWithChildren,
   DotauthConsentRoute: DotauthConsentRoute,

--- a/apps/ui/src/routes/$orgSlug.entities.tsx
+++ b/apps/ui/src/routes/$orgSlug.entities.tsx
@@ -1,0 +1,32 @@
+import { AppShell } from "@/components/AppShell"
+import { EntityBrowser } from "@/features/entities"
+import { createFileRoute, Navigate } from "@tanstack/react-router"
+import { useSession } from "@/lib/auth-client"
+import { IconInfoCircle } from "@tabler/icons-react"
+
+export const Route = createFileRoute("/$orgSlug/entities")({
+  component: EntitiesPage,
+})
+
+function EntitiesPage() {
+  const { data: session, isPending } = useSession()
+
+  if (isPending) return null
+  if (!session) return <Navigate to="/sign-in" replace />
+
+  return (
+    <AppShell>
+      <div className="flex min-h-screen flex-col">
+        <div className="sticky top-0 z-10 border-b border-white/8 bg-zinc-950/80 px-6 py-2 backdrop-blur">
+          <div className="flex items-center justify-end">
+            <div className="flex items-center gap-2 text-xs text-amber-300">
+              <IconInfoCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              Showing stub data — FalkorDB not yet connected
+            </div>
+          </div>
+        </div>
+        <EntityBrowser />
+      </div>
+    </AppShell>
+  )
+}

--- a/apps/ui/src/routes/$orgSlug.entities.tsx
+++ b/apps/ui/src/routes/$orgSlug.entities.tsx
@@ -2,7 +2,6 @@ import { AppShell } from "@/components/AppShell"
 import { EntityBrowser } from "@/features/entities"
 import { createFileRoute, Navigate } from "@tanstack/react-router"
 import { useSession } from "@/lib/auth-client"
-import { IconInfoCircle } from "@tabler/icons-react"
 
 export const Route = createFileRoute("/$orgSlug/entities")({
   component: EntitiesPage,
@@ -16,17 +15,7 @@ function EntitiesPage() {
 
   return (
     <AppShell>
-      <div className="flex min-h-screen flex-col">
-        <div className="sticky top-0 z-10 border-b border-white/8 bg-zinc-950/80 px-6 py-2 backdrop-blur">
-          <div className="flex items-center justify-end">
-            <div className="flex items-center gap-2 text-xs text-amber-300">
-              <IconInfoCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-              Showing stub data — FalkorDB not yet connected
-            </div>
-          </div>
-        </div>
-        <EntityBrowser />
-      </div>
+      <EntityBrowser />
     </AppShell>
   )
 }

--- a/apps/ui/src/routes/$orgSlug.graph.tsx
+++ b/apps/ui/src/routes/$orgSlug.graph.tsx
@@ -2,7 +2,6 @@ import { AppShell } from "@/components/AppShell"
 import { createFileRoute, Navigate } from "@tanstack/react-router"
 import { useSession } from "@/lib/auth-client"
 import { Suspense, lazy } from "react"
-import { IconInfoCircle } from "@tabler/icons-react"
 
 const GraphVisualization = lazy(() =>
   import("@/features/graph/GraphVisualization").then((m) => ({
@@ -32,7 +31,6 @@ function GraphPage() {
               Entity relationship map for this organisation's indexed repositories
             </p>
           </div>
-          <StubBanner />
         </header>
 
         <div className="relative min-h-0 flex-1">
@@ -51,11 +49,3 @@ function GraphPage() {
   )
 }
 
-function StubBanner() {
-  return (
-    <div className="flex items-center gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
-      <IconInfoCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
-      Showing stub data — FalkorDB not yet connected
-    </div>
-  )
-}

--- a/apps/ui/src/routes/$orgSlug.graph.tsx
+++ b/apps/ui/src/routes/$orgSlug.graph.tsx
@@ -1,0 +1,61 @@
+import { AppShell } from "@/components/AppShell"
+import { createFileRoute, Navigate } from "@tanstack/react-router"
+import { useSession } from "@/lib/auth-client"
+import { Suspense, lazy } from "react"
+import { IconInfoCircle } from "@tabler/icons-react"
+
+const GraphVisualization = lazy(() =>
+  import("@/features/graph/GraphVisualization").then((m) => ({
+    default: m.GraphVisualization,
+  })),
+)
+
+export const Route = createFileRoute("/$orgSlug/graph")({
+  component: GraphPage,
+})
+
+function GraphPage() {
+  const { data: session, isPending } = useSession()
+
+  if (isPending) return null
+  if (!session) return <Navigate to="/sign-in" replace />
+
+  return (
+    <AppShell>
+      <div className="flex h-screen flex-col">
+        <header className="flex shrink-0 items-center justify-between border-b border-white/8 px-6 py-4">
+          <div>
+            <h1 className="text-xl font-semibold text-zinc-100">
+              Knowledge Graph
+            </h1>
+            <p className="mt-0.5 text-sm text-zinc-400">
+              Entity relationship map for this organisation's indexed repositories
+            </p>
+          </div>
+          <StubBanner />
+        </header>
+
+        <div className="relative min-h-0 flex-1">
+          <Suspense
+            fallback={
+              <div className="flex h-full items-center justify-center">
+                <p className="text-sm text-zinc-400">Initialising graph…</p>
+              </div>
+            }
+          >
+            <GraphVisualization />
+          </Suspense>
+        </div>
+      </div>
+    </AppShell>
+  )
+}
+
+function StubBanner() {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+      <IconInfoCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+      Showing stub data — FalkorDB not yet connected
+    </div>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,9 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.162.4
         version: 1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/react-virtual':
+        specifier: ^3.13.21
+        version: 3.13.21(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/router-plugin':
         specifier: ^1.162.4
         version: 1.162.4(@tanstack/react-router@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -4149,6 +4152,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.13.21':
+    resolution: {integrity: sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.162.2':
     resolution: {integrity: sha512-su/X6YP7LIhiy3FWkvCb5JL2LVmfupMXavvfyuPQayWb+E1NJQhYU8dbEcSGB0sNIMZeAmz0iIBSV2MVvuzQ8g==}
     engines: {node: '>=20.19'}
@@ -4223,6 +4232,9 @@ packages:
 
   '@tanstack/store@0.9.1':
     resolution: {integrity: sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg==}
+
+  '@tanstack/virtual-core@3.13.21':
+    resolution: {integrity: sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==}
 
   '@tanstack/virtual-file-routes@1.161.4':
     resolution: {integrity: sha512-42WoRePf8v690qG8yGRe/YOh+oHni9vUaUUfoqlS91U2scd3a5rkLtVsc6b7z60w3RogH0I00vdrC5AaeiZ18w==}
@@ -13702,6 +13714,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.13.21(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.21
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.162.2':
     dependencies:
       '@tanstack/history': 1.161.4
@@ -13834,6 +13852,8 @@ snapshots:
       '@tanstack/router-core': 1.162.2
 
   '@tanstack/store@0.9.1': {}
+
+  '@tanstack/virtual-core@3.13.21': {}
 
   '@tanstack/virtual-file-routes@1.161.4': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,10 +36,10 @@ importers:
         version: 2.0.111(@langchain/core@1.1.27(@opentelemetry/api@1.9.0)(openai@6.22.0(ws@8.19.0)(zod@4.3.6)))(@langchain/langgraph@1.1.5(@langchain/core@1.1.27(@opentelemetry/api@1.9.0)(openai@6.22.0(ws@8.19.0)(zod@4.3.6)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)
       '@better-auth/oauth-provider':
         specifier: ^1.4.18
-        version: 1.4.18(7e3e96099f8b50cb33de2e512434d8fb)
+        version: 1.4.18(424383eee2742dc0b018d0f4b4fbf974)
       '@better-auth/passkey':
         specifier: ^1.4.18
-        version: 1.4.18(9142a074048e98925d52480a40280475)
+        version: 1.4.18(5c321b8a81891eb5b94a74ee367be94b)
       '@hono/mcp':
         specifier: ^0.2.3
         version: 0.2.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.1))(hono@4.12.1)(zod@4.3.6)
@@ -87,10 +87,10 @@ importers:
         version: 6.0.105(zod@4.3.6)
       better-auth:
         specifier: ^1.4.18
-        version: 1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(drizzle-kit@1.0.0-beta.15-859cf75)(drizzle-orm@1.0.0-beta.15-859cf75(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(drizzle-kit@1.0.0-beta.16-ea816b6)(drizzle-orm@1.0.0-beta.16-ea816b6(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       drizzle-orm:
         specifier: beta
-        version: 1.0.0-beta.15-859cf75(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6)
+        version: 1.0.0-beta.16-ea816b6(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6)
       hono:
         specifier: ^4.12.1
         version: 4.12.1
@@ -157,7 +157,7 @@ importers:
         version: 17.3.1
       drizzle-kit:
         specifier: beta
-        version: 1.0.0-beta.15-859cf75
+        version: 1.0.0-beta.16-ea816b6
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -175,7 +175,7 @@ importers:
         version: 0.9.44(hono@4.12.1)
       drizzle-orm:
         specifier: beta
-        version: 1.0.0-beta.15-859cf75(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6)
+        version: 1.0.0-beta.16-ea816b6(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6)
       hono:
         specifier: ^4.12.1
         version: 4.12.1
@@ -249,16 +249,19 @@ importers:
         version: 1.2.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/oauth-provider':
         specifier: ^1.4.18
-        version: 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@3.25.76))
+        version: 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@3.25.76))
       '@better-auth/passkey':
         specifier: ^1.4.18
-        version: 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@3.25.76))(nanostores@1.1.0)
+        version: 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@4.3.6))(nanostores@1.1.0)
+      '@cosmograph/react':
+        specifier: ^2.1.0
+        version: 2.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@daveyplate/better-auth-tanstack':
         specifier: ^1.3.6
         version: 1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@daveyplate/better-auth-ui':
         specifier: ^3.3.15
-        version: 3.3.15(cd8d1a6c60658256eff813f4fc410832)
+        version: 3.3.15(977c7884ab535fce0a7541a5939c0833)
       '@scure/base':
         specifier: ^2.0.0
         version: 2.0.0
@@ -869,6 +872,22 @@ packages:
     peerDependencies:
       commander: ~13.1.0
 
+  '@cosmograph/cosmograph@2.1.0':
+    resolution: {integrity: sha512-1bw3dpQfmyUX8g59/KPBjuNzAhbruq9tWbsf8l3xCR5icG/K9PFSMaMKufQytqIlYBB+CeWZBFgq8jbEURh//Q==}
+
+  '@cosmograph/react@2.1.0':
+    resolution: {integrity: sha512-D+G0zTBAPiODt01LEdSyh6+VNB/TvneqpOi0lgBZe0Ig2LsAwTe509fYb+9JYUA2jKDjuefvaMWfY4boyBy9tg==}
+    peerDependencies:
+      react: '>=16.8.0 || ^17 || ^18'
+      react-dom: '>=16.8.0 || ^17 || ^18'
+
+  '@cosmograph/ui@2.1.0':
+    resolution: {integrity: sha512-DODjN/XkI15K7wJncZmsy8xSDAOEGr6FrPN46j4hfjAgfkm9XWokJYxesl1vnodteed5IS4EfxHzzxeLaWJMBg==}
+
+  '@cosmos.gl/graph@2.6.4':
+    resolution: {integrity: sha512-i+N9lSpAjGLTUPelo/bKNbQnKPDqt3k2UnRlfIWe2Lrambc4J3QFgOfpR8AalQ/1tgLRoeNtVBZ1GPpsNqae5w==}
+    engines: {node: '>=12.2.0', npm: '>=7.0.0'}
+
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
@@ -957,6 +976,12 @@ packages:
 
   '@drizzle-team/brocli@0.11.0':
     resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
+
+  '@duckdb/duckdb-wasm@1.30.0':
+    resolution: {integrity: sha512-9aWrm+4ayl4sTlvGtl/b+LxrUyXaac3yyVqkoJ3F7Vkd62PoS8PcQIRJ/KjXBW36LP1CnPY5jjvFyIcTFLtcXA==}
+
+  '@duckdb/duckdb-wasm@1.32.0':
+    resolution: {integrity: sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==}
 
   '@ecies/ciphers@0.2.5':
     resolution: {integrity: sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==}
@@ -1556,6 +1581,9 @@ packages:
   '@instantdb/version@0.22.142':
     resolution: {integrity: sha512-C2HTo95PllT0b47EFDBC9/XILHwUbaDL/3pE2Q8aI0htB+1gf1Drodz6T4d2BNHJkdELYuDEK6ZpyPIMZqaV7Q==}
 
+  '@interacta/css-labels@0.1.3-beta.2':
+    resolution: {integrity: sha512-dXySLlEeqoo0XjECuc+vBpDdbyabzicnOniM4TgmtLPFZHFAKIdWYpHYu4bj9MkguP+5WpIXB8fw4Qq/2RJYqg==}
+
   '@internationalized/date@3.11.0':
     resolution: {integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==}
 
@@ -1613,6 +1641,9 @@ packages:
   '@js-temporal/polyfill@0.5.1':
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
     engines: {node: '>=12'}
+
+  '@juggle/resize-observer@3.4.0':
+    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
   '@langchain/core@1.1.27':
     resolution: {integrity: sha512-YVtEz3nqCh8WxtdVXUICmt2BR2An+mn4YRJUBwcHX47Yrh2VwxpO0l97B2N/sNi658m65HnGyz2/hAjF3fzc1w==}
@@ -1872,6 +1903,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@observablehq/plot@0.6.17':
+    resolution: {integrity: sha512-/qaXP/7mc4MUS0s4cPPFASDRjtsWp85/TbfsciqDgU1HwYixbSbbytNuInD8AcTYC3xaxACgVX06agdfQy9W+g==}
+    engines: {node: '>=12'}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -4268,6 +4303,12 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -4400,6 +4441,9 @@ packages:
   '@types/mssql@9.1.9':
     resolution: {integrity: sha512-P0nCgw6vzY23UxZMnbI4N7fnLGANt4LI4yvxze1paPj+LuN28cFv5EI+QidP8udnId/BKhkcRhm/BleNsjK65A==}
 
+  '@types/node@20.19.37':
+    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
@@ -4461,6 +4505,24 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@uwdata/flechette@2.3.0':
+    resolution: {integrity: sha512-FdTqVEJZL4MwTv+vY1jOUMW2i5pr/G5S4BGdmQ/7wSOCtA0I74UP117kzXiKe1FrB5+ydM4tFxrCdF8Dq9WgNA==}
+
+  '@uwdata/mosaic-core@0.21.1':
+    resolution: {integrity: sha512-nRh93+A7U/06x/6boSLUUaSCo4pkNAjOgV8P2Zl6ZZeF5pWynLcSqT30WLQPx+VewTvFgJGCymocymdbirFxYw==}
+
+  '@uwdata/mosaic-inputs@0.21.1':
+    resolution: {integrity: sha512-9h/PFk71QL5+Nhqsai9pqVdnHUQb8OAemZrPossbfvb3q62o7RpU+jMwxcAId4uB/qRTAFxr0LgRfoPxrjfZYg==}
+
+  '@uwdata/mosaic-plot@0.21.1':
+    resolution: {integrity: sha512-ZPBD0Km44VIexZ7l88n1yWh8QpVJakJnmkyq6zr8aujw2i2+MkrcI8Abc2aPJ74o2YiSb9hMKxno83nB/Mfy7A==}
+
+  '@uwdata/mosaic-sql@0.21.1':
+    resolution: {integrity: sha512-2B4Dle4odyxIaBaDVRfQchebH/CUZvUV8kIwKF3V2GksQoF8KYY/Q6zTLTJhYrDEdUkt8M0OIy4U/Ntw93CV1A==}
+
+  '@uwdata/vgplot@0.21.1':
+    resolution: {integrity: sha512-R+CFYeTPdNoMzMAxNwt7coTqcWWY6aOKUj28SqkQ4dbL3Ig37RjCnRDcpFzCqvxaSeOwZRXQ1Ld3WhnagqDh/Q==}
 
   '@vercel/nft@1.3.2':
     resolution: {integrity: sha512-HC8venRc4Ya7vNeBsJneKHHMDDWpQie7VaKhAIOst3MKO+DES+Y/SbzSp8mFkD7OzwAE2HhHkeSuSmwS20mz3A==}
@@ -4613,6 +4675,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apache-arrow@17.0.0:
+    resolution: {integrity: sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==}
+    hasBin: true
+
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
     engines: {node: '>= 14'}
@@ -4634,6 +4700,14 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  array-back@3.1.0:
+    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
+    engines: {node: '>=6'}
+
+  array-back@6.2.2:
+    resolution: {integrity: sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==}
+    engines: {node: '>=12.17'}
 
   asn1js@3.0.7:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
@@ -4818,6 +4892,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  binary-search-bounds@2.0.5:
+    resolution: {integrity: sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -4908,6 +4985,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
+    engines: {node: '>=12'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -5048,6 +5129,14 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  command-line-args@5.2.1:
+    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
+    engines: {node: '>=4.0.0'}
+
+  command-line-usage@7.0.4:
+    resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
+    engines: {node: '>=12.20.0'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -5524,12 +5613,12 @@ packages:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
-  drizzle-kit@1.0.0-beta.15-859cf75:
-    resolution: {integrity: sha512-Y36s1XQGVb1PgU3aRNgufp1K3D2VkIifu8kv4Ubsmxi+Dq+N7KMklnpp7Knu/XC4FZi2MHPPG3v3o097r0/TcQ==}
+  drizzle-kit@1.0.0-beta.16-ea816b6:
+    resolution: {integrity: sha512-GiJQqCNPZP8Kk+i7/sFa3rtXbq26tLDNi3LbMx9aoLuwF2ofk8CS7cySUGdI+r4J3q0a568quC8FZeaFTCw4IA==}
     hasBin: true
 
-  drizzle-orm@1.0.0-beta.15-859cf75:
-    resolution: {integrity: sha512-dGVb2Q70H2AV6513hkOXR3Ud0FeGXLdugVq3YehoqkGIVTJrkuo0gRnCcW/dfI00O07t3T4HSh4clF/D/o/IsQ==}
+  drizzle-orm@1.0.0-beta.16-ea816b6:
+    resolution: {integrity: sha512-k9gT4f0O9Qvah5YK/zL+FZonQ8TPyVxcG/ojN4dzO0fHP8hs8tBno8lqmJo53g0JLWv3Q2nsTUoyBRKM2TljFw==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -5931,6 +6020,13 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-replace@3.0.0:
+    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
+    engines: {node: '>=4.0.0'}
+
+  flatbuffers@24.12.23:
+    resolution: {integrity: sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==}
+
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
@@ -6104,6 +6200,12 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  gl-bench@1.0.42:
+    resolution: {integrity: sha512-zuMsA/NCPmI8dPy6q3zTUH8OUM5cqKg7uVWwqzrtXJPBqoypM0XeFWEc8iFOqbf/1qtXieWOrbmgFEByKTQt4Q==}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -6350,6 +6452,9 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  interval-tree-1d@1.0.4:
+    resolution: {integrity: sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ==}
+
   intl-messageformat@10.7.18:
     resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
 
@@ -6518,6 +6623,9 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  isoformat@0.2.1:
+    resolution: {integrity: sha512-tFLRAygk9NqrRPhJSnNGh7g7oaVWDwR0wKh/GM2LgmPa50Eg4UfyaCO4I8k6EqJHl1/uh2RAD6g06n5ygEnrjQ==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -6575,6 +6683,10 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
+    engines: {node: '>=0.8'}
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -7751,6 +7863,10 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  random@4.1.0:
+    resolution: {integrity: sha512-6Ajb7XmMSE9EFAMGC3kg9mvE7fGlBip25mYYuSMzw/uUSrmGilvZo2qwX3RnTRjwXkwkS+4swse9otZ92VjAtQ==}
+    engines: {node: '>=14'}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -7938,6 +8054,9 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
+  regl@2.1.1:
+    resolution: {integrity: sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==}
+
   rehype-harden@1.1.8:
     resolution: {integrity: sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==}
 
@@ -8107,6 +8226,9 @@ packages:
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
+  seedrandom@3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -8420,6 +8542,10 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
+  table-layout@4.1.1:
+    resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
+    engines: {node: '>=12.17'}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -8649,6 +8775,14 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  typical@4.0.0:
+    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
+    engines: {node: '>=8'}
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
+    engines: {node: '>=12.17'}
 
   ua-is-frozen@0.1.2:
     resolution: {integrity: sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==}
@@ -9076,6 +9210,10 @@ packages:
   winston@3.19.0:
     resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
     engines: {node: '>= 12.0.0'}
+
+  wordwrapjs@5.1.1:
+    resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
+    engines: {node: '>=12.17'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -9655,41 +9793,30 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)':
-    dependencies:
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.21
-      '@standard-schema/spec': 1.1.0
-      better-call: 1.1.8(zod@3.25.76)
-      jose: 6.1.3
-      kysely: 0.28.11
-      nanostores: 1.1.0
-      zod: 4.3.6
-
   '@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)':
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.1.0
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.1.8(zod@3.25.76)
       jose: 6.1.3
       kysely: 0.28.11
       nanostores: 1.1.0
       zod: 4.3.6
 
-  '@better-auth/oauth-provider@1.4.18(7e3e96099f8b50cb33de2e512434d8fb)':
+  '@better-auth/oauth-provider@1.4.18(424383eee2742dc0b018d0f4b4fbf974)':
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(drizzle-kit@1.0.0-beta.15-859cf75)(drizzle-orm@1.0.0-beta.15-859cf75(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(drizzle-kit@1.0.0-beta.16-ea816b6)(drizzle-orm@1.0.0-beta.16-ea816b6(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 1.1.8(zod@4.3.6)
       jose: 6.1.3
       zod: 4.3.6
 
-  '@better-auth/oauth-provider@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@3.25.76))':
+  '@better-auth/oauth-provider@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@3.25.76))':
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
+      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -9697,21 +9824,21 @@ snapshots:
       jose: 6.1.3
       zod: 4.3.6
 
-  '@better-auth/passkey@1.4.18(9142a074048e98925d52480a40280475)':
+  '@better-auth/passkey@1.4.18(5c321b8a81891eb5b94a74ee367be94b)':
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.3
-      better-auth: 1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(drizzle-kit@1.0.0-beta.15-859cf75)(drizzle-orm@1.0.0-beta.15-859cf75(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(drizzle-kit@1.0.0-beta.16-ea816b6)(drizzle-orm@1.0.0-beta.16-ea816b6(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 1.1.8(zod@4.3.6)
       nanostores: 1.1.0
       zod: 4.3.6
 
-  '@better-auth/passkey@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@3.25.76))(nanostores@1.1.0)':
+  '@better-auth/passkey@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@4.3.6))(nanostores@1.1.0)':
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
+      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
@@ -9720,12 +9847,6 @@ snapshots:
       better-call: 1.1.8(zod@3.25.76)
       nanostores: 1.1.0
       zod: 4.3.6
-
-  '@better-auth/telemetry@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))':
-    dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.21
 
   '@better-auth/telemetry@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))':
     dependencies:
@@ -9818,6 +9939,59 @@ snapshots:
     dependencies:
       commander: 13.1.0
 
+  '@cosmograph/cosmograph@2.1.0':
+    dependencies:
+      '@cosmograph/ui': 2.1.0
+      '@cosmos.gl/graph': 2.6.4
+      '@duckdb/duckdb-wasm': 1.32.0
+      '@interacta/css-labels': 0.1.3-beta.2
+      '@uwdata/mosaic-core': 0.21.1
+      '@uwdata/mosaic-plot': 0.21.1
+      '@uwdata/mosaic-sql': 0.21.1
+      '@uwdata/vgplot': 0.21.1
+      apache-arrow: 17.0.0
+      d3-array: 3.2.4
+      d3-brush: 3.0.0
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-selection: 3.0.0
+      dompurify: 3.3.1
+
+  '@cosmograph/react@2.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@cosmograph/cosmograph': 2.1.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@cosmograph/ui@2.1.0':
+    dependencies:
+      '@juggle/resize-observer': 3.4.0
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-format: 3.1.2
+      d3-scale: 4.0.2
+      d3-selection: 3.0.0
+      d3-time-format: 4.1.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@cosmos.gl/graph@2.6.4':
+    dependencies:
+      d3-array: 3.2.4
+      d3-color: 3.1.0
+      d3-drag: 3.0.0
+      d3-ease: 3.0.1
+      d3-scale: 4.0.2
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+      dompurify: 3.3.1
+      gl-bench: 1.0.42
+      gl-matrix: 3.4.4
+      random: 4.1.0
+      regl: 2.1.1
+
   '@csstools/color-helpers@6.0.2':
     optional: true
 
@@ -9860,9 +10034,9 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@daveyplate/better-auth-ui@3.3.15(cd8d1a6c60658256eff813f4fc410832)':
+  '@daveyplate/better-auth-ui@3.3.15(977c7884ab535fce0a7541a5939c0833)':
     dependencies:
-      '@better-auth/passkey': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@3.25.76))(nanostores@1.1.0)
+      '@better-auth/passkey': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@4.3.6))(nanostores@1.1.0)
       '@better-fetch/fetch': 1.1.21
       '@captchafox/react': 1.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -9923,6 +10097,14 @@ snapshots:
       which: 4.0.0
 
   '@drizzle-team/brocli@0.11.0': {}
+
+  '@duckdb/duckdb-wasm@1.30.0':
+    dependencies:
+      apache-arrow: 17.0.0
+
+  '@duckdb/duckdb-wasm@1.32.0':
+    dependencies:
+      apache-arrow: 17.0.0
 
   '@ecies/ciphers@0.2.5(@noble/ciphers@1.3.0)':
     dependencies:
@@ -10333,6 +10515,8 @@ snapshots:
 
   '@instantdb/version@0.22.142': {}
 
+  '@interacta/css-labels@0.1.3-beta.2': {}
+
   '@internationalized/date@3.11.0':
     dependencies:
       '@swc/helpers': 0.5.19
@@ -10402,6 +10586,8 @@ snapshots:
   '@js-temporal/polyfill@0.5.1':
     dependencies:
       jsbi: 4.3.2
+
+  '@juggle/resize-observer@3.4.0': {}
 
   '@langchain/core@1.1.27(@opentelemetry/api@1.9.0)(openai@6.22.0(ws@8.19.0)(zod@4.3.6))':
     dependencies:
@@ -10732,6 +10918,12 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@observablehq/plot@0.6.17':
+    dependencies:
+      d3: 7.9.0
+      interval-tree-1d: 1.0.4
+      isoformat: 0.2.1
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -13750,6 +13942,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -13908,6 +14104,10 @@ snapshots:
       - '@azure/core-client'
       - supports-color
 
+  '@types/node@20.19.37':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
@@ -13973,6 +14173,35 @@ snapshots:
       - supports-color
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@uwdata/flechette@2.3.0': {}
+
+  '@uwdata/mosaic-core@0.21.1':
+    dependencies:
+      '@duckdb/duckdb-wasm': 1.30.0
+      '@uwdata/flechette': 2.3.0
+      '@uwdata/mosaic-sql': 0.21.1
+
+  '@uwdata/mosaic-inputs@0.21.1':
+    dependencies:
+      '@uwdata/mosaic-core': 0.21.1
+      '@uwdata/mosaic-sql': 0.21.1
+
+  '@uwdata/mosaic-plot@0.21.1':
+    dependencies:
+      '@observablehq/plot': 0.6.17
+      '@uwdata/mosaic-core': 0.21.1
+      '@uwdata/mosaic-sql': 0.21.1
+      d3: 7.9.0
+
+  '@uwdata/mosaic-sql@0.21.1': {}
+
+  '@uwdata/vgplot@0.21.1':
+    dependencies:
+      '@uwdata/mosaic-core': 0.21.1
+      '@uwdata/mosaic-inputs': 0.21.1
+      '@uwdata/mosaic-plot': 0.21.1
+      '@uwdata/mosaic-sql': 0.21.1
 
   '@vercel/nft@1.3.2(rollup@4.59.0)':
     dependencies:
@@ -14160,6 +14389,18 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  apache-arrow@17.0.0:
+    dependencies:
+      '@swc/helpers': 0.5.19
+      '@types/command-line-args': 5.2.3
+      '@types/command-line-usage': 5.0.4
+      '@types/node': 20.19.37
+      command-line-args: 5.2.1
+      command-line-usage: 7.0.4
+      flatbuffers: 24.12.23
+      json-bignum: 0.0.3
+      tslib: 2.8.1
+
   archiver-utils@5.0.2:
     dependencies:
       glob: 10.5.0
@@ -14195,6 +14436,10 @@ snapshots:
       dequal: 2.0.3
 
   aria-query@5.3.2: {}
+
+  array-back@3.1.0: {}
+
+  array-back@6.2.2: {}
 
   asn1js@3.0.7:
     dependencies:
@@ -14287,7 +14532,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(drizzle-kit@1.0.0-beta.15-859cf75)(drizzle-orm@1.0.0-beta.15-859cf75(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(drizzle-kit@1.0.0-beta.16-ea816b6)(drizzle-orm@1.0.0-beta.16-ea816b6(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -14303,8 +14548,8 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@tanstack/react-start': 1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      drizzle-kit: 1.0.0-beta.15-859cf75
-      drizzle-orm: 1.0.0-beta.15-859cf75(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6)
+      drizzle-kit: 1.0.0-beta.16-ea816b6
+      drizzle-orm: 1.0.0-beta.16-ea816b6(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       pg: 8.18.0
       react: 19.2.4
@@ -14314,13 +14559,13 @@ snapshots:
 
   better-auth@1.4.18(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
-      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
+      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.1.8(zod@3.25.76)
       defu: 6.1.4
       jose: 6.1.3
       kysely: 0.28.11
@@ -14359,6 +14604,8 @@ snapshots:
     optional: true
 
   binary-extensions@2.3.0: {}
+
+  binary-search-bounds@2.0.5: {}
 
   bindings@1.5.0:
     dependencies:
@@ -14472,6 +14719,10 @@ snapshots:
       pathval: 2.0.1
 
   chai@6.2.2: {}
+
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
 
   chalk@4.1.2:
     dependencies:
@@ -14627,6 +14878,20 @@ snapshots:
   comlink@4.4.2: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  command-line-args@5.2.1:
+    dependencies:
+      array-back: 3.1.0
+      find-replace: 3.0.0
+      lodash.camelcase: 4.3.0
+      typical: 4.0.0
+
+  command-line-usage@7.0.4:
+    dependencies:
+      array-back: 6.2.2
+      chalk-template: 0.4.0
+      table-layout: 4.1.1
+      typical: 7.3.0
 
   commander@11.1.0: {}
 
@@ -15057,14 +15322,14 @@ snapshots:
 
   dotenv@17.3.1: {}
 
-  drizzle-kit@1.0.0-beta.15-859cf75:
+  drizzle-kit@1.0.0-beta.16-ea816b6:
     dependencies:
       '@drizzle-team/brocli': 0.11.0
       '@js-temporal/polyfill': 0.5.1
       esbuild: 0.25.12
       jiti: 2.6.1
 
-  drizzle-orm@1.0.0-beta.15-859cf75(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6):
+  drizzle-orm@1.0.0-beta.16-ea816b6(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(zod@4.3.6):
     dependencies:
       '@types/mssql': 9.1.9(@azure/core-client@1.10.1)
       mssql: 11.0.1(@azure/core-client@1.10.1)
@@ -15446,6 +15711,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-replace@3.0.0:
+    dependencies:
+      array-back: 3.1.0
+
+  flatbuffers@24.12.23: {}
+
   fn.name@1.1.0: {}
 
   foreground-child@3.3.1:
@@ -15639,6 +15910,10 @@ snapshots:
       pathe: 2.0.3
 
   github-slugger@2.0.0: {}
+
+  gl-bench@1.0.42: {}
+
+  gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -15983,6 +16258,10 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  interval-tree-1d@1.0.4:
+    dependencies:
+      binary-search-bounds: 2.0.5
+
   intl-messageformat@10.7.18:
     dependencies:
       '@formatjs/ecma402-abstract': 2.3.6
@@ -16110,6 +16389,8 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  isoformat@0.2.1: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -16181,6 +16462,8 @@ snapshots:
     optional: true
 
   jsesc@3.1.0: {}
+
+  json-bignum@0.0.3: {}
 
   json-parse-even-better-errors@2.3.1: {}
 
@@ -17701,6 +17984,10 @@ snapshots:
 
   radix3@1.1.2: {}
 
+  random@4.1.0:
+    dependencies:
+      seedrandom: 3.0.5
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -18016,6 +18303,8 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  regl@2.1.1: {}
+
   rehype-harden@1.1.8:
     dependencies:
       unist-util-visit: 5.1.0
@@ -18252,6 +18541,8 @@ snapshots:
       compute-scroll-into-view: 3.1.1
 
   scule@1.3.0: {}
+
+  seedrandom@3.0.5: {}
 
   selderee@0.11.0:
     dependencies:
@@ -18656,6 +18947,11 @@ snapshots:
 
   tabbable@6.4.0: {}
 
+  table-layout@4.1.1:
+    dependencies:
+      array-back: 6.2.2
+      wordwrapjs: 5.1.1
+
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
@@ -18879,6 +19175,10 @@ snapshots:
       mime-types: 3.0.2
 
   typescript@5.9.3: {}
+
+  typical@4.0.0: {}
+
+  typical@7.3.0: {}
 
   ua-is-frozen@0.1.2: {}
 
@@ -19291,6 +19591,8 @@ snapshots:
       stack-trace: 0.0.10
       triple-beam: 1.4.1
       winston-transport: 4.9.0
+
+  wordwrapjs@5.1.1: {}
 
   wrap-ansi@6.2.0:
     dependencies:


### PR DESCRIPTION
Two pages for visualising and interacting with the graph:

- The visual using cosmograph, with search and filters that highlights the graph, and
- The entity browser, allowing users to search nodes + edges of their graph, with filters and search

These are created with stubbed data (considerate of FalkorDB).

**Design decisions to make:**
- Stable node IDs — FalkorDB internal integer IDs are not stable across deletes. The indexing pipeline must store a uuid or deterministic path-based identifier as a node property and use that as the graph's pointIdBy key.
- `repository` as a property vs relationship — The denormalisation (storing repository as a flat string on every node) is pragmatic for query performance but deviates from the graph model. Either make it an explicit design decision or handle it via a Cypher OPTIONAL MATCH (n)-[:BELONGS_TO]->(r) RETURN r.name in the API layer.
- RelationshipType enum — Will need to expand to CONTAINS, CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEPENDS_ON, MENTIONS (or make it string with a validated union) when the indexer is built. Will defer to Jakub.