### PR TITLE
feat: Atlassian OAuth 2.0 (3LO) + Confluence sync engine

### DIFF
--- a/apps/backend/src/app/app.ts
+++ b/apps/backend/src/app/app.ts
@@ -10,6 +10,7 @@ import { registerOpenapiRoutes } from "../routes/openapi.js"
 import { registerStatusRoutes } from "../routes/status"
 import { registerUiRoutes } from "../routes/ui.js"
 import { registerV1Routes } from "../routes/v1/index.js"
+import { oauthRoutes } from "../routes/oauth.js"
 import type { AppEnv } from "./env.js"
 
 export type { AppEnv } from "./env.js"
@@ -44,6 +45,9 @@ export function createApp() {
 
   // auth
   registerAuthRoutes(app)
+
+  // public OAuth callback — must be before auth middleware
+  app.route("/oauth", oauthRoutes)
 
   // /:orgSlug/api/v1 routes
   const v1 = registerV1Routes(app)

--- a/apps/backend/src/db/schema/connectors.ts
+++ b/apps/backend/src/db/schema/connectors.ts
@@ -18,10 +18,22 @@ export const connectors = pgTable(
     config: jsonb("config").notNull().$type<{
       syncMode: "pr" | "auto"
       schedule: "hourly" | "daily" | "manual"
+      githubToken?: string
+
+      // Legacy basic-auth (deprecated — kept for backward compatibility)
       confluenceBaseUrl?: string
       confluenceEmail?: string
       confluenceApiToken?: string
-      githubToken?: string
+
+      // OAuth 2.0 fields
+      deploymentType?: "cloud" | "datacenter"
+      // Cloud: resolved from accessible-resources after OAuth
+      cloudId?: string
+      // Encrypted refresh token (AES-256-GCM via crypto.ts)
+      oauthRefreshToken?: string
+      // Data Center only: customer-provided application link credentials
+      oauthClientId?: string
+      oauthClientSecret?: string
     }>(),
     enabled: boolean("enabled").notNull().default(true),
     githubRepoId: text("github_repo_id"),

--- a/apps/backend/src/models/connectors.ts
+++ b/apps/backend/src/models/connectors.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm"
 import { requireCurrentOrgId } from "src/auth/context.js"
 import { connectors } from "src/db/schema/connectors.js"
 import { generateObjectId } from "src/lib/id.js"
-import { getOrgDb } from "../db/client.js"
+import { getOrgDb, getSystemDb } from "../db/client.js"
 
 export type ConnectorRecord = typeof connectors.$inferSelect
 export type ConnectorConfig = ConnectorRecord["config"]
@@ -22,17 +22,6 @@ export const getConnector = async (connectorId: string) => {
   return db.query.connectors.findFirst({
     where: {
       id: { eq: connectorId },
-      orgId: { eq: orgId },
-    },
-  })
-}
-
-export const getConnectorByType = async (type: string) => {
-  const orgId = requireCurrentOrgId()
-  const db = getOrgDb()
-  return db.query.connectors.findFirst({
-    where: {
-      type: { eq: type },
       orgId: { eq: orgId },
     },
   })
@@ -136,13 +125,11 @@ export const deleteConnector = async (connectorId: string) => {
   return deleted != null
 }
 
-export const getEnabledConnectors = async () => {
-  const orgId = requireCurrentOrgId()
-  const db = getOrgDb()
+/** System-level query: returns all enabled connectors across every org.
+ *  Bypasses RLS — for use only in background workers. */
+export const listAllEnabledConnectors = async () => {
+  const db = getSystemDb()
   return db.query.connectors.findMany({
-    where: {
-      orgId: { eq: orgId },
-      enabled: { eq: true },
-    },
+    where: { enabled: { eq: true } },
   })
 }

--- a/apps/backend/src/routes/oauth.ts
+++ b/apps/backend/src/routes/oauth.ts
@@ -1,0 +1,144 @@
+import { Hono } from "hono"
+import type { AppEnv } from "../app/env.js"
+import { getSystemDb } from "../db/client.js"
+import { connectors } from "../db/schema/connectors.js"
+import { consumeOAuthState } from "../models/oauth-states.js"
+import { encrypt } from "../services/crypto.js"
+import { and, eq } from "drizzle-orm"
+
+export const oauthRoutes = new Hono<AppEnv>()
+
+/**
+ * GET /oauth/atlassian/callback
+ *
+ * Public route — called by Atlassian after the user grants consent.
+ * Exchanges the code for tokens, resolves the cloudId (Cloud only),
+ * encrypts the refresh token, and stores everything on the connector.
+ */
+oauthRoutes.get("/atlassian/callback", async (c) => {
+  const env = c.get("env")
+  const code = c.req.query("code")
+  const stateNonce = c.req.query("state")
+  const errorParam = c.req.query("error")
+
+  // Redirect back to the browser-facing app, not the ngrok tunnel URL.
+  // AUTH_BASE_URL is where the user's session cookie lives.
+  const uiBase = env.AUTH_BASE_URL.replace(/\/$/, "")
+
+  if (errorParam) {
+    return c.redirect(`${uiBase}/oauth/error?reason=${encodeURIComponent(errorParam)}`)
+  }
+
+  if (!code || !stateNonce) {
+    return c.redirect(`${uiBase}/oauth/error?reason=missing_params`)
+  }
+
+  // Validate and consume state nonce
+  const state = await consumeOAuthState(stateNonce)
+  if (!state) {
+    return c.redirect(`${uiBase}/oauth/error?reason=invalid_state`)
+  }
+
+  const { connectorId, orgId, orgSlug } = state
+  const callbackUrl = `${env.PUBLIC_URL}/oauth/atlassian/callback`
+  const db = getSystemDb()
+
+  // Look up the connector (raw query — no org context middleware here)
+  const [connector] = await db
+    .select()
+    .from(connectors)
+    .where(and(eq(connectors.id, connectorId), eq(connectors.orgId, orgId)))
+    .limit(1)
+
+  if (!connector) {
+    return c.redirect(`${uiBase}/oauth/error?reason=connector_not_found`)
+  }
+
+  const isCloud = connector.config.deploymentType !== "datacenter"
+
+  // Determine token endpoint + client credentials
+  const tokenUrl = isCloud
+    ? "https://auth.atlassian.com/oauth/token"
+    : `${connector.config.confluenceBaseUrl?.replace(/\/$/, "")}/rest/oauth2/latest/token`
+
+  const clientId = isCloud
+    ? (env.ATLASSIAN_CLIENT_ID ?? "")
+    : (connector.config.oauthClientId ?? "")
+
+  const clientSecret = isCloud
+    ? (env.ATLASSIAN_CLIENT_SECRET ?? "")
+    : (connector.config.oauthClientSecret ?? "")
+
+  // Exchange authorisation code for tokens
+  let tokenData: { access_token: string; refresh_token?: string; scope?: string }
+  try {
+    const res = await fetch(tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri: callbackUrl,
+      }),
+    })
+    if (!res.ok) {
+      const err = await res.text()
+      console.error("[oauth] token exchange failed", res.status, err)
+      return c.redirect(`${uiBase}/oauth/error?reason=token_exchange_failed`)
+    }
+    tokenData = await res.json() as typeof tokenData
+  } catch (e) {
+    console.error("[oauth] token exchange error", e)
+    return c.redirect(`${uiBase}/oauth/error?reason=token_exchange_error`)
+  }
+
+  if (!tokenData.refresh_token) {
+    console.error("[oauth] no refresh_token in response — was offline_access scope requested?")
+    return c.redirect(`${uiBase}/oauth/error?reason=no_refresh_token`)
+  }
+
+  // Resolve cloudId for Cloud connectors
+  let cloudId: string | undefined
+  if (isCloud) {
+    try {
+      const res = await fetch("https://api.atlassian.com/oauth/token/accessible-resources", {
+        headers: { Authorization: `Bearer ${tokenData.access_token}` },
+      })
+      if (!res.ok) throw new Error(`accessible-resources: ${res.status}`)
+      const sites = await res.json() as Array<{ id: string; url: string; name: string }>
+
+      if (sites.length === 0) {
+        return c.redirect(`${uiBase}/oauth/error?reason=no_accessible_sites`)
+      }
+
+      // Match against the connector's stored base URL if set, otherwise take first
+      const stored = connector.config.confluenceBaseUrl?.replace(/\/$/, "").toLowerCase()
+      const match = stored
+        ? sites.find((s) => s.url.replace(/\/$/, "").toLowerCase() === stored)
+        : null
+
+      cloudId = (match ?? sites[0])!.id
+    } catch (e) {
+      console.error("[oauth] accessible-resources error", e)
+      return c.redirect(`${uiBase}/oauth/error?reason=cloudid_resolution_failed`)
+    }
+  }
+
+  // Encrypt refresh token and persist to connector
+  const encryptedRefreshToken = encrypt(tokenData.refresh_token)
+  const updatedConfig = {
+    ...connector.config,
+    oauthRefreshToken: encryptedRefreshToken,
+    ...(cloudId ? { cloudId } : {}),
+  }
+
+  await db
+    .update(connectors)
+    .set({ config: updatedConfig, updatedAt: new Date() })
+    .where(and(eq(connectors.id, connectorId), eq(connectors.orgId, orgId)))
+
+  console.log(`[oauth] connector ${connectorId} authorised successfully`)
+  return c.redirect(`${uiBase}/${orgSlug}/connectors?oauth=success`)
+})

--- a/apps/backend/src/routes/v1/connectors.ts
+++ b/apps/backend/src/routes/v1/connectors.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { randomBytes } from "crypto"
 import type { AppEnv } from "../../app/env.js"
 import {
   createConnectorSpaces,
@@ -6,12 +7,13 @@ import {
   replaceConnectorSpaces,
 } from "../../models/connector-spaces.js"
 import {
-  createSyncLog,
   getLatestSyncLog,
   listSyncLogs,
 } from "../../models/connector-sync-logs.js"
+import { createOAuthState } from "../../models/oauth-states.js"
 import { syncOrchestrator } from "../../services/confluence/index.js"
 import { ConfluenceClient } from "../../services/confluence/client.js"
+import { buildConfluenceConfig } from "../../services/confluence/config.js"
 import {
   createConnector,
   deleteConnector,
@@ -20,6 +22,7 @@ import {
   getConnector,
   listConnectors,
   updateConnector,
+  type ConnectorConfig,
 } from "../../models/connectors.js"
 
 const ErrorResponseSchema = z
@@ -31,10 +34,17 @@ const ConnectorConfigSchema = z
     // syncMode and schedule are system-controlled; kept for DB compatibility only
     syncMode: z.enum(["pr", "auto"]).optional().default("auto"),
     schedule: z.enum(["hourly", "daily", "manual"]).optional().default("manual"),
+    githubToken: z.string().optional(),
+    // Legacy basic-auth
     confluenceBaseUrl: z.string().url().optional(),
     confluenceEmail: z.string().email().optional(),
     confluenceApiToken: z.string().optional(),
-    githubToken: z.string().optional(),
+    // OAuth 2.0
+    deploymentType: z.enum(["cloud", "datacenter"]).optional(),
+    cloudId: z.string().optional(),
+    oauthRefreshToken: z.string().optional(),
+    oauthClientId: z.string().optional(),
+    oauthClientSecret: z.string().optional(),
   })
   .openapi("ConnectorConfig")
 
@@ -510,6 +520,28 @@ export const saveScopeRoute = createRoute({
   },
 })
 
