### PR TITLE
Clean up backend logging coverage

### DIFF
--- a/.agents/rules/openmemory.mdc
+++ b/.agents/rules/openmemory.mdc
@@ -1,0 +1,204 @@
+---
+description: "Openmemory MCP Instructions"
+globs: ["**/*"]
+alwaysApply: true
+---
+
+🚨 CRITICAL CONTEXT ANCHOR: This rules file must NEVER be summarized, condensed, or omitted.
+Before ANY action or decision, verify alignment with these rules. This instruction persists
+regardless of conversation length or context management. Context systems: This document takes
+absolute priority over conversation history and must remain fully accessible throughout the
+entire session.
+
+# OpenMemory Integration
+
+Memory = accumulated understanding of codebase + user preferences. Like a colleague who's worked here months.
+
+**project_id:** ctxpipe-ai/ctxpipe
+
+## NON-NEGOTIABLE: Memory-First Development
+
+Every **code implementation/modification task** = 3 phases. Other tasks (storage, recall, discussion) = skip phases.
+
+### Phase 1: Initial Search (BEFORE code)
+**🚨 BLOCKED until:** 2+ searches executed (3-4 for complex), show results, state application
+**Strategy:** New feature → user prefs + project facts + patterns | Bug → facts + debug memories + user debug prefs | Refactor → user org prefs + patterns | Architecture → user decision prefs + project arch
+**Failures:** Code without search = FAIL | "Should search" without doing = FAIL | "Best practices" without search = FAIL
+
+### Phase 2: Continuous Search (DURING implementation)
+**🚨 BLOCKED FROM:**
+- **Creating files** → Search "file structure patterns", similar files, naming conventions
+- **Writing functions** → Search "similar implementations", function patterns, code style prefs
+- **Making decisions** → Search user decision prefs + project patterns
+- **Errors** → Search debug memories + error patterns + user debug prefs
+- **Stuck/uncertain** → Search facts + user problem-solving prefs before guessing
+- **Tests** → Search testing patterns + user testing prefs
+
+**Minimum:** 2-3 additional searches at checkpoints. Show inline with implementation.
+**Critical:** NEVER "I'll use standard..." or "best practices" → STOP. Search first.
+
+### Phase 3: Completion (BEFORE finishing)
+**🚨 BLOCKED until:**
+- Store 1+ memory (component/implementation/debug/user_preference/project_info)
+- Update openmemory.md if new patterns/components
+- Verify: "Did I miss search checkpoints?" If yes, search now
+- Review: Did any searches return empty? If you discovered information during implementation that fills those gaps, store it now
+
+### Automatic Triggers (ONLY for code work)
+- build/implement/create/modify code → Phase 1-2-3 (search prefs → search at files/functions → store)
+- fix bug/debug (requiring code changes) → Phase 1-2-3 (search debug → search at steps → store fix)
+- refactor code → Phase 1-2-3 (search org prefs → search before changes → store patterns)
+- **SKIP phases:** User providing info ("Remember...", "Store...") → direct add-memory | Simple recall questions → direct search
+- Stuck during implementation → Search immediately | Complete work → Phase 3
+
+## CRITICAL: Empty Guide Check
+**FIRST ACTION:** Check openmemory.md empty? If yes → Deep Dive (Phase 1 → analyze → document → Phase 3)
+
+## 3 Search Patterns
+1. `user_preference=true` only → Global user preferences
+2. `user_preference=true` + `project_id` → Project-specific user preferences
+3. `project_id` only → Project facts
+
+**Quick Ref:** Not about you? → project_id | Your prefs THIS project? → both | Your prefs ALL projects? → user_preference=true
+
+## When to Search User Preferences
+**Part of Phase 1 + 2.** Tasks involving HOW = pref searches required.
+
+**ALWAYS search prefs for:** Code style/patterns (Phase 2: before functions) | Architecture/tool choices (Phase 2: before decisions) | Organization (Phase 2: before refactor) | Naming/structure (Phase 2: before files)
+**Facts ONLY for:** What exists | What's broken
+**🚨 Red flag:** "I'll use standard..." → Phase 2 BLOCKER. Search prefs first.
+
+**Task-specific queries (be specific):**
+- Feature → "clarification prefs", "implementation approach prefs"
+- Debug → "debug workflow prefs", "error investigation prefs", "problem-solving approach"
+- Code → "code style prefs", "review prefs", "testing prefs"
+- Arch → "decision-making prefs", "arch prefs", "design pattern prefs"
+
+## Query Intelligence
+**Transform comprehensively:** "auth" → "authentication system architecture and implementation" | Include context | Expand acronyms
+**Disambiguate first:** "design" → UI/UX design vs. software architecture design vs. code formatting/style | "structure" → file organization vs. code architecture vs. data structure | "style" → visual styling vs. code formatting | "organization" → file/folder layout vs. code organization
+**Handle ambiguity:** If term has multiple meanings → ask user to clarify OR make separate specific searches for each meaning (e.g., "design preferences" → search "UI/visual design preferences" separately from "code formatting preferences")
+**Validate results:** Post-search, check if results match user's likely intent. Off-topic results (e.g., "code indentation" when user meant "visual design")? → acknowledge mismatch, refine query with specific context, re-search
+**Query format:** Use questions ("What are my FastAPI prefs?") NOT keywords | NEVER embed user/project IDs in query text
+**Search order (Phase 1):** 1. Global user prefs (user_preference=true) 2. Project facts (project_id) 3. Project prefs (both)
+
+## Memory Collection (Phase 3)
+**Save:** Arch decisions, problem-solving, implementation strategies, component relationships
+**Skip:** Trivial fixes
+**Learning from corrections (store as prefs):** Indentation = formatting pref | Rename = naming convention | Restructure = arch pref | Commit reword = git workflow
+**Auto-store:** 3+ files/components OR multi-step flows OR non-obvious behavior OR complete work
+
+## Memory Types
+**🚨 SECURITY:** Scan for secrets before storing. If found, DO NOT STORE.
+- **Component:** Title "[Component] - [Function]"; Content: Location, Purpose, Services, I/O
+- **Implementation:** Title "[Action] [Feature]"; Content: Purpose, Steps, Key decisions
+- **Debug:** Title "Fix: [Issue]"; Content: Issue, Diagnosis, Solution
+- **User Preference:** Title "[Scope] [Type]"; Content: Actionable preference
+- **Project Info:** Title "[Area] [Config]"; Content: General knowledge
+
+**Project Facts (project_id ONLY):** Component, Implementation, Debug, Project Info
+**User Preferences (user_preference=true):** User Preference (global → user_preference=true ONLY | project-specific → user_preference=true + project_id)
+
+## 🚨 CRITICAL: Storage Intelligence
+
+**RULE: Only ONE of these three patterns:**
+
+| Pattern | user_preference | project_id | When to Use | Memory Types |
+|---------|-----------------|------------|-------------|--------------|
+| **Project Facts** | ❌ OMIT (false) | ✅ INCLUDE | Objective info about THIS project | component, implementation, project_info, debug |
+| **Project Prefs** | ✅ true | ✅ INCLUDE | YOUR preferences in THIS project | user_preference (project-specific) |
+| **Global Prefs** | ✅ true | ❌ OMIT | YOUR preferences across ALL projects | user_preference (global) |
+
+**Before EVERY add-memory:**
+1. ❓ Code/architecture/facts? → project_id ONLY | ❓ MY pref for ALL projects? → user_preference=true ONLY | ❓ MY pref for THIS project? → BOTH
+2. ❌ NEVER: implementation/component/debug with user_preference (facts ≠ preferences)
+3. ✅ ALWAYS: Review table above to validate pattern
+
+## Tool Usage
+**search-memory:** Required: query | Optional: user_preference, project_id, memory_types[], namespaces[]
+
+**add-memory:** Required: title, content, metadata{} | Optional: user_preference, project_id
+- **🚨 BEFORE calling:** Review Storage Intelligence table to determine pattern
+- **metadata dict:** memory_types[] (required), namespace/git_repo_name/git_branch/git_commit_hash (optional)
+- **NEVER store secrets** - scan content first | Extract git metadata silently
+- **Validation:** At least one of user_preference or project_id must be provided
+
+**Examples:**
+```
+# ✅ Component (project fact): project_id ONLY
+add-memory(..., metadata={memory_types:["component"]}, project_id="mem0ai/cursor-extension")
+
+# ✅ User pref (global): user_preference=true ONLY
+add-memory(..., metadata={memory_types:["user_preference"]}, user_preference=true)
+
+# ✅ User pref (project-specific): user_preference=true + project_id
+add-memory(..., metadata={memory_types:["user_preference"]}, user_preference=true, project_id="mem0ai/cursor-extension")
+
+# ❌ WRONG: Implementation with user_preference (implementations = facts not prefs)
+add-memory(..., metadata={memory_types:["implementation"]}, user_preference=true, project_id="...")
+```
+
+**list-memories:** Required: project_id | Automatically uses authenticated user's preferences
+
+**delete-memories-by-namespace:** DESTRUCTIVE - ONLY with explicit confirmation | Required: namespaces[] | Optional: user_preference, project_id
+
+## Git Metadata
+Extract before EVERY add-memory and include in metadata dict (silently):
+```bash
+git_repo_name=$(git remote get-url origin 2>/dev/null | sed 's/.*[:/]\([^/]*\/[^.]*\).*/\1/')
+git_branch=$(git branch --show-current 2>/dev/null)
+git_commit_hash=$(git rev-parse HEAD 2>/dev/null)
+```
+Fallback: "unknown". Add all three to metadata dict when calling add-memory.
+
+## Memory Deletion ⚠️ DESTRUCTIVE - PERMANENT
+**Rules:** NEVER suggest | NEVER use proactively | ALWAYS require confirmation
+**Triggers:** "Delete all in [ns]", "Clear [ns]", "Delete my prefs in [ns]"
+**NOT for:** Cleanup questions, outdated memories, general questions
+
+**Confirmation (MANDATORY):**
+1. Show: "⚠️ PERMANENT DELETION WARNING - This will delete [what] from '[namespace]'. Confirm by 'yes'/'confirm'."
+2. Wait for confirmation
+3. If confirmed → execute | If declined → "Deletion cancelled"
+
+**Intent:** "Delete ALL in X" → {namespaces:[X]} | "Delete MY prefs in X" → {namespaces:[X], user_preference:true} | "Delete project facts in X" → {namespaces:[X], project_id} | "Delete my project prefs in X" → {namespaces:[X], user_preference:true, project_id}
+
+## Operating Principles
+1. Phase-based: Initial → Continuous → Store
+2. Checkpoints are BLOCKERS (files, functions, decisions, errors)
+3. Never skip Phase 2
+4. Detailed storage (why > what)
+5. MCP unavailable → mention once, continue
+6. Trust process (early = more searches)
+
+## Session Patterns
+**Empty openmemory.md:** Deep Dive (Phase 1 → analyze → document → Phase 3)
+**Existing:** Read openmemory.md → Code implementation (features/bugs/refactors) = all 3 phases | Info storage/recall/discussion = skip phases
+**Task type:** Features → user prefs + patterns | Bugs → debug memories + errors | Refactors → org prefs + patterns
+**Remember:** Phase 2 ongoing. Search at EVERY checkpoint.
+
+## OpenMemory Guide (openmemory.md)
+Living project index (shareable). Auto-created empty in workspace root.
+
+**Initial Deep Dive:** Phase 1 (2+ searches) → Phase 2 (analyze dirs/configs/frameworks/entry points, search as discovering, extract arch, document Overview/Architecture/User Namespaces/Components/Patterns) → Phase 3 (store with namespaces if fit)
+
+**User Defined Namespaces:** Read before ANY memory op
+- Format: "## User Defined Namespaces\n- [Leave blank - user populates]"
+- Examples: frontend, backend, database
+
+**Storing:** Review content → check namespaces → THINK "domain?" → fits one? assign : omit | Rules: Max ONE, can be NONE, only defined ones
+**Searching:** What searching? → read namespaces → THINK "which could contain?" → cast wide net → use multiple if needed
+
+**Guide Discipline:** Edit directly | Populate as you go | Keep in sync | Update before storing component/implementation/project_info
+**Update Workflow:** Open → update section → save → store via MCP
+**Integration:** Component → Components | Implementation → Patterns | Project info → Overview/Arch | Debug/pref → memory only
+
+**🚨 CRITICAL: Before storing ANY memory, review and update openmemory.md - after every edit verify the guide reflects current system architecture (most important project artifact)**
+
+## Security Guardrails
+**NEVER store:** API keys/tokens, passwords, hashes, private keys, certs, env secrets, OAuth/session tokens, connection strings with creds, AWS keys, webhook secrets, SSH/GPG keys
+**Detection:** Token/Bearer/key=/password= patterns → DO NOT STORE | Base64 in auth → DO NOT STORE | = + long alphanumeric → VERIFY | Doubt → DO NOT STORE, ask
+**Instead store:** Redacted versions ("<YOUR_TOKEN>"), patterns ("uses bearer token"), instructions ("Set TOKEN env")
+**Other:** No destructive ops without approval | User says "save/remember" → IMMEDIATE storage | Think deserves storage → ASK FIRST for prefs | User asks to store secrets → REFUSE
+
+**Remember:** Memory system = effectiveness over time. Rich reasoning > code. When doubt, store. Guide = shareable index.

