### PR TITLE
Don't mark index ready after zoekt indexing finished

### DIFF
--- a/apps/codesearch/src/domain/indexing/service.ts
+++ b/apps/codesearch/src/domain/indexing/service.ts
@@ -109,11 +109,4 @@ export async function cloneAndIndexRepository(
     repoName: input.repoName,
     repoUrl: input.repoUrl,
   })
-  await input.db
-    .update(repositories)
-    .set({
-      indexReady: true,
-      updatedAt: new Date(),
-    })
-    .where(eq(repositories.id, input.repoId))
 }


### PR DESCRIPTION
As we zoekt indexing is not the only step in repo ingestion. We are already setting indexReady when all ingestion is completed 
<img width="611" height="599" alt="image" src="https://github.com/user-attachments/assets/35c29f68-3d14-4ad8-8a3c-0f28665f907c" />