+export const oauthStartRoute = createRoute({
+  method: "get",
+  path: "/{id}/oauth/start",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ url: z.string().url() }),
+        },
+      },
+      description: "Atlassian OAuth authorisation URL to redirect the browser to",
+    },
+    400: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Bad request" },
+    401: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Unauthorized" },
+    404: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Not found" },
+  },
+})
+
 export const listSyncLogsRoute = createRoute({
   method: "get",
   path: "/{id}/logs",
@@ -605,23 +637,10 @@ const spaceToResponse = (s: {
   updatedAt: s.updatedAt.toISOString(),
 })
 
-const getConfluenceClient = (connector: {
-  config: {
-    confluenceBaseUrl?: string
-    confluenceEmail?: string
-    confluenceApiToken?: string
-  }
-}) => {
-  const { confluenceBaseUrl, confluenceEmail, confluenceApiToken } =
-    connector.config
-  if (!confluenceBaseUrl || !confluenceEmail || !confluenceApiToken) {
-    return null
-  }
-  return new ConfluenceClient({
-    baseUrl: confluenceBaseUrl,
-    email: confluenceEmail,
-    apiToken: confluenceApiToken,
-  })
+const getConfluenceClient = (connector: { config: ConnectorConfig }): ConfluenceClient | null => {
+  const confluenceConfig = buildConfluenceConfig(connector.config)
+  if (!confluenceConfig) return null
+  return new ConfluenceClient(confluenceConfig)
 }
 
 const validateSharedRepo = async (
@@ -778,7 +797,7 @@ export const connectorRoutes = new OpenAPIHono<AppEnv>()
         updates.githubBranch = body.githubBranch
       }
       if (body.spaces) {
-        await createConnectorSpaces({
+        await replaceConnectorSpaces({
           connectorId: id,
           spaces: body.spaces,
         })
@@ -823,12 +842,12 @@ export const connectorRoutes = new OpenAPIHono<AppEnv>()
     }
     try {
       const config = connector.config
-      if (
-        !config.confluenceBaseUrl ||
-        !config.confluenceEmail ||
-        !config.confluenceApiToken
-      ) {
-        return c.json({ error: "Confluence configuration missing" }, 400)
+      const confluenceClient = getConfluenceClient(connector)
+      if (!confluenceClient) {
+        return c.json(
+          { error: "Confluence not connected — authorise via OAuth or add credentials" },
+          400,
+        )
       }
       if (!connector.githubRepoName || !config.githubToken) {
         return c.json({ error: "GitHub configuration missing" }, 400)
@@ -839,14 +858,18 @@ export const connectorRoutes = new OpenAPIHono<AppEnv>()
         return c.json({ error: "Invalid GitHub repository name" }, 400)
       }
 
+      const confluenceConfig = buildConfluenceConfig(config)
+      if (!confluenceConfig) {
+        return c.json(
+          { error: "Confluence not connected — authorise via OAuth or add credentials" },
+          400,
+        )
+      }
+
       const result = await syncOrchestrator.sync({
         connectorId: id,
         orgId: connector.orgId,
-        confluenceConfig: {
-          baseUrl: config.confluenceBaseUrl,
-          email: config.confluenceEmail,
-          apiToken: config.confluenceApiToken,
-        },
+        confluenceConfig,
         githubConfig: {
           token: config.githubToken,
           owner,
@@ -882,7 +905,6 @@ export const connectorRoutes = new OpenAPIHono<AppEnv>()
     if (!client) return c.json({ error: "Confluence credentials not configured" }, 400)
     try {
       const spaces = await client.listSpaces()
-      console.log(`[spaces] fetched ${spaces.length} spaces for connector ${id}`)
       return c.json({ items: spaces }, 200)
     } catch (e) {
       console.error("Error listing Confluence spaces", e)
@@ -903,12 +925,10 @@ export const connectorRoutes = new OpenAPIHono<AppEnv>()
     try {
       if (parentId) {
         const pages = await client.getChildPageSummaries(parentId)
-        console.log(`[pages] parentId=${parentId} → ${pages.length} children`)
         return c.json({ items: pages }, 200)
       }
       const space = await client.getSpace(spaceKey)
       const pages = await client.getTopLevelPages(space.id, space.homepageId)
-      console.log(`[pages] spaceKey=${spaceKey} top-level → ${pages.length} pages`)
       return c.json({ items: pages }, 200)
     } catch (e) {
       console.error("Error listing Confluence pages", e)
@@ -929,7 +949,6 @@ export const connectorRoutes = new OpenAPIHono<AppEnv>()
     if (!confluenceClient) return c.json({ error: "Confluence credentials not configured" }, 400)
     try {
       const pages = await confluenceClient.searchPages(spaceKey, q)
-      console.log(`[search] spaceKey=${spaceKey} q="${q}" → ${pages.length} results`)
       return c.json({ items: pages }, 200)
     } catch (e) {
       console.error("Error searching Confluence pages", e)
@@ -960,14 +979,19 @@ export const connectorRoutes = new OpenAPIHono<AppEnv>()
       })
 
       const [owner, repo] = connector.githubRepoName.split("/")
+
+      const confluenceConfigForScope = buildConfluenceConfig(config)
+      if (!confluenceConfigForScope) {
+        return c.json(
+          { error: "Confluence not connected — authorise via OAuth or add credentials" },
+          400,
+        )
+      }
+
       const result = await syncOrchestrator.syncConfig({
         connectorId: id,
         orgId: connector.orgId,
-        confluenceConfig: {
-          baseUrl: config.confluenceBaseUrl!,
-          email: config.confluenceEmail!,
-          apiToken: config.confluenceApiToken!,
-        },
+        confluenceConfig: confluenceConfigForScope,
         githubConfig: {
           token: config.githubToken,
           owner: owner!,
@@ -993,6 +1017,76 @@ export const connectorRoutes = new OpenAPIHono<AppEnv>()
       console.error("Error saving scope", e)
       return c.json({ error: "Internal server error" }, 500)
     }
+  })
+  .openapi(oauthStartRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
+
+    const id = c.req.param("id")
+    const connector = await getConnector(id)
+    if (!connector) return c.json({ error: "Not found" }, 404)
+
+    const env = c.get("env")
+    const isCloud = connector.config.deploymentType !== "datacenter"
+
+    if (isCloud) {
+      if (!env.ATLASSIAN_CLIENT_ID) {
+        return c.json({ error: "ATLASSIAN_CLIENT_ID is not configured" }, 400)
+      }
+      if (!env.PUBLIC_URL) {
+        return c.json({ error: "PUBLIC_URL is not configured" }, 400)
+      }
+    } else {
+      if (!connector.config.oauthClientId || !connector.config.confluenceBaseUrl) {
+        return c.json({ error: "Data Center OAuth credentials not configured on this connector" }, 400)
+      }
+    }
+
+    const orgId = c.get("orgId") ?? connector.orgId
+    const orgSlug = c.get("orgSlug") ?? ""
+
+    const nonce = randomBytes(24).toString("hex")
+    await createOAuthState({ id: nonce, connectorId: id, orgId, orgSlug })
+
+    const callbackUrl = `${env.PUBLIC_URL}/oauth/atlassian/callback`
+    const scopes = [
+      // Classic scopes (v1 REST API + search)
+      "read:confluence-content.all",
+      "read:confluence-space.summary",
+      "read:confluence-content.summary",
+      "search:confluence",
+      // Granular scopes required by v2 API
+      "read:space:confluence",
+      "read:page:confluence",
+      "offline_access",
+    ].join(" ")
+
+    let authUrl: string
+    if (isCloud) {
+      // Build manually to get %20 for spaces — URLSearchParams uses + which
+      // some OAuth servers reject in the scope parameter.
+      authUrl =
+        `https://auth.atlassian.com/authorize` +
+        `?audience=${encodeURIComponent("api.atlassian.com")}` +
+        `&client_id=${encodeURIComponent(env.ATLASSIAN_CLIENT_ID!)}` +
+        `&scope=${encodeURIComponent(scopes)}` +
+        `&redirect_uri=${encodeURIComponent(callbackUrl)}` +
+        `&state=${nonce}` +
+        `&response_type=code` +
+        `&prompt=consent`
+    } else {
+      const baseUrl = connector.config.confluenceBaseUrl!.replace(/\/$/, "")
+      const params = new URLSearchParams({
+        client_id: connector.config.oauthClientId!,
+        redirect_uri: callbackUrl,
+        state: nonce,
+        response_type: "code",
+      })
+      authUrl = `${baseUrl}/rest/oauth2/latest/authorize?${params}`
+    }
+
+    return c.json({ url: authUrl }, 200)
   })
   .openapi(listSyncLogsRoute, async (c) => {
     const user = c.get("user")

--- a/apps/backend/src/services/confluence/client.ts
+++ b/apps/backend/src/services/confluence/client.ts
@@ -41,39 +41,111 @@ export type ConfluencePage = z.infer<typeof ConfluencePageSchema>
 export type ConfluenceSpace = z.infer<typeof ConfluenceSpaceSchema>
 export type ConfluencePageSummary = z.infer<typeof ConfluencePageSummarySchema>
 
-export interface ConfluenceClientConfig {
-  baseUrl: string
-  apiToken: string
-  email: string
-}
+export type ConfluenceClientConfig =
+  | {
+      authType: "basic"
+      baseUrl: string
+      email: string
+      apiToken: string
+    }
+  | {
+      authType: "oauth"
+      /** Confluence API base — e.g. https://api.atlassian.com/ex/confluence/{cloudId} (Cloud)
+       *  or https://confluence.company.com (DC) */
+      apiBaseUrl: string
+      refreshToken: string
+      clientId: string
+      clientSecret: string
+      /** Token endpoint — Atlassian Cloud or DC instance URL */
+      tokenUrl: string
+    }
 
 export class ConfluenceClient {
-  private baseUrl: string
-  private apiToken: string
-  private email: string
+  private config: ConfluenceClientConfig
+  private cachedAccessToken: string | null = null
+  private cachedTokenExpiry = 0
 
   constructor(config: ConfluenceClientConfig) {
-    this.baseUrl = config.baseUrl.replace(/\/$/, "")
-    this.apiToken = config.apiToken
-    this.email = config.email
+    this.config = config
   }
 
-  private getAuthHeader(): string {
-    const credentials = Buffer.from(`${this.email}:${this.apiToken}`).toString(
-      "base64",
-    )
-    return `Basic ${credentials}`
+  private get apiBaseUrl(): string {
+    return this.config.authType === "basic"
+      ? this.config.baseUrl.replace(/\/$/, "")
+      : this.config.apiBaseUrl.replace(/\/$/, "")
+  }
+
+  private async getAuthHeader(): Promise<string> {
+    if (this.config.authType === "basic") {
+      const creds = Buffer.from(
+        `${this.config.email}:${this.config.apiToken}`,
+      ).toString("base64")
+      return `Basic ${creds}`
+    }
+    // OAuth — refresh access token if missing or expiring within 60s
+    if (!this.cachedAccessToken || Date.now() >= this.cachedTokenExpiry - 60_000) {
+      await this.refreshAccessToken()
+    }
+    return `Bearer ${this.cachedAccessToken}`
+  }
+
+  private async refreshAccessToken(): Promise<void> {
+    if (this.config.authType !== "oauth") return
+    const res = await fetch(this.config.tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: this.config.clientId,
+        client_secret: this.config.clientSecret,
+        refresh_token: this.config.refreshToken,
+      }),
+    })
+    if (!res.ok) {
+      const err = await res.text()
+      throw new Error(`Confluence token refresh failed: ${res.status} - ${err}`)
+    }
+    const data = (await res.json()) as { access_token: string; expires_in: number }
+    this.cachedAccessToken = data.access_token
+    this.cachedTokenExpiry = Date.now() + data.expires_in * 1000
   }
 
   private async request<T>(
     endpoint: string,
     options: RequestInit = {},
   ): Promise<T> {
-    const url = `${this.baseUrl}/wiki/api/v2${endpoint}`
+    const url = `${this.apiBaseUrl}/wiki/api/v2${endpoint}`
+    const authHeader = await this.getAuthHeader()
     const response = await fetch(url, {
       ...options,
       headers: {
-        Authorization: this.getAuthHeader(),
+        Authorization: authHeader,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(
+        `Confluence API error: ${response.status} ${response.statusText} - ${error}`,
+      )
+    }
+
+    return response.json() as Promise<T>
+  }
+
+  private async requestV1<T>(
+    endpoint: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const url = `${this.apiBaseUrl}/wiki/rest/api${endpoint}`
+    const authHeader = await this.getAuthHeader()
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: authHeader,
         Accept: "application/json",
         "Content-Type": "application/json",
         ...options.headers,
@@ -99,13 +171,19 @@ export class ConfluenceClient {
         type: string
         homepageId?: string
       }>
-    }>(`/spaces?keys=${encodeURIComponent(spaceKey)}`)
+    }>(`/spaces?keys=${encodeURIComponent(spaceKey)}&limit=250`)
 
-    if (!data.results.length) {
-      throw new Error(`Space not found: ${spaceKey}`)
+    const returnedKeys = data.results.map((r) => r.key)
+
+    // Find by key — defensive against the API ignoring the filter and returning all spaces
+    const match = data.results.find((r) => r.key === spaceKey)
+    if (!match) {
+      throw new Error(
+        `Space not found: ${spaceKey}. API returned keys: [${returnedKeys.join(", ")}]`,
+      )
     }
 
-    return ConfluenceSpaceSchema.parse(data.results[0])
+    return ConfluenceSpaceSchema.parse(match)
   }
 
   async *getPagesInSpace(
@@ -117,7 +195,6 @@ export class ConfluenceClient {
 
     while (true) {
       const params = new URLSearchParams({
-        spaceId,
         limit: limit.toString(),
         status: "current",
         "body-format": "storage",
@@ -132,7 +209,7 @@ export class ConfluenceClient {
         _links: {
           next?: string
         }
-      }>(`/pages?${params.toString()}`)
+      }>(`/spaces/${spaceId}/pages?${params.toString()}`)
 
       for (const page of data.results) {
         const parsed = ConfluencePageSchema.safeParse(page)
@@ -147,7 +224,7 @@ export class ConfluenceClient {
         break
       }
 
-      const nextUrl = new URL(data._links.next, this.baseUrl)
+      const nextUrl = new URL(data._links.next, "https://dummy.invalid")
       cursor = nextUrl.searchParams.get("cursor") ?? undefined
       if (!cursor) break
     }
@@ -189,8 +266,6 @@ export class ConfluenceClient {
         _links: { next?: string }
       }>(`/spaces?${params.toString()}`)
 
-      console.log(`[spaces] page ${page}: API returned ${data.results.length} raw results, hasNext=${!!data._links.next}`)
-
       for (const space of data.results) {
         const parsed = ConfluenceSpaceSchema.safeParse(space)
         if (parsed.success) {
@@ -202,7 +277,7 @@ export class ConfluenceClient {
 
       if (!data._links.next) break
 
-      const nextUrl = new URL(data._links.next, this.baseUrl)
+      const nextUrl = new URL(data._links.next, "https://dummy.invalid")
       cursor = nextUrl.searchParams.get("cursor") ?? undefined
       if (!cursor) break
     }
@@ -286,10 +361,11 @@ export class ConfluenceClient {
       limit: limit.toString(),
       expand: "space",
     })
-    const url = `${this.baseUrl}/wiki/rest/api/content/search?${params.toString()}`
+    const url = `${this.apiBaseUrl}/wiki/rest/api/content/search?${params.toString()}`
+    const authHeader = await this.getAuthHeader()
     const response = await fetch(url, {
       headers: {
-        Authorization: this.getAuthHeader(),
+        Authorization: authHeader,
         Accept: "application/json",
       },
     })

--- a/apps/backend/src/services/confluence/config.ts
+++ b/apps/backend/src/services/confluence/config.ts
@@ -1,0 +1,50 @@
+import { decrypt } from "../crypto.js"
+import type { ConfluenceClientConfig } from "./client.js"
+
+type ConnectorConfig = {
+  confluenceBaseUrl?: string
+  confluenceEmail?: string
+  confluenceApiToken?: string
+  deploymentType?: string
+  cloudId?: string
+  oauthRefreshToken?: string
+  oauthClientId?: string
+  oauthClientSecret?: string
+}
+
+/**
+ * Build a ConfluenceClientConfig from a connector's stored config.
+ * Returns null if neither OAuth nor basic-auth credentials are present.
+ */
+export function buildConfluenceConfig(config: ConnectorConfig): ConfluenceClientConfig | null {
+  if (config.oauthRefreshToken) {
+    const isCloud = config.deploymentType !== "datacenter"
+    return {
+      authType: "oauth",
+      apiBaseUrl: isCloud
+        ? `https://api.atlassian.com/ex/confluence/${config.cloudId}`
+        : (config.confluenceBaseUrl ?? "").replace(/\/$/, ""),
+      refreshToken: decrypt(config.oauthRefreshToken),
+      clientId: isCloud
+        ? (process.env.ATLASSIAN_CLIENT_ID ?? "")
+        : (config.oauthClientId ?? ""),
+      clientSecret: isCloud
+        ? (process.env.ATLASSIAN_CLIENT_SECRET ?? "")
+        : (config.oauthClientSecret ?? ""),
+      tokenUrl: isCloud
+        ? "https://auth.atlassian.com/oauth/token"
+        : `${(config.confluenceBaseUrl ?? "").replace(/\/$/, "")}/rest/oauth2/latest/token`,
+    }
+  }
+
+  if (config.confluenceBaseUrl && config.confluenceEmail && config.confluenceApiToken) {
+    return {
+      authType: "basic",
+      baseUrl: config.confluenceBaseUrl,
+      email: config.confluenceEmail,
+      apiToken: config.confluenceApiToken,
+    }
+  }
+
+  return null
+}

--- a/apps/backend/src/services/confluence/sync.ts
+++ b/apps/backend/src/services/confluence/sync.ts
@@ -177,6 +177,12 @@ export class ConfluenceSyncOrchestrator {
       const confluenceSpace = await confluence.getSpace(space.spaceKey)
 
       for await (const page of confluence.getPagesInSpace(confluenceSpace.id)) {
+        // Defensive: discard any page the API returns that doesn't belong to this space
+        if (page.spaceId !== confluenceSpace.id) {
+          console.warn(`[sync] skipping page id=${page.id} spaceId=${page.spaceId} (expected ${confluenceSpace.id})`)
+          continue
+        }
+
         // Filter by selectedPageIds if set
         if (
           space.selectedPageIds !== null &&
@@ -204,6 +210,7 @@ export class ConfluenceSyncOrchestrator {
           lastSyncedAt: new Date(),
         })
       }
+
     }
 
     if (files.length === 0) {
@@ -256,30 +263,10 @@ export class ConfluenceSyncOrchestrator {
       success: true,
       pagesAdded,
       pagesUpdated,
-      pagesDeleted: 0,
+      pagesDeleted: deletions.length,
     }
   }
 
-  private generatePRBody(
-    pagesAdded: number,
-    pagesUpdated: number,
-    spacesCount: number,
-  ): string {
-    return [
-      "## Confluence Sync",
-      "",
-      `This PR syncs documentation from ${spacesCount} Confluence space(s).`,
-      "",
-      "### Summary",
-      `- **Pages added:** ${pagesAdded}`,
-      `- **Pages updated:** ${pagesUpdated}`,
-      "",
-      "### Notes",
-      "- Files are organised by Confluence space key under `confluence/`",
-      "- Each file includes frontmatter with Confluence metadata",
-      "- Original Confluence formatting has been converted to Markdown",
-    ].join("\n")
-  }
 }
 
 export const syncOrchestrator = new ConfluenceSyncOrchestrator()

--- a/apps/backend/src/services/github/client.ts
+++ b/apps/backend/src/services/github/client.ts
@@ -158,8 +158,8 @@ export class GitHubClient {
       return data.tree
         .filter((item) => item.type === "blob" && item.path.startsWith(prefix))
         .map((item) => item.path)
-    } catch {
-      // Repo may be empty or branch not yet created
+    } catch (err) {
+      console.warn(`[github] listFilesInTree failed (branch=${branch}, prefix=${prefix}):`, err)
       return []
     }
   }


### PR DESCRIPTION
## Summary

Stacked on #29. Implements the full Atlassian OAuth flow and fixes correctness issues in the Confluence sync engine.

**OAuth flow**
- Connector config schema extended: `deploymentType`, `cloudId`, `oauthRefreshToken`, `oauthClientId/Secret`
- `POST /:id/oauth/start` — builds Atlassian authorization URL with required scopes, stores state nonce
- `GET /oauth/atlassian/callback` — exchanges code for tokens, resolves `cloudId` via accessible-resources, encrypts and persists refresh token
- Supports both Cloud (centralised app credentials) and Data Center (per-customer app link)

**Confluence client**
- Discriminated union config (`basic | oauth`) with transparent access token refresh
- Switched to `/wiki/api/v2/spaces/{id}/pages` — fixes `spaceId` query param being silently ignored on the generic `/pages` endpoint (was returning pages from all spaces)
- `buildConfluenceConfig()` shared utility in `services/confluence/config.ts` — replaces 4 duplicate credential-resolution blocks

**Sync engine**
- Reconciliation: `listFilesInTree` + `sha: null` deletions remove out-of-scope or deleted files from GitHub on every sync
- Defensive `page.spaceId` check guards against API returning pages from the wrong space
- `listAllEnabledConnectors()` system-level DB query (bypasses RLS) for background worker use

## Notes

- Sync is a stateless full re-sync each cycle. Checkpoint-based resumption is a known follow-up (see reviewer comment on the original PR).