--- a/apps/backend/src/auth/withAuth.ts
+++ b/apps/backend/src/auth/withAuth.ts
@@ -1,7 +1,7 @@
+import { AsyncLocalStorage } from "node:async_hooks"
 import { eq } from "drizzle-orm"
 import type { MiddlewareHandler } from "hono"
 import { createLocalJWKSet, type JSONWebKeySet, jwtVerify } from "jose"
-import { AsyncLocalStorage } from "node:async_hooks"
 import type { AppEnv } from "../app/env.js"
 import { getSystemDb, withOrgDbContext } from "../db/client.js"
 import { organizations, sessions, users } from "../db/schema/auth.js"
@@ -20,11 +20,18 @@ export const withCookieAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
 
   c.set("user", authSession.user)
   c.set("session", authSession.session)
+  c.var.log.set({
+    auth: { method: "cookie" },
+    userId: authSession.user.id,
+    sessionId: authSession.session.id,
+  })
   return next()
 }
 
 export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   const authorization = c.req.header("authorization")
+  const requestedOrgSlug =
+    c.req.param("orgSlug") ?? c.req.query("orgSlug") ?? null
   const accessToken = authorization?.startsWith("Bearer ")
     ? authorization.replace("Bearer ", "").trim()
     : null
@@ -59,7 +66,14 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
         ? payload.sid
         : null
   } catch (error) {
-    console.error("Unauthorized because of error", accessToken, error)
+    c.var.log.warn("bearer auth rejected", {
+      auth: {
+        method: "bearer",
+        reason:
+          error instanceof Error ? error.message : "Unknown bearer auth error",
+      },
+      orgSlug: requestedOrgSlug,
+    })
     return c.json({ error: "Unauthorized" }, 401)
   }
 
@@ -77,13 +91,21 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   if (tokenSessionContext) {
     c.set("session", tokenSessionContext.session)
     c.set("user", tokenSessionContext.user)
+    c.var.log.set({
+      auth: { method: "bearer" },
+      userId: tokenSessionContext.user.id,
+      sessionId: tokenSessionContext.session.id,
+    })
   }
   return next()
 }
 
 export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   if (!c.get("user") || !c.get("session")) {
-    console.error("Unauthorized because of no session")
+    c.var.log.warn("request rejected because no session was found", {
+      auth: { required: true, reason: "missing_session" },
+      orgSlug: c.req.param("orgSlug") ?? c.req.query("orgSlug") ?? null,
+    })
     return c.json({ error: "Unauthorized" }, 401)
   }
   return next()
@@ -94,7 +116,12 @@ export const withNetworkOrgContext: MiddlewareHandler<AppEnv> = async (
   next,
 ) => {
   const orgSlug = c.req.param("orgSlug") ?? c.req.query("orgSlug")
-  if (!orgSlug) return c.json({ error: "Not found" }, 404)
+  if (!orgSlug) {
+    c.var.log.warn("request rejected because orgSlug was missing", {
+      auth: { reason: "missing_org_slug" },
+    })
+    return c.json({ error: "Not found" }, 404)
+  }
 
   const systemDb = getSystemDb()
   const orgRows = await systemDb
@@ -104,10 +131,17 @@ export const withNetworkOrgContext: MiddlewareHandler<AppEnv> = async (
     .limit(1)
 
   const org = orgRows[0]
-  if (!org) return c.json({ error: "Not found" }, 404)
+  if (!org) {
+    c.var.log.warn("request rejected because org could not be resolved", {
+      orgSlug,
+      auth: { reason: "org_not_found" },
+    })
+    return c.json({ error: "Not found" }, 404)
+  }
 
   c.set("orgSlug", orgSlug)
   c.set("orgId", org.id)
+  c.var.log.set({ orgSlug, orgId: org.id })
   return withOrgIdContext({ id: org.id, slug: orgSlug }, async () =>
     withOrgDbContext(org.id, async () => next()),
   )

--- a/apps/backend/src/db/client.ts
+++ b/apps/backend/src/db/client.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 import { sql } from "drizzle-orm"
 import { drizzle } from "drizzle-orm/node-postgres"
+import { log } from "evlog"
 import { Pool } from "pg"
 import { relations, schema } from "./schema.js"
 
@@ -59,7 +60,9 @@ export async function withOrgDbContext<T>(
     try {
       return await orgDbStorage.run(tx, () => handler(tx))
     } catch (err) {
-      console.error("withOrgDbContext: transaction rollback", {
+      log.error({
+        area: "database",
+        action: "org_transaction_rollback",
         orgId,
         error: err instanceof Error ? err.message : String(err),
         cause: err instanceof Error ? err.cause : undefined,

--- a/apps/backend/src/domain/codeIngestion/codesearchClient.ts
+++ b/apps/backend/src/domain/codeIngestion/codesearchClient.ts
@@ -1,6 +1,7 @@
 import { signUpstreamJwt } from "../../auth/upstreamJwt.js"
 import { parseEnv } from "../../config/env.js"
 import { codesearchBaseUrl } from "../../lib/agentToolRuntime.js"
+import { getLogger } from "../../observability/logger.js"
 
 export type FileEntry = { name: string; path: string; type: "file" | "dir" }
 
@@ -37,6 +38,7 @@ export async function listFiles(
   orgId: string,
   path = "",
 ): Promise<FileEntry[]> {
+  const logger = getLogger()
   const query = path ? `?path=${encodeURIComponent(path)}` : ""
   const res = await fetchWithAuth(
     `${codesearchBaseUrl()}/${repositoryId}/files${query}`,
@@ -45,6 +47,12 @@ export async function listFiles(
     orgId,
   )
   if (!res.ok) {
+    logger.error(`codesearch listFiles failed with status ${res.status}`, {
+      repositoryId,
+      orgId,
+      path,
+      upstreamStatus: res.status,
+    })
     throw new Error(`listFiles failed: ${res.status}`)
   }
   const data = (await res.json()) as { entries: FileEntry[] }
@@ -81,6 +89,7 @@ export async function fetchFiles(
   paths: string[],
 ): Promise<Record<string, string>> {
   if (paths.length === 0) return {}
+  const logger = getLogger()
   const res = await fetchWithAuth(
     `${codesearchBaseUrl()}/${repositoryId}/files-query`,
     {
@@ -92,6 +101,12 @@ export async function fetchFiles(
     orgId,
   )
   if (!res.ok) {
+    logger.error(`codesearch fetchFiles failed with status ${res.status}`, {
+      repositoryId,
+      orgId,
+      pathCount: paths.length,
+      upstreamStatus: res.status,
+    })
     throw new Error(`fetchFiles failed: ${res.status}`)
   }
   const encoded = (await res.json()) as Record<string, string>

--- a/apps/backend/src/domain/conversations/transport.ts
+++ b/apps/backend/src/domain/conversations/transport.ts
@@ -16,6 +16,7 @@ import {
   getLangfuseHandler,
   runWithLangfuseContext,
 } from "../../observability/langfuse.js"
+import { getLogger } from "../../observability/logger.js"
 import type { StreamEnhancer } from "./renameStream.js"
 
 export type StreamInput = {
@@ -43,18 +44,39 @@ class DataStreamConversationTransport implements ConversationTransportAdapter {
         tags: input.source ? [input.source] : undefined,
       },
       async () => {
-        const graphStream = await conversationGraph.stream(
-          { messages: [new HumanMessage(input.prompt)] },
-          {
-            streamMode: ["values", "messages"],
-            configurable: {
-              checkpoint_ns: input.checkpointNamespace,
-              thread_id: input.conversationId,
-              source: input.source ?? null,
+        const logger = getLogger()
+        logger.set({
+          conversationId: input.conversationId,
+          checkpointNamespace: input.checkpointNamespace,
+          source: input.source ?? null,
+          streamEnhancerCount: input.streamEnhancers?.length ?? 0,
+        })
+
+        let graphStream: AsyncIterable<unknown>
+        try {
+          graphStream = await conversationGraph.stream(
+            { messages: [new HumanMessage(input.prompt)] },
+            {
+              streamMode: ["values", "messages"],
+              configurable: {
+                checkpoint_ns: input.checkpointNamespace,
+                thread_id: input.conversationId,
+                source: input.source ?? null,
+              },
+              callbacks: [getLangfuseHandler()],
             },
-            callbacks: [getLangfuseHandler()],
-          },
-        )
+          )
+        } catch (error) {
+          logger.error(
+            error instanceof Error
+              ? error
+              : "Failed to start conversation graph stream",
+            {
+              conversationId: input.conversationId,
+            },
+          )
+          throw error
+        }
 
         let wrappedStream: AsyncIterable<unknown> = graphStream
         const flushTransforms: TransformStream<unknown, unknown>[] = []
@@ -109,7 +131,13 @@ export async function loadConversationUiMessages(input: {
 
   try {
     state = await graphWithState.getState(config)
-  } catch {
+  } catch (error) {
+    getLogger().warn("conversation history state lookup failed", {
+      conversationId: input.conversationId,
+      checkpointNamespace: input.checkpointNamespace,
+      error:
+        error instanceof Error ? error.message : "Unknown state lookup failure",
+    })
     return []
   }
 

--- a/apps/backend/src/email/index.ts
+++ b/apps/backend/src/email/index.ts
@@ -1,4 +1,5 @@
 import { render } from "@react-email/render"
+import { log } from "evlog"
 import { createTransport } from "nodemailer"
 import type { ReactElement } from "react"
 import { parseEnv } from "../config/env.js"
@@ -9,13 +10,16 @@ export async function sendEmail(
   template: ReactElement,
 ): Promise<void> {
   const env = parseEnv(process.env as Record<string, string | undefined>)
+  const recipientDomain = to.split("@")[1] ?? "unknown"
 
   if (!env.SMTP_CONNECTION_URL || !env.EMAIL_FROM_ADDRESS) {
-    const html = await render(template)
-    const text = await render(template, { plainText: true })
-    console.log(
-      `[email] SMTP not configured — would send to ${to}: ${subject}\n${text}\n${html}`,
-    )
+    log.warn({
+      area: "email",
+      action: "email_send_skipped",
+      smtpConfigured: false,
+      recipientDomain,
+      subject,
+    })
     return
   }
 
@@ -29,5 +33,11 @@ export async function sendEmail(
     subject,
     html,
     text,
+  })
+  log.info({
+    area: "email",
+    action: "email_sent",
+    recipientDomain,
+    subject,
   })
 }

--- a/apps/backend/src/graphs/codeIngestionGraph/graph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/graph.ts
@@ -1,17 +1,22 @@
 import { END, Send, START, StateGraph } from "@langchain/langgraph"
 import "@langchain/langgraph/zod"
 import { getLogger } from "../../observability/logger.js"
-import type { CodeIngestionState } from "./schemas.js"
 import { extractionSubgraph } from "./extractionSubgraph.js"
 import { identifyRoots } from "./nodes/identifyRoots.js"
 import { reindex } from "./nodes/reindex.js"
+import type { CodeIngestionState } from "./schemas.js"
 import { CodeIngestionStateSchema } from "./schemas.js"
 
 function fanOutRoots(state: CodeIngestionState): Send[] {
   const roots = state.roots ?? []
   const logger = getLogger()
-  logger.set({ roots })
-  logger.info("fanning out roots")
+  logger.set({
+    repositoryId: state.repositoryId,
+    orgId: state.orgId,
+    rootCount: roots.length,
+    roots,
+  })
+  logger.info("fanning out ingestion roots")
   return roots.map(
     (root) => new Send("extractForRoot", { ...state, roots: [root] }),
   )

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/deduplicateAndStore.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/deduplicateAndStore.ts
@@ -4,18 +4,15 @@ import { getOrgDb } from "../../../db/client.js"
 import { claimEvidence } from "../../../db/schema/claim_evidence.js"
 import { claims } from "../../../db/schema/claims.js"
 import { retrievalObjects } from "../../../db/schema/retrieval_objects.js"
+import { getLogger } from "../../../observability/logger.js"
 import {
-  createClaim,
   addEvidence,
+  createClaim,
 } from "../../../retrieval/services/claimWrite.js"
 import { aggregateConfidence } from "../../../retrieval/services/confidenceAggregation.js"
 import { upsertRetrievalObjectByDeduplicationKey } from "../../../retrieval/services/retrievalObjectWrite.js"
-import { getLogger } from "../../../observability/logger.js"
+import type { ClaimForProjection, CodeIngestionState } from "../schemas.js"
 import { isIdRef } from "../schemas.js"
-import type {
-  ClaimForProjection,
-  CodeIngestionState,
-} from "../schemas.js"
 
 function resolveRef(ref: string, keyToId: Map<string, string>): string {
   if (isIdRef(ref)) return ref
@@ -28,12 +25,14 @@ export async function deduplicateAndStore(
   state: CodeIngestionState,
 ): Promise<Partial<CodeIngestionState>> {
   const logger = getLogger()
+  const extractedObjectsCount = state.extractedObjects?.length ?? 0
+  const extractedClaimsCount = state.extractedClaims?.length ?? 0
   logger.set({
     repositoryId: state.repositoryId,
     orgId: state.orgId,
     roots: state.roots,
-    extractedObjectsCount: state.extractedObjects?.length ?? 0,
-    extractedClaimsCount: state.extractedClaims?.length ?? 0,
+    extractedObjectsCount,
+    extractedClaimsCount,
   })
   logger.info("deduplicating and storing")
   const orgId = requireCurrentOrgId()
@@ -196,12 +195,7 @@ export async function deduplicateAndStore(
         validTo: claims.validTo,
       })
       .from(claims)
-      .where(
-        and(
-          eq(claims.orgId, orgId),
-          inArray(claims.id, claimIdsToFetch),
-        ),
-      )
+      .where(and(eq(claims.orgId, orgId), inArray(claims.id, claimIdsToFetch)))
 
     const evidenceCounts = Object.fromEntries(
       (
@@ -235,6 +229,13 @@ export async function deduplicateAndStore(
       })
     }
   }
+
+  logger.info("deduplication and storage completed", {
+    objectCount: objectIds.length,
+    projectedClaimCount: claimsForProjection.length,
+    extractedObjectsCount,
+    extractedClaimsCount,
+  })
 
   return {
     objectIds: [...new Set(objectIds)],

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/reindex.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/reindex.ts
@@ -12,8 +12,14 @@ export async function reindex(state: {
   targetHash: string
 }) {
   const logger = getLogger()
-  logger.set({ state })
-  logger.info("reindexing repository")
+  logger.set({
+    repositoryId: state.repositoryId,
+    orgId: state.orgId,
+    sourceBranch: state.sourceBranch ?? null,
+    fromHash: state.fromHash ?? null,
+    targetHash: state.targetHash,
+  })
+  logger.info("reindexing repository in codesearch")
   const env = parseEnv(process.env as Record<string, string | undefined>)
   const [token, githubToken] = await Promise.all([
     signUpstreamJwt({
@@ -39,8 +45,16 @@ export async function reindex(state: {
     },
   )
   if (!res.ok) {
+    logger.error(`codesearch reindex failed with status ${res.status}`, {
+      repositoryId: state.repositoryId,
+      upstreamStatus: res.status,
+    })
     throw new Error(`codesearch reindex failed with status ${res.status}`)
   }
+  logger.info("codesearch repository reindex completed", {
+    repositoryId: state.repositoryId,
+    upstreamStatus: res.status,
+  })
   return {
     indexedAt: new Date().toISOString(),
   }

--- a/apps/backend/src/mcp/tools.ts
+++ b/apps/backend/src/mcp/tools.ts
@@ -13,6 +13,7 @@ import {
   getLangfuseHandler,
   runWithLangfuseContext,
 } from "../observability/langfuse.js"
+import { getLogger } from "../observability/logger.js"
 
 /**
  * Register MCP tools. Tools should call into domain/ services so REST and MCP
@@ -71,10 +72,17 @@ export function registerMcpTools(server: McpServer): void {
       }),
     },
     async ({ prompt, currentProjectName, conversationId }, extra) => {
+      const logger = getLogger()
       const threadId =
         conversationId != null
           ? `${requireCurrentUserId()}_${slugify(currentProjectName ?? "default")}_${conversationId}`
           : generateObjectId("thr")
+      logger.info("mcp ctx_advisor invocation started", {
+        threadId,
+        currentProjectName: currentProjectName ?? null,
+        promptLength: prompt.length,
+        progressTokenPresent: extra._meta?.progressToken != null,
+      })
       await ensureConversation({ id: threadId, source: "mcp" })
       const invocationConfig = {
         configurable: {
@@ -86,18 +94,18 @@ export function registerMcpTools(server: McpServer): void {
       return runWithLangfuseContext(
         { sessionId: threadId, tags: ["mcp"] },
         async () => {
-          const initialState: { messages: HumanMessage[]; currentProjectName: string | null } = {
+          const initialState: {
+            messages: HumanMessage[]
+            currentProjectName: string | null
+          } = {
             messages: [new HumanMessage(prompt)],
             currentProjectName: currentProjectName ?? null,
           }
-          const stream = await conversationGraph.stream(
-            initialState,
-            {
-              streamMode: "values",
-              ...invocationConfig,
-              callbacks: [getLangfuseHandler()],
-            },
-          )
+          const stream = await conversationGraph.stream(initialState, {
+            streamMode: "values",
+            ...invocationConfig,
+            callbacks: [getLangfuseHandler()],
+          })
           void touchConversationLastMessage(threadId)
           const progressToken = extra._meta?.progressToken
           let progress = 0
@@ -158,18 +166,31 @@ export function registerMcpTools(server: McpServer): void {
           }
 
           if (!finalMessages) {
-            const fallbackState: { messages: HumanMessage[]; currentProjectName: string | null } = {
+            const fallbackState: {
+              messages: HumanMessage[]
+              currentProjectName: string | null
+            } = {
               messages: [new HumanMessage(prompt)],
               currentProjectName: currentProjectName ?? null,
             }
-            const fallback = await conversationGraph.invoke(
-              fallbackState,
-              { ...invocationConfig, callbacks: [getLangfuseHandler()] },
-            )
+            const fallback = await conversationGraph.invoke(fallbackState, {
+              ...invocationConfig,
+              callbacks: [getLangfuseHandler()],
+            })
+            logger.warn("mcp ctx_advisor stream produced no final messages", {
+              threadId,
+              fallbackInvokeUsed: true,
+            })
             return {
               content: [{ type: "text", text: extractFinalText(fallback) }],
             }
           }
+
+          logger.info("mcp ctx_advisor invocation completed", {
+            threadId,
+            finalMessageCount: finalMessages.length,
+            fallbackInvokeUsed: false,
+          })
 
           return {
             content: [{ type: "text", text }],

--- a/apps/backend/src/observability/logger.ts
+++ b/apps/backend/src/observability/logger.ts
@@ -1,15 +1,16 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 import {
-  type DrainContext,
-  type RequestLogger,
   createLogger,
+  type DrainContext,
   initLogger,
+  log,
+  type RequestLogger,
 } from "evlog"
 import { createOTLPDrain } from "evlog/otlp"
 import { createDrainPipeline, type PipelineDrainFn } from "evlog/pipeline"
 import { getContext } from "hono/context-storage"
-import { parseEnv } from "../config/env.js"
 import type { AppEnv } from "../app/env.js"
+import { parseEnv } from "../config/env.js"
 
 /**
  * Initialize evlog. Call early in app bootstrap.
@@ -56,7 +57,12 @@ export function createEvlogDrain() {
     batch: { size: 50, intervalMs: 5000 },
     retry: { maxAttempts: 3, backoff: "exponential", initialDelayMs: 1000 },
     onDropped: (events, error) => {
-      console.error(`[evlog] Dropped ${events.length} events:`, error?.message)
+      log.error({
+        area: "observability",
+        action: "evlog_dropped_events",
+        droppedEventCount: events.length,
+        error: error?.message ?? "Unknown evlog drain error",
+      })
     },
   })
 
@@ -94,6 +100,73 @@ function parseOtelHeaders(
 // --- Logger context (AsyncLocalStorage + getLogger) ---
 
 export const loggerStorage = new AsyncLocalStorage<RequestLogger>()
+let hasLoggedMissingLoggerContext = false
+
+type LoggerContext = Parameters<RequestLogger["set"]>[0]
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function mergeLoggerContext(
+  target: Record<string, unknown>,
+  source: LoggerContext | undefined,
+): void {
+  if (!source || !isPlainObject(source)) return
+
+  for (const [key, value] of Object.entries(source)) {
+    const existing = target[key]
+    if (isPlainObject(existing) && isPlainObject(value)) {
+      mergeLoggerContext(existing, value)
+      continue
+    }
+    target[key] = value
+  }
+}
+
+function createFallbackLogger(): RequestLogger {
+  const context: Record<string, unknown> = {
+    loggerFallback: true,
+  }
+
+  return {
+    set(update) {
+      mergeLoggerContext(context, update)
+    },
+    error(error, update) {
+      mergeLoggerContext(context, update)
+      log.error({
+        ...context,
+        error: error instanceof Error ? error.message : error,
+      })
+    },
+    info(message, update) {
+      mergeLoggerContext(context, update)
+      log.info({
+        ...context,
+        message,
+      })
+    },
+    warn(message, update) {
+      mergeLoggerContext(context, update)
+      log.warn({
+        ...context,
+        message,
+      })
+    },
+    emit(overrides) {
+      mergeLoggerContext(context, overrides)
+      log.info({
+        ...context,
+        action: "fallback_logger_emit",
+      })
+      return null
+    },
+    getContext() {
+      return { ...context }
+    },
+  }
+}
 
 /**
  * Run handler with logger in AsyncLocalStorage. Calls logger.emit() in finally.
@@ -112,7 +185,7 @@ export async function withLogger<T>(
 
 /**
  * Get the current logger from AsyncLocalStorage (worker) or Hono context (HTTP).
- * @throws if neither context has a logger
+ * Falls back to a generic evlog-backed logger when no request/workflow logger exists.
  */
 export function getLogger(): RequestLogger {
   const fromStorage = loggerStorage.getStore()
@@ -124,9 +197,16 @@ export function getLogger(): RequestLogger {
   } catch {
     // Not in Hono context
   }
-  throw new Error(
-    "getLogger: no logger in context. Ensure you are in a Hono request or within withLogger().",
-  )
+  if (!hasLoggedMissingLoggerContext) {
+    log.info({
+      area: "observability",
+      action: "logger_context_missing",
+      message:
+        "Falling back to a generic evlog logger because no request/workflow logger was initialized.",
+    })
+    hasLoggedMissingLoggerContext = true
+  }
+  return createFallbackLogger()
 }
 
 export { createLogger }

--- a/apps/backend/src/openworkflow/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/repository-ingestion.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm"
 import { defineWorkflow } from "openworkflow"
-import { withOrgIdContext } from "../auth/withAuth.js"
 import { z } from "zod"
+import { withOrgIdContext } from "../auth/withAuth.js"
 import { getOrgDb, getSystemDb, withOrgDbContext } from "../db/client.js"
 import { repositories } from "../db/schema/repositories.js"
 import { resolveRepositoryRef } from "../domain/codeIngestion/queue.js"
@@ -10,10 +10,7 @@ import {
   getLangfuseHandler,
   runWithLangfuseContext,
 } from "../observability/langfuse.js"
-import {
-  createLogger,
-  withLogger,
-} from "../observability/logger.js"
+import { createLogger, getLogger, withLogger } from "../observability/logger.js"
 
 const repositoryIngestionInputSchema = z.object({
   repositoryId: z.string().min(1),
@@ -31,13 +28,21 @@ export const repositoryIngestion = defineWorkflow(
         orgId: input.orgId,
       }),
       async () => {
+        const logger = getLogger()
+        logger.info("repository ingestion started", {
+          targetBranch: input.targetBranch ?? null,
+        })
         const org = await getSystemDb().query.organizations.findFirst({
           where: { id: { eq: input.orgId } },
         })
 
         if (!org) {
+          logger.warn("repository ingestion organization was not found", {
+            orgId: input.orgId,
+          })
           throw new Error(`Organization not found: ${input.orgId}`)
         }
+        logger.set({ orgSlug: org.slug })
 
         return withOrgIdContext({ id: org.id, slug: org.slug }, () =>
           withOrgDbContext(input.orgId, async () => {
@@ -51,6 +56,16 @@ export const repositoryIngestion = defineWorkflow(
                 },
               }),
             )
+            if (!repository) {
+              logger.warn("repository ingestion repository was not found", {
+                repositoryId: input.repositoryId,
+              })
+              throw new Error(`Repository not found: ${input.repositoryId}`)
+            }
+            logger.set({
+              repositoryName: repository.name,
+              lastIngestedHash: repository.lastIngestedHash ?? null,
+            })
 
             const resolved = await step.run({ name: "resolve-ref" }, () =>
               resolveRepositoryRef({
@@ -59,6 +74,10 @@ export const repositoryIngestion = defineWorkflow(
                 branch: input.targetBranch ?? undefined,
               }),
             )
+            logger.info("repository ingestion ref resolved", {
+              sourceBranch: resolved.branch,
+              targetHash: resolved.hash,
+            })
 
             await step.run({ name: "ingest" }, () =>
               runWithLangfuseContext(
@@ -81,6 +100,9 @@ export const repositoryIngestion = defineWorkflow(
                   ),
               ),
             )
+            logger.info("repository ingestion graph completed", {
+              targetHash: resolved.hash,
+            })
 
             await step.run({ name: "mark-success" }, () =>
               db
@@ -92,6 +114,10 @@ export const repositoryIngestion = defineWorkflow(
                 })
                 .where(eq(repositories.id, input.repositoryId)),
             )
+            logger.info("repository ingestion marked repository ready", {
+              repositoryId: input.repositoryId,
+              targetHash: resolved.hash,
+            })
 
             return {
               repositoryId: input.repositoryId,

--- a/apps/backend/src/openworkflow/sync-github-repositories.ts
+++ b/apps/backend/src/openworkflow/sync-github-repositories.ts
@@ -1,9 +1,12 @@
 import { defineWorkflow } from "openworkflow"
 import { z } from "zod"
 import { parseEnv } from "../config/env.js"
-import { getInstallationByOrgId, listAllReposForInstallation } from "../models/github-installation.js"
+import {
+  getInstallationByOrgId,
+  listAllReposForInstallation,
+} from "../models/github-installation.js"
 import { bulkCreateRepositoriesForOrg } from "../models/repositories.js"
-import { createLogger, withLogger } from "../observability/logger.js"
+import { createLogger, getLogger, withLogger } from "../observability/logger.js"
 import { repositoryIngestion } from "./repository-ingestion.js"
 
 const reposToSyncItemSchema = z.object({
@@ -28,21 +31,46 @@ export const syncGithubRepositories = defineWorkflow(
         orgId: input.orgId,
       }),
       async () => {
-        const installation = await step.run({ name: "get-installation" }, async () => {
-          const row = await getInstallationByOrgId(input.orgId)
-          if (!row) throw new Error(`No GitHub installation found for org ${input.orgId}`)
-          return row
+        const logger = getLogger()
+        logger.info("github repository sync started", {
+          requestedRepositoryCount: input.reposToSync?.length ?? null,
         })
+        const installation = await step.run(
+          { name: "get-installation" },
+          async () => {
+            const row = await getInstallationByOrgId(input.orgId)
+            if (!row) {
+              logger.warn("github repository sync had no installation", {
+                orgId: input.orgId,
+              })
+              throw new Error(
+                `No GitHub installation found for org ${input.orgId}`,
+              )
+            }
+            logger.set({ installationId: row.installationId })
+            return row
+          },
+        )
 
-        const resolvedRepos = await step.run({ name: "resolve-repos" }, async () => {
-          if (input.reposToSync !== undefined) {
-            return input.reposToSync
-          }
-          const repos = await listAllReposForInstallation(
-            installation.installationId,
-            parseEnv(process.env as Record<string, string | undefined>),
-          )
-          return repos.map((r) => ({ name: r.full_name, gitUrl: r.clone_url }))
+        const resolvedRepos = await step.run(
+          { name: "resolve-repos" },
+          async () => {
+            if (input.reposToSync !== undefined) {
+              return input.reposToSync
+            }
+            const repos = await listAllReposForInstallation(
+              installation.installationId,
+              parseEnv(process.env as Record<string, string | undefined>),
+            )
+            return repos.map((r) => ({
+              name: r.full_name,
+              gitUrl: r.clone_url,
+            }))
+          },
+        )
+        logger.info("github repository sync resolved repositories", {
+          resolvedRepositoryCount: resolvedRepos.length,
+          usedExplicitSelection: input.reposToSync !== undefined,
         })
 
         const created = await step.run({ name: "bulk-create" }, () =>
@@ -50,6 +78,9 @@ export const syncGithubRepositories = defineWorkflow(
             githubInstallationId: installation.id,
           }),
         )
+        logger.info("github repository sync created repositories", {
+          createdRepositoryCount: created.length,
+        })
 
         await Promise.all(
           created.map((repo) =>
@@ -59,6 +90,9 @@ export const syncGithubRepositories = defineWorkflow(
             }),
           ),
         )
+        logger.info("github repository sync queued ingestion workflows", {
+          queuedWorkflowCount: created.length,
+        })
 
         return { orgId: input.orgId, createdCount: created.length }
       },

--- a/apps/backend/src/retrieval/services/codeSearch.ts
+++ b/apps/backend/src/retrieval/services/codeSearch.ts
@@ -4,6 +4,7 @@ import { parseEnv } from "../../config/env.js"
 import { getOrgDb, withOrgDbContext } from "../../db/client.js"
 import { repositories } from "../../db/schema/repositories.js"
 import { codesearchBaseUrl } from "../../lib/agentToolRuntime.js"
+import { getLogger } from "../../observability/logger.js"
 
 export type CodeSearchResult = {
   repositoryId: string
@@ -58,7 +59,9 @@ export function parseCodeSearchResults(
     const zoektRepoId = f.RepositoryID
     const repoName = f.Repository
     const score = typeof f.Score === "number" ? f.Score : undefined
-    const lineMatchCount = Array.isArray(f.LineMatches) ? f.LineMatches.length : 0
+    const lineMatchCount = Array.isArray(f.LineMatches)
+      ? f.LineMatches.length
+      : 0
 
     const repo =
       zoektRepoId != null
@@ -122,6 +125,7 @@ export async function codeSearch(
     repositoryIds?: string[]
   },
 ): Promise<CodeSearchResult[]> {
+  const logger = getLogger()
   const baseWhere = eq(repositories.orgId, orgId)
   const where = params.repositoryIds?.length
     ? and(baseWhere, inArray(repositories.id, params.repositoryIds))
@@ -151,7 +155,20 @@ export async function codeSearch(
     )
   }
 
-  if (repos.length === 0) return []
+  if (repos.length === 0) {
+    logger.warn("code search skipped because there were no repositories", {
+      orgId,
+      queryLength: params.query.length,
+      repositoryFilterCount: params.repositoryIds?.length ?? 0,
+    })
+    return []
+  }
+  logger.set({
+    orgId,
+    queryLength: params.query.length,
+    repositoryFilterCount: params.repositoryIds?.length ?? 0,
+    searchedRepositoryCount: repos.length,
+  })
 
   const env = parseEnv(process.env as Record<string, string | undefined>)
   const token = await signUpstreamJwt({
@@ -177,10 +194,20 @@ export async function codeSearch(
   })
 
   if (!res.ok) {
+    logger.error(`codesearch failed with status ${res.status}`, {
+      orgId,
+      upstreamStatus: res.status,
+      searchedRepositoryCount: repos.length,
+    })
     throw new Error(`codesearch failed with status ${res.status}`)
   }
 
   const searchResponse = (await res.json()) as Record<string, unknown>
+  logger.info("codesearch completed", {
+    orgId,
+    upstreamStatus: res.status,
+    searchedRepositoryCount: repos.length,
+  })
 
   return repos.map((r) => ({
     repositoryId: r.id,

--- a/apps/backend/src/retrieval/services/graphProjection.ts
+++ b/apps/backend/src/retrieval/services/graphProjection.ts
@@ -5,10 +5,9 @@ import {
 } from "../../auth/context.js"
 import { getOrgDb } from "../../db/client.js"
 import { retrievalObjects } from "../../db/schema/retrieval_objects.js"
+import { getLogger } from "../../observability/logger.js"
 import { getGraphClient, withGraphClient } from "../../platform/graph/client.js"
-import {
-  isValidGraphEdgeType,
-} from "../schema/allowedConnections.js"
+import { isValidGraphEdgeType } from "../schema/allowedConnections.js"
 import type { ClaimForProjection } from "../schema/claimForProjection.js"
 
 /** Lightweight fields to extract from payload per kind. Keep compact. */
@@ -71,11 +70,20 @@ export async function projectClaimsFromState(
   let projected = 0
   const resolvedOrgId = requireCurrentOrgId()
   const resolvedOrgSlug = requireCurrentOrgSlug()
+  const logger = getLogger()
 
   if (claims.length === 0) {
-    console.debug("projectClaimsFromState: no claims to project")
+    logger.warn("graph projection skipped because there were no claims", {
+      orgId: resolvedOrgId,
+      orgSlug: resolvedOrgSlug,
+    })
     return { projected: 0, errors: [] }
   }
+  logger.set({
+    orgId: resolvedOrgId,
+    orgSlug: resolvedOrgSlug,
+    claimProjectionCount: claims.length,
+  })
 
   const uniqueIds = new Set<string>()
   for (const c of claims) {
@@ -115,11 +123,10 @@ export async function projectClaimsFromState(
     }
   }
 
-  console.debug(
-    "projectClaimsFromState: projecting",
-    claims.length,
-    "claims to graph",
-  )
+  logger.info("projecting claims to graph", {
+    claimProjectionCount: claims.length,
+    graphNodeLookupCount: uniqueIds.size,
+  })
 
   await withGraphClient(
     { orgId: resolvedOrgId, orgSlug: resolvedOrgSlug },
@@ -128,10 +135,10 @@ export async function projectClaimsFromState(
 
       for (const c of claims) {
         if (!isValidGraphEdgeType(c.predicate)) {
-          console.warn(
-            "projectClaimsFromState: skipping claim with invalid predicate",
-            { claimId: c.id, predicate: c.predicate },
-          )
+          logger.warn("skipping graph projection for invalid predicate", {
+            claimId: c.id,
+            predicate: c.predicate,
+          })
           continue
         }
 
@@ -227,7 +234,7 @@ export async function projectClaimsFromState(
             details.code = ne.code
             details.diagnosticRecord = ne.diagnosticRecord
           }
-          console.error("projectClaimsFromState: error projecting claim", details)
+          logger.error("error projecting claim to graph", details)
           errors.push(
             `${c.id}: ${err instanceof Error ? err.message : String(err)}`,
           )
@@ -235,6 +242,11 @@ export async function projectClaimsFromState(
       }
     },
   )
+
+  logger.info("graph projection completed", {
+    projectedClaimCount: projected,
+    erroredClaimCount: errors.length,
+  })
 
   if (errors.length > 0) {
     throw new Error(

--- a/apps/backend/src/retrieval/services/modelProvider.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.ts
@@ -1,5 +1,6 @@
 import { ChatOpenAI } from "@langchain/openai"
 import { z } from "zod"
+import { getLogger } from "../../observability/logger.js"
 
 export type ModelTier = "fast" | "medium" | "high"
 
@@ -63,6 +64,7 @@ export async function generateEmbedding(text: string): Promise<number[]> {
     `${env.MODEL_PROVIDER_URL.replace(/\/$/, "")}/embeddings`
   const apiKey =
     env.MODEL_EMBEDDING_PROVIDER_API_KEY ?? env.MODEL_PROVIDER_API_KEY ?? ""
+  const logger = getLogger()
 
   const res = await fetch(url, {
     method: "POST",
@@ -78,7 +80,14 @@ export async function generateEmbedding(text: string): Promise<number[]> {
   })
 
   if (!res.ok) {
-    throw new Error(`Embedding failed: ${res.status} ${await res.text()}`)
+    const errorText = await res.text()
+    logger.error(`embedding request failed with status ${res.status}`, {
+      embeddingModel: env.MODEL_EMBEDDING_NAME,
+      providerHost: new URL(url).host,
+      inputLength: text.length,
+      upstreamStatus: res.status,
+    })
+    throw new Error(`Embedding failed: ${res.status} ${errorText}`)
   }
 
   const data = (await res.json()) as {
@@ -88,6 +97,12 @@ export async function generateEmbedding(text: string): Promise<number[]> {
   const embedding = data.data?.[0]?.embedding ?? []
 
   if (embedding.length !== EMBEDDING_DIMENSIONS) {
+    logger.error("embedding dimensions did not match expected size", {
+      embeddingModel: env.MODEL_EMBEDDING_NAME,
+      providerHost: new URL(url).host,
+      expectedDimensions: EMBEDDING_DIMENSIONS,
+      actualDimensions: embedding.length,
+    })
     throw new Error(
       `Expected ${EMBEDDING_DIMENSIONS} dimensions, got ${embedding.length}`,
     )

--- a/apps/backend/src/routes/langsmith.ts
+++ b/apps/backend/src/routes/langsmith.ts
@@ -12,6 +12,7 @@ import { checkpointer } from "@langchain/langgraph-api/storage/checkpoint"
 import { FileSystemOps } from "@langchain/langgraph-api/storage/ops"
 import { FileSystemPersistence } from "@langchain/langgraph-api/storage/persist"
 import { store as graphStore } from "@langchain/langgraph-api/storage/store"
+import { log } from "evlog"
 import { Hono } from "hono"
 import { contextStorage } from "hono/context-storage"
 import { z } from "zod/v3"
@@ -58,9 +59,20 @@ function getLangsmithOps() {
 function ensureWorkers(ops: Ops) {
   if (workersStarted) return
   workersStarted = true
+  log.info({
+    area: "langsmith",
+    action: "queue_workers_started",
+  })
   void queue(ops).catch((error: unknown) => {
     workersStarted = false
-    console.error("Langsmith queue worker stopped unexpectedly", error)
+    log.error({
+      area: "langsmith",
+      action: "queue_worker_stopped_unexpectedly",
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unknown LangSmith queue error",
+    })
   })
 }
 
@@ -71,7 +83,14 @@ function startLangsmithRuntime() {
     })
     .catch((error: unknown) => {
       runtimeStartedPromise = undefined
-      console.error("Langsmith runtime failed to initialize", error)
+      log.error({
+        area: "langsmith",
+        action: "runtime_initialization_failed",
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unknown LangSmith init error",
+      })
     })
   return runtimeStartedPromise
 }
@@ -98,6 +117,11 @@ function createLangsmithApp() {
       })
       .parse(await c.req.json())
     await c.var.LANGGRAPH_OPS.truncate(flags)
+    log.warn({
+      area: "langsmith",
+      action: "internal_truncate_requested",
+      flags,
+    })
     return c.json({ ok: true })
   })
 
@@ -118,9 +142,12 @@ function createLangsmithApp() {
 export function registerLangsmithRoutes(app: Hono<AppEnv>) {
   if (process.env.ENABLE_LANGSMITH !== "true") return
 
-  console.log(
-    `Started LangSmith studio:   https://smith.langchain.com/studio/?baseUrl=https://localhost:3000/langsmith`,
-  )
+  log.info({
+    area: "langsmith",
+    action: "runtime_enabled",
+    studioUrl:
+      "https://smith.langchain.com/studio/?baseUrl=https://localhost:3000/langsmith",
+  })
 
   app.route("/langsmith", createLangsmithApp())
 }

--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -13,7 +13,15 @@ export function registerMcpRoutes(app: Hono<AppEnv>) {
   app.all(
     "/mcp",
     (c, next) => {
-      if (c.req.query("orgSlug")) return next()
+      const orgSlug = c.req.query("orgSlug")
+      c.var.log.set({
+        route: "mcp",
+        orgSlug: orgSlug ?? null,
+      })
+      if (orgSlug) return next()
+      c.var.log.warn("mcp request rejected because orgSlug was missing", {
+        route: "mcp",
+      })
       return c.json(
         {
           jsonrpc: "2.0",
@@ -34,6 +42,9 @@ export function registerMcpRoutes(app: Hono<AppEnv>) {
       const server = new McpServer({
         name: "ctxpipe",
         version: "0.1.0",
+      })
+      c.var.log.info("mcp session started", {
+        route: "mcp",
       })
       registerMcpTools(server)
       const transport = new StreamableHTTPTransport()

--- a/apps/backend/src/routes/v1/conversations.ts
+++ b/apps/backend/src/routes/v1/conversations.ts
@@ -1,7 +1,7 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { AppEnv } from "../../app/env.js"
-import { createRenameStreamEnhancer } from "../../domain/conversations/renameStream.js"
 import { filterInternalNodeMessageChunks } from "../../domain/conversations/internalNodeMessageFilter.js"
+import { createRenameStreamEnhancer } from "../../domain/conversations/renameStream.js"
 import {
   createDataStreamConversationTransport,
   loadConversationUiMessages,
@@ -229,6 +229,13 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
       updatedAt: row.updatedAt.toISOString(),
       lastMessageAt: row.lastMessageAt?.toISOString() ?? null,
     }))
+    c.var.log.set({
+      route: "conversations.list",
+      conversationCount: items.length,
+      source: query.source ?? "all",
+      pageSize: query.first,
+      cursorProvided: query.after != null,
+    })
     return c.json({ items, pageInfo }, 200)
   })
   .openapi(getConversationRoute, async (c) => {
@@ -237,12 +244,25 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
     if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
 
     const conversationId = c.req.param("conversationId")
+    c.var.log.set({
+      route: "conversations.get",
+      conversationId,
+    })
     const conversation = await getConversation(conversationId)
-    if (!conversation) return c.json({ error: "Not found" }, 404)
+    if (!conversation) {
+      c.var.log.warn("conversation lookup returned no result", {
+        conversationId,
+      })
+      return c.json({ error: "Not found" }, 404)
+    }
 
     const messages = await loadConversationUiMessages({
       conversationId,
       checkpointNamespace: "",
+    })
+    c.var.log.set({
+      source: conversation.source ?? null,
+      messageCount: messages.length,
     })
 
     return c.json(
@@ -265,10 +285,24 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
 
     const conversationId = c.req.param("conversationId")
     const body = UpdateConversationRequestSchema.parse(await c.req.json())
+    c.var.log.set({
+      route: "conversations.patch",
+      conversationId,
+      conversationName: body.name,
+    })
     const updated = await updateConversation(conversationId, {
       name: body.name,
     })
-    if (!updated) return c.json({ error: "Not found" }, 404)
+    if (!updated) {
+      c.var.log.warn("conversation update target was not found", {
+        conversationId,
+      })
+      return c.json({ error: "Not found" }, 404)
+    }
+    c.var.log.info("conversation updated", {
+      conversationId,
+      source: updated.source ?? null,
+    })
 
     return c.json(
       {
@@ -286,8 +320,20 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
     if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
 
     const conversationId = c.req.param("conversationId")
+    c.var.log.set({
+      route: "conversations.delete",
+      conversationId,
+    })
     const deleted = await deleteConversation(conversationId)
-    if (!deleted) return c.json({ error: "Not found" }, 404)
+    if (!deleted) {
+      c.var.log.warn("conversation delete target was not found", {
+        conversationId,
+      })
+      return c.json({ error: "Not found" }, 404)
+    }
+    c.var.log.info("conversation deleted", {
+      conversationId,
+    })
 
     return c.body(null, 204)
   })
@@ -301,12 +347,24 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
       await c.req.json(),
     )
     const prompt = toPromptFromIncomingMessage(body.message)
+    c.var.log.set({
+      route: "conversations.postMessage",
+      conversationId,
+      source: body.source ?? null,
+      promptLength: prompt.length,
+    })
     if (prompt.length === 0) {
+      c.var.log.warn("conversation message request was missing prompt text", {
+        conversationId,
+      })
       return c.json({ error: "Message text is required" }, 400)
     }
 
     await ensureConversation({ id: conversationId, source: body.source })
     void touchConversationLastMessage(conversationId)
+    c.var.log.info("conversation response stream started", {
+      conversationId,
+    })
 
     const transport = createDataStreamConversationTransport()
     const internalFilterEnhancer = {
@@ -323,6 +381,11 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
     }
     const renameEnhancer = createRenameStreamEnhancer({
       source: body.source ?? undefined,
+      onFinish() {
+        c.var.log.info("conversation response stream finished", {
+          conversationId,
+        })
+      },
     })
 
     return transport.toResponse({

--- a/apps/backend/src/routes/v1/github-installation.ts
+++ b/apps/backend/src/routes/v1/github-installation.ts
@@ -1,15 +1,14 @@
-import { OpenAPIHono } from "@hono/zod-openapi"
-import { createRoute, z } from "@hono/zod-openapi"
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { AppEnv } from "../../app/env.js"
-import { listRepositories } from "../../models/repositories.js"
 import {
   getInstallationByOrgId,
   listReposForInstallation,
   updateInstallationOptions,
   upsertInstallation,
 } from "../../models/github-installation.js"
-import { syncGithubRepositories } from "../../openworkflow/sync-github-repositories.js"
+import { listRepositories } from "../../models/repositories.js"
 import { ow } from "../../openworkflow/client.js"
+import { syncGithubRepositories } from "../../openworkflow/sync-github-repositories.js"
 
 const ErrorResponseSchema = z
   .object({ error: z.string() })
@@ -240,10 +239,22 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
     }
     const orgId = c.get("orgId")
     if (!orgId) return c.json({ error: "Not found" }, 404)
+    c.var.log.set({
+      route: "githubInstallation.get",
+      orgId,
+    })
     const installation = await getInstallationByOrgId(orgId)
     if (!installation) {
+      c.var.log.warn("github installation lookup returned no result", {
+        orgId,
+      })
       return c.json({ error: "No GitHub installation found for this org" }, 404)
     }
+    c.var.log.set({
+      installationId: installation.installationId,
+      ingestAllRepositories: installation.ingestAllRepositories,
+      includeFutureRepos: installation.includeFutureRepos,
+    })
     return c.json(
       {
         ...installation,
@@ -259,13 +270,26 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
     }
     const orgId = c.get("orgId")
     if (!orgId) return c.json({ error: "Not found" }, 404)
+    c.var.log.set({
+      route: "githubInstallation.setup",
+      orgId,
+    })
     const [installation, repos] = await Promise.all([
       getInstallationByOrgId(orgId),
       listRepositories(),
     ])
     if (!installation) {
+      c.var.log.warn("github installation setup lookup returned no result", {
+        orgId,
+      })
       return c.json({ error: "No GitHub installation found for this org" }, 404)
     }
+    c.var.log.set({
+      installationId: installation.installationId,
+      savedRepositoryCount: repos.length,
+      ingestAllRepositories: installation.ingestAllRepositories,
+      includeFutureRepos: installation.includeFutureRepos,
+    })
     return c.json(
       {
         ingestAllRepositories: installation.ingestAllRepositories,
@@ -285,8 +309,16 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
     const orgId = c.get("orgId")
     if (!orgId) return c.json({ error: "Not found" }, 404)
     const body = c.req.valid("json")
+    c.var.log.set({
+      route: "githubInstallation.register",
+      orgId,
+      installationId: body.installationId,
+    })
     try {
       const installation = await upsertInstallation(orgId, body.installationId)
+      c.var.log.info("github installation registered", {
+        installationId: installation.installationId,
+      })
       return c.json(
         {
           ...installation,
@@ -295,8 +327,16 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
         },
         200,
       )
-    } catch (e) {
-      console.error("Error registering installation", e)
+    } catch (error) {
+      c.var.log.error(
+        error instanceof Error
+          ? error
+          : "Failed to register GitHub installation",
+        {
+          orgId,
+          installationId: body.installationId,
+        },
+      )
       return c.json({ error: "Internal server error" }, 500)
     }
   })
@@ -306,13 +346,28 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
     }
     const orgId = c.get("orgId")
     if (!orgId) return c.json({ error: "Not found" }, 404)
+    c.var.log.set({
+      route: "githubInstallation.repositories",
+      orgId,
+    })
     const installation = await getInstallationByOrgId(orgId)
     if (!installation) {
+      c.var.log.warn(
+        "github installation repository listing had no installation",
+        {
+          orgId,
+        },
+      )
       return c.json({ error: "No GitHub installation found for this org" }, 404)
     }
     const query = ListInstallationReposQuerySchema.parse({
       page: c.req.query("page"),
       per_page: c.req.query("per_page"),
+    })
+    c.var.log.set({
+      installationId: installation.installationId,
+      page: query.page,
+      perPage: query.per_page,
     })
     const env = c.var.env
     try {
@@ -322,13 +377,28 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
         query.page,
         query.per_page,
       )
+      c.var.log.info("github installation repositories loaded", {
+        installationId: installation.installationId,
+        repositoryCount: result.repositories.length,
+        repositorySelection: result.repositorySelection,
+        hasMore: result.hasMore,
+      })
       return c.json(result, 200)
-    } catch (e) {
-      console.error("Error listing installation repos", e)
+    } catch (error) {
+      c.var.log.error(
+        error instanceof Error
+          ? error
+          : "Failed to list GitHub installation repositories",
+        {
+          installationId: installation.installationId,
+        },
+      )
       return c.json(
         {
           error:
-            e instanceof Error ? e.message : "Failed to list repositories",
+            error instanceof Error
+              ? error.message
+              : "Failed to list repositories",
         },
         500,
       )
@@ -341,17 +411,40 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
     const orgId = c.get("orgId")
     if (!orgId) return c.json({ error: "Not found" }, 404)
     const body = c.req.valid("json")
+    c.var.log.set({
+      route: "githubInstallation.update",
+      orgId,
+      ingestAllRepositories: body.ingestAllRepositories,
+      includeFutureRepos: body.includeFutureRepos,
+      selectedRepositoryCount: body.selectedRepositories?.length ?? 0,
+    })
     try {
       const existingInstallation = await getInstallationByOrgId(orgId)
       if (!existingInstallation) {
-        return c.json({ error: "No GitHub installation found for this org" }, 404)
+        c.var.log.warn("github installation update had no installation", {
+          orgId,
+        })
+        return c.json(
+          { error: "No GitHub installation found for this org" },
+          404,
+        )
       }
+      c.var.log.set({
+        installationId: existingInstallation.installationId,
+      })
       const installation = await updateInstallationOptions(orgId, {
         ingestAllRepositories: body.ingestAllRepositories,
         includeFutureRepos: body.includeFutureRepos,
       })
       if (!installation) {
-        return c.json({ error: "No GitHub installation found for this org" }, 404)
+        c.var.log.warn("github installation update returned no installation", {
+          orgId,
+          installationId: existingInstallation.installationId,
+        })
+        return c.json(
+          { error: "No GitHub installation found for this org" },
+          404,
+        )
       }
 
       const selectedRepos = body.selectedRepositories ?? []
@@ -366,6 +459,11 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
             }
           : { orgId }
       void ow.runWorkflow(syncGithubRepositories.spec, workflowPayload)
+      c.var.log.info("github installation options updated and sync queued", {
+        installationId: installation.installationId,
+        selectedRepositoryCount: selectedRepos.length,
+        syncAllRepositories: body.ingestAllRepositories,
+      })
 
       return c.json(
         {
@@ -375,8 +473,15 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
         },
         200,
       )
-    } catch (e) {
-      console.error("Error updating installation options", e)
+    } catch (error) {
+      c.var.log.error(
+        error instanceof Error
+          ? error
+          : "Failed to update GitHub installation options",
+        {
+          orgId,
+        },
+      )
       return c.json({ error: "Internal server error" }, 500)
     }
   })

--- a/apps/backend/src/routes/v1/repositories.ts
+++ b/apps/backend/src/routes/v1/repositories.ts
@@ -218,6 +218,10 @@ export const repositoryRoutes = new OpenAPIHono<AppEnv>()
       createdAt: r.createdAt.toISOString(),
       updatedAt: r.updatedAt.toISOString(),
     }))
+    c.var.log.set({
+      route: "repositories.list",
+      repositoryCount: items.length,
+    })
     return c.json({ items }, 200)
   })
   .openapi(getRepositoryRoute, async (c) => {
@@ -227,10 +231,21 @@ export const repositoryRoutes = new OpenAPIHono<AppEnv>()
       return c.json({ error: "Unauthorized" }, 401)
     }
     const id = c.req.param("id")
+    c.var.log.set({
+      route: "repositories.get",
+      repositoryId: id,
+    })
     const repository = await getRepository(id)
     if (!repository) {
+      c.var.log.warn("repository lookup returned no result", {
+        repositoryId: id,
+      })
       return c.json({ error: "Not found" }, 404)
     }
+    c.var.log.set({
+      repositoryName: repository.name,
+      indexReady: repository.indexReady,
+    })
     return c.json(
       {
         ...repository,
@@ -247,6 +262,17 @@ export const repositoryRoutes = new OpenAPIHono<AppEnv>()
       return c.json({ error: "Unauthorized" }, 401)
     }
     const body = c.req.valid("json")
+    c.var.log.set({
+      route: "repositories.create",
+      repositoryName: body.name,
+      gitUrlHost: (() => {
+        try {
+          return new URL(body.gitUrl).host
+        } catch {
+          return "invalid"
+        }
+      })(),
+    })
     try {
       const repository = await createRepository({
         name: body.name,
@@ -256,6 +282,11 @@ export const repositoryRoutes = new OpenAPIHono<AppEnv>()
         repositoryId: repository.id,
         orgId: repository.orgId,
       })
+      c.var.log.info("repository created and ingestion queued", {
+        repositoryId: repository.id,
+        repositoryName: repository.name,
+        indexReady: repository.indexReady,
+      })
       return c.json(
         {
           ...repository,
@@ -264,8 +295,13 @@ export const repositoryRoutes = new OpenAPIHono<AppEnv>()
         },
         201,
       )
-    } catch (e) {
-      console.error("Error creating repository", e)
+    } catch (error) {
+      c.var.log.error(
+        error instanceof Error ? error : "Failed to create repository",
+        {
+          repositoryName: body.name,
+        },
+      )
       return c.json({ error: "Internal server error" }, 500)
     }
   })
@@ -276,13 +312,29 @@ export const repositoryRoutes = new OpenAPIHono<AppEnv>()
       return c.json({ error: "Unauthorized" }, 401)
     }
     const id = c.req.param("id")
+    c.var.log.set({
+      route: "repositories.delete",
+      repositoryId: id,
+    })
     try {
       const repository = await deleteRepository(id)
       if (!repository) {
+        c.var.log.warn("repository delete target was not found", {
+          repositoryId: id,
+        })
         return c.json({ error: "Not found" }, 404)
       }
+      c.var.log.info("repository deleted", {
+        repositoryId: id,
+      })
       return c.body(null, 204)
-    } catch {
+    } catch (error) {
+      c.var.log.error(
+        error instanceof Error ? error : "Failed to delete repository",
+        {
+          repositoryId: id,
+        },
+      )
       return c.json({ error: "Internal server error" }, 500)
     }
   })

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,4 +1,5 @@
 import type { Serve } from "bun"
+import { log } from "evlog"
 import { createApp } from "./app/app.js"
 import { parseEnv } from "./config/env.js"
 import { closeDb } from "./db/client.js"
@@ -14,15 +15,39 @@ import {
 const env = parseEnv(process.env as Record<string, string | undefined>)
 initOtel(env)
 initEvlog()
+log.info({
+  area: "server",
+  action: "backend_bootstrap_complete",
+  port: env.PORT,
+  nodeEnv: env.NODE_ENV,
+  langsmithEnabled: process.env.ENABLE_LANGSMITH === "true",
+})
 const app = createApp()
 let shuttingDown = false
 
 async function shutdownResources() {
   if (shuttingDown) return
   shuttingDown = true
-  await Promise.all([flushEvlog(), shutdownOtel()])
-  await shutdownGraphClients()
-  await closeDb()
+  log.info({
+    area: "server",
+    action: "backend_shutdown_started",
+  })
+  try {
+    await Promise.all([flushEvlog(), shutdownOtel()])
+    await shutdownGraphClients()
+    await closeDb()
+    log.info({
+      area: "server",
+      action: "backend_shutdown_completed",
+    })
+  } catch (error) {
+    log.error({
+      area: "server",
+      action: "backend_shutdown_failed",
+      error:
+        error instanceof Error ? error.message : "Unknown shutdown failure",
+    })
+  }
 }
 
 process.on("SIGINT", () => {


### PR DESCRIPTION
This adds structured backend logging across the backend request, workflow, and retrieval paths, replacing raw console logging and filling in missing context for auth, repositories, GitHub installation, conversations, MCP, LangSmith, and server lifecycle events.

It also updates the logger bootstrap to fall back to an evlog-backed logger when request/workflow context is missing, and adds structured summaries around codesearch, graph projection, embedding, and repository ingestion flows.

Sensitive or noisy logs were tightened up, including removing bearer token and email body logging in favor of structured events.

The branch also includes the OpenMemory rules file and an empty openmemory.md placeholder that are part of the current workspace diff.