### PR TITLE
feat: connector management UI for OAuth + scope selection

### DIFF
--- a/apps/ui/src/features/connectors/AddConnectorModal.tsx
+++ b/apps/ui/src/features/connectors/AddConnectorModal.tsx
@@ -1,117 +1,162 @@
 import { Button } from "@/components/ui/Button"
 import { TextField } from "@/components/ui/TextField"
 import { useState } from "react"
+import { client } from "@/lib/api"
+import { useParams } from "@tanstack/react-router"
+import { toast } from "sonner"
+import { useMutation } from "@tanstack/react-query"
+import type { Connector } from "./types"
 
 interface AddConnectorModalProps {
   onClose: () => void
-  onSubmit: (data: {
-    type: string
-    githubRepoName?: string
-    githubBranch?: string
-    config: {
-      confluenceBaseUrl?: string
-      confluenceEmail?: string
-      confluenceApiToken?: string
-      githubToken?: string
-    }
-  }) => void
-  isPending?: boolean
-  error?: string
+  onSuccess: () => void
 }
 
-export function AddConnectorModal({
-  onClose,
-  onSubmit,
-  isPending,
-  error,
-}: AddConnectorModalProps) {
-  const [type, setType] = useState("confluence")
+export function AddConnectorModal({ onClose, onSuccess }: AddConnectorModalProps) {
+  const { orgSlug } = useParams({ from: "/$orgSlug/connectors" })
+
+  const [type] = useState("confluence")
+  const [deploymentType, setDeploymentType] = useState<"cloud" | "datacenter">("cloud")
   const [confluenceBaseUrl, setConfluenceBaseUrl] = useState("")
-  const [confluenceEmail, setConfluenceEmail] = useState("")
-  const [confluenceApiToken, setConfluenceApiToken] = useState("")
+  const [oauthClientId, setOauthClientId] = useState("")
+  const [oauthClientSecret, setOauthClientSecret] = useState("")
   const [githubToken, setGithubToken] = useState("")
   const [githubRepoName, setGithubRepoName] = useState("")
   const [githubBranch, setGithubBranch] = useState("main")
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    onSubmit({
-      type,
-      githubRepoName: githubRepoName || undefined,
-      githubBranch: githubBranch || undefined,
-      config: {
-        confluenceBaseUrl: confluenceBaseUrl || undefined,
-        confluenceEmail: confluenceEmail || undefined,
-        confluenceApiToken: confluenceApiToken || undefined,
-        githubToken: githubToken || undefined,
-      },
-    })
-  }
+  // Step 1: create connector → Step 2: redirect to Atlassian OAuth
+  const createAndConnect = useMutation({
+    mutationFn: async () => {
+      const createRes = await client[":orgSlug"].api.v1.connectors.$post({
+        json: {
+          type,
+          githubRepoName: githubRepoName || undefined,
+          githubBranch: githubBranch || undefined,
+          config: {
+            deploymentType,
+            githubToken: githubToken || undefined,
+            confluenceBaseUrl: confluenceBaseUrl || undefined,
+            oauthClientId: oauthClientId || undefined,
+            oauthClientSecret: oauthClientSecret || undefined,
+          },
+        },
+        param: { orgSlug },
+      })
+      if (!createRes.ok) {
+        const err = await createRes.json().catch(() => ({}))
+        throw new Error((err as { error?: string }).error ?? "Failed to create connector")
+      }
+      const connector = (await createRes.json()) as Connector
+
+      // Fetch the OAuth start URL
+      const startRes = await client[":orgSlug"].api.v1.connectors[":id"]["oauth"]["start"].$get({
+        param: { orgSlug, id: connector.id },
+      })
+      if (!startRes.ok) {
+        const err = await startRes.json().catch(() => ({}))
+        throw new Error((err as { error?: string }).error ?? "Failed to start OAuth")
+      }
+      const { url } = (await startRes.json()) as { url: string }
+      return url
+    },
+    onSuccess: (url) => {
+      onSuccess()
+      window.location.href = url
+    },
+    onError: (err: Error) => {
+      toast.error(err.message)
+    },
+  })
+
+  const isCloud = deploymentType === "cloud"
 
   return (
     <div className="w-full max-w-lg rounded-lg bg-zinc-900 p-6 shadow-xl">
-      <h2 className="mb-1 text-xl font-semibold text-zinc-100">
-        Add Connector
-      </h2>
-      <p className="mb-4 text-sm text-zinc-400">
-        Connect an external source. After creating, use the scope button to
-        select which spaces and pages to sync.
+      <h2 className="mb-1 text-xl font-semibold text-zinc-100">Add Connector</h2>
+      <p className="mb-5 text-sm text-zinc-400">
+        Connect an external source. You'll be redirected to authorise access via OAuth.
       </p>
 
-      {error && (
-        <div className="mb-4 rounded-md bg-red-900/50 p-3 text-sm text-red-200">
-          {error}
-        </div>
-      )}
-
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          createAndConnect.mutate()
+        }}
+        className="space-y-4"
+      >
+        {/* Deployment type */}
         <div>
-          <label
-            htmlFor="connector-type"
-            className="mb-1 block text-sm font-medium text-zinc-300"
-          >
-            Type
+          <label className="mb-1 block text-sm font-medium text-zinc-300">
+            Confluence deployment
           </label>
-          <select
-            id="connector-type"
-            value={type}
-            onChange={(e) => setType(e.target.value)}
-            className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 focus:border-teal-500 focus:outline-none"
-          >
-            <option value="confluence">Confluence</option>
-          </select>
+          <div className="flex gap-3">
+            {(["cloud", "datacenter"] as const).map((dt) => (
+              <label
+                key={dt}
+                className={[
+                  "flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
+                  deploymentType === dt
+                    ? "border-teal-500 bg-teal-900/20 text-teal-300"
+                    : "border-zinc-700 text-zinc-400 hover:border-zinc-500",
+                ].join(" ")}
+              >
+                <input
+                  type="radio"
+                  className="sr-only"
+                  name="deploymentType"
+                  value={dt}
+                  checked={deploymentType === dt}
+                  onChange={() => setDeploymentType(dt)}
+                />
+                {dt === "cloud" ? "Atlassian Cloud" : "Data Center (self-hosted)"}
+              </label>
+            ))}
+          </div>
+          {isCloud && (
+            <p className="mt-1.5 text-xs text-zinc-500">
+              Requires <code className="text-zinc-400">ATLASSIAN_CLIENT_ID</code> and{" "}
+              <code className="text-zinc-400">ATLASSIAN_CLIENT_SECRET</code> to be set in the backend.
+            </p>
+          )}
         </div>
 
-        {type === "confluence" && (
+        {/* Confluence instance URL — always shown */}
+        <TextField
+          label={isCloud ? "Confluence Cloud URL" : "Confluence instance URL"}
+          type="url"
+          value={confluenceBaseUrl}
+          onChange={setConfluenceBaseUrl}
+          placeholder={isCloud ? "https://your-org.atlassian.net" : "https://confluence.company.com"}
+          description={
+            isCloud
+              ? "Used to match your site after OAuth — optional if you only have one Atlassian site"
+              : "Your self-hosted Confluence instance"
+          }
+          isRequired={!isCloud}
+        />
+
+        {/* DC-only: OAuth application link credentials */}
+        {!isCloud && (
           <>
             <TextField
-              label="Confluence Base URL"
-              type="url"
-              value={confluenceBaseUrl}
-              onChange={setConfluenceBaseUrl}
-              placeholder="https://your-domain.atlassian.net"
+              label="OAuth Client ID"
+              value={oauthClientId}
+              onChange={setOauthClientId}
+              placeholder="From Settings → Application Links"
               isRequired
             />
-
             <TextField
-              label="Confluence Email"
-              type="email"
-              value={confluenceEmail}
-              onChange={setConfluenceEmail}
-              placeholder="you@example.com"
-              isRequired
-            />
-
-            <TextField
-              label="Confluence API Token"
+              label="OAuth Client Secret"
               type="password"
-              value={confluenceApiToken}
-              onChange={setConfluenceApiToken}
-              placeholder="your-api-token"
+              value={oauthClientSecret}
+              onChange={setOauthClientSecret}
+              placeholder="From Settings → Application Links"
               isRequired
             />
           </>
         )}
+
+        <hr className="border-zinc-800" />
 
         <TextField
           label="GitHub Token"
@@ -138,17 +183,17 @@ export function AddConnectorModal({
           placeholder="main"
         />
 
-        <div className="flex justify-end gap-3 pt-4">
+        <div className="flex justify-end gap-3 pt-2">
           <Button
             type="button"
             variant="secondary"
             onPress={onClose}
-            isDisabled={isPending}
+            isDisabled={createAndConnect.isPending}
           >
             Cancel
           </Button>
-          <Button type="submit" variant="primary" isPending={isPending}>
-            Create Connector
+          <Button type="submit" variant="primary" isPending={createAndConnect.isPending}>
+            Create & Connect →
           </Button>
         </div>
       </form>

--- a/apps/ui/src/features/connectors/EditConnectorModal.tsx
+++ b/apps/ui/src/features/connectors/EditConnectorModal.tsx
@@ -1,6 +1,11 @@
 import { Button } from "@/components/ui/Button"
 import { TextField } from "@/components/ui/TextField"
 import { useState } from "react"
+import { useMutation } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { client } from "@/lib/api"
+import { useParams } from "@tanstack/react-router"
+import { IconCheck, IconAlertTriangle } from "@tabler/icons-react"
 import type { Connector } from "./types"
 
 interface EditCredentialsModalProps {
@@ -10,12 +15,10 @@ interface EditCredentialsModalProps {
     githubRepoName?: string
     githubBranch?: string
     config?: {
-      syncMode?: "pr" | "auto"
-      schedule?: "hourly" | "daily" | "manual"
       githubToken?: string
-      confluenceApiToken?: string
-      confluenceEmail?: string
       confluenceBaseUrl?: string
+      confluenceEmail?: string
+      confluenceApiToken?: string
     }
   }) => void
   isPending?: boolean
@@ -29,14 +32,38 @@ export function EditConnectorModal({
   isPending,
   error,
 }: EditCredentialsModalProps) {
-  const [githubRepoName, setGithubRepoName] = useState(
-    connector.githubRepoName ?? "",
-  )
-  const [githubBranch, setGithubBranch] = useState(
-    connector.githubBranch ?? "main",
-  )
+  const { orgSlug } = useParams({ from: "/$orgSlug/connectors" })
+  const [githubRepoName, setGithubRepoName] = useState(connector.githubRepoName ?? "")
+  const [githubBranch, setGithubBranch] = useState(connector.githubBranch ?? "main")
   const [githubToken, setGithubToken] = useState("")
+
+  // Legacy fields — only shown for connectors still using basic auth
   const [confluenceApiToken, setConfluenceApiToken] = useState("")
+
+  const typeLabel = connector.type.charAt(0).toUpperCase() + connector.type.slice(1)
+  const isOAuthConnected = !!connector.config.oauthRefreshToken
+  const isLegacy = !isOAuthConnected && !!connector.config.confluenceApiToken
+  const isCloud = connector.config.deploymentType !== "datacenter"
+
+  const reconnectMutation = useMutation({
+    mutationFn: async () => {
+      const res = await client[":orgSlug"].api.v1.connectors[":id"]["oauth"]["start"].$get({
+        param: { orgSlug, id: connector.id },
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error((err as { error?: string }).error ?? "Failed to start OAuth")
+      }
+      const { url } = (await res.json()) as { url: string }
+      return url
+    },
+    onSuccess: (url) => {
+      window.location.href = url
+    },
+    onError: (err: Error) => {
+      toast.error(err.message)
+    },
+  })
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -47,26 +74,58 @@ export function EditConnectorModal({
     onSubmit({
       githubRepoName: githubRepoName || undefined,
       githubBranch: githubBranch || undefined,
-      config:
-        Object.keys(configUpdates).length > 0
-          ? { ...connector.config, ...configUpdates }
-          : undefined,
+      config: Object.keys(configUpdates).length > 0
+        ? { ...connector.config, ...configUpdates }
+        : undefined,
     })
   }
 
-  const typeLabel =
-    connector.type.charAt(0).toUpperCase() + connector.type.slice(1)
-
   return (
     <div className="w-full max-w-lg rounded-lg bg-zinc-900 p-6 shadow-xl">
-      <h2 className="mb-1 text-xl font-semibold text-zinc-100">
-        Edit Credentials
-      </h2>
-      <p className="mb-4 text-sm text-zinc-400">{typeLabel}</p>
+      <h2 className="mb-1 text-xl font-semibold text-zinc-100">Edit Credentials</h2>
+      <p className="mb-5 text-sm text-zinc-400">{typeLabel}</p>
 
       {error && (
-        <div className="mb-4 rounded-md bg-red-900/50 p-3 text-sm text-red-200">
-          {error}
+        <div className="mb-4 rounded-md bg-red-900/50 p-3 text-sm text-red-200">{error}</div>
+      )}
+
+      {/* OAuth connection status */}
+      {connector.type === "confluence" && (
+        <div className={[
+          "mb-5 flex items-start gap-3 rounded-lg border p-3",
+          isOAuthConnected
+            ? "border-teal-800 bg-teal-900/20"
+            : "border-amber-800 bg-amber-900/20",
+        ].join(" ")}>
+          {isOAuthConnected ? (
+            <IconCheck className="mt-0.5 h-4 w-4 shrink-0 text-teal-400" />
+          ) : (
+            <IconAlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+          )}
+          <div className="flex-1 min-w-0">
+            <p className={[
+              "text-sm font-medium",
+              isOAuthConnected ? "text-teal-300" : "text-amber-300",
+            ].join(" ")}>
+              {isOAuthConnected
+                ? `Connected via OAuth (${isCloud ? "Atlassian Cloud" : "Data Center"})`
+                : isLegacy
+                  ? "Using legacy API token — consider migrating to OAuth"
+                  : "Not connected — authorise access to start syncing"}
+            </p>
+            {isOAuthConnected && connector.config.cloudId && (
+              <p className="mt-0.5 text-xs text-teal-600">
+                Cloud ID: {connector.config.cloudId}
+              </p>
+            )}
+          </div>
+          <Button
+            variant="secondary"
+            onPress={() => reconnectMutation.mutate()}
+            isPending={reconnectMutation.isPending}
+          >
+            {isOAuthConnected ? "Reconnect" : "Connect via OAuth"}
+          </Button>
         </div>
       )}
 
@@ -79,14 +138,12 @@ export function EditConnectorModal({
           description="All connectors in this org must share the same repository"
           isRequired
         />
-
         <TextField
           label="GitHub Branch"
           value={githubBranch}
           onChange={setGithubBranch}
           placeholder="main"
         />
-
         <TextField
           label="GitHub Token (leave blank to keep existing)"
           type="password"
@@ -95,24 +152,20 @@ export function EditConnectorModal({
           placeholder="ghp_xxxxxxxxxxxx"
         />
 
-        {connector.type === "confluence" && (
+        {/* Legacy: only show if connector still uses basic auth */}
+        {isLegacy && connector.type === "confluence" && (
           <TextField
             label="Confluence API Token (leave blank to keep existing)"
             type="password"
             value={confluenceApiToken}
             onChange={setConfluenceApiToken}
             placeholder="ATATT3x..."
-            description="Rotate if your token has been revoked or expired"
+            description="Legacy — use 'Connect via OAuth' above to migrate"
           />
         )}
 
-        <div className="flex justify-end gap-3 pt-4">
-          <Button
-            type="button"
-            variant="secondary"
-            onPress={onClose}
-            isDisabled={isPending}
-          >
+        <div className="flex justify-end gap-3 pt-2">
+          <Button type="button" variant="secondary" onPress={onClose} isDisabled={isPending}>
             Cancel
           </Button>
           <Button type="submit" variant="primary" isPending={isPending}>

--- a/apps/ui/src/features/connectors/EditScopeModal.tsx
+++ b/apps/ui/src/features/connectors/EditScopeModal.tsx
@@ -83,9 +83,10 @@ export function EditScopeModal({ connector, onClose }: EditScopeModalProps) {
   const typeLabel =
     connector.type.charAt(0).toUpperCase() + connector.type.slice(1)
   const missingCredentials =
-    !connector.config.confluenceBaseUrl ||
-    !connector.config.confluenceEmail ||
-    !connector.config.confluenceApiToken
+    !connector.config.oauthRefreshToken &&
+    (!connector.config.confluenceBaseUrl ||
+      !connector.config.confluenceEmail ||
+      !connector.config.confluenceApiToken)
 
   return (
     <div className="flex flex-col rounded-lg bg-zinc-900 shadow-xl" style={{ width: "780px", height: "660px" }}>

--- a/apps/ui/src/features/connectors/SpacePageTree.tsx
+++ b/apps/ui/src/features/connectors/SpacePageTree.tsx
@@ -2,7 +2,13 @@ import { useState, useCallback, useEffect } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { client } from "@/lib/api"
 import { Checkbox } from "@/components/ui/Checkbox"
-import { IconChevronRight, IconLoader2, IconSearch } from "@tabler/icons-react"
+import {
+  IconChevronRight,
+  IconLoader2,
+  IconSearch,
+  IconStack2,
+  IconFileText,
+} from "@tabler/icons-react"
 
 export interface SpaceScopeItem {
   spaceKey: string
@@ -25,7 +31,7 @@ interface ConfluencePage {
 }
 
 // ---------------------------------------------------------------------------
-// PageNode — lazy-loads children on expand; hides chevron when leaf confirmed
+// PageNode — lazy-loads children on expand
 // ---------------------------------------------------------------------------
 
 interface PageNodeProps {
@@ -48,6 +54,7 @@ function PageNode({
   depth = 0,
 }: PageNodeProps) {
   const [expanded, setExpanded] = useState(false)
+  const [hasLoadedChildren, setHasLoadedChildren] = useState(false)
 
   const { data: children = [], isFetching, isError } = useQuery({
     queryKey: ["connector-child-pages", connectorId, spaceKey, page.id],
@@ -66,8 +73,14 @@ function PageNode({
     throwOnError: false,
   })
 
+  useEffect(() => {
+    if (!isFetching && expanded) setHasLoadedChildren(true)
+  }, [isFetching, expanded])
+
+  const isLeaf = hasLoadedChildren && children.length === 0
   const isSelected =
     selectedPageIds === null || selectedPageIds.includes(page.id)
+  const isAllMode = selectedPageIds === null
 
   return (
     <div>
@@ -75,10 +88,14 @@ function PageNode({
         className="flex items-center gap-1.5 py-1 rounded hover:bg-zinc-800/50"
         style={{ paddingLeft: `${8 + depth * 16}px` }}
       >
+        {/* Expand chevron — invisible placeholder when confirmed leaf */}
         <button
           type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-zinc-500 hover:text-zinc-300"
+          onClick={() => !isLeaf && setExpanded((v) => !v)}
+          className={[
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded text-zinc-500 hover:text-zinc-300",
+            isLeaf ? "pointer-events-none opacity-0" : "",
+          ].join(" ")}
           aria-label={expanded ? "Collapse" : "Expand"}
         >
           {isFetching ? (
@@ -93,10 +110,15 @@ function PageNode({
           )}
         </button>
 
+        <IconFileText className="h-3.5 w-3.5 shrink-0 text-zinc-500" />
+
         <Checkbox
           isSelected={isSelected}
           onChange={() => onTogglePage(spaceKey, page.id, page.title)}
-          className="text-sm text-zinc-300"
+          className={[
+            "text-sm text-zinc-300",
+            isAllMode ? "opacity-60" : "",
+          ].join(" ")}
         >
           {page.title}
         </Checkbox>
@@ -131,34 +153,43 @@ function PageNode({
 }
 
 // ---------------------------------------------------------------------------
-// SpaceRow — space checkbox + expandable page list (browse without selecting)
+// SpaceNode — unified space row with inline page tree
 // ---------------------------------------------------------------------------
 
-interface SpaceRowProps {
+interface SpaceNodeProps {
   space: ConfluenceSpace
   connectorId: string
   orgSlug: string
   scope: SpaceScopeItem | undefined
   onToggleSpace: (space: ConfluenceSpace) => void
   onTogglePage: (spaceKey: string, pageId: string, pageTitle: string) => void
-  pageSearch: string
+  search: string
 }
 
-function SpaceRow({
+function SpaceNode({
   space,
   connectorId,
   orgSlug,
   scope,
   onToggleSpace,
   onTogglePage,
-  pageSearch,
-}: SpaceRowProps) {
+  search,
+}: SpaceNodeProps) {
   const [expanded, setExpanded] = useState(false)
-  const isSpaceSelected = scope !== undefined
-  const isPersonal = space.key.startsWith("~")
-  const isSearching = pageSearch.trim().length > 0
 
-  // Tree mode: top-level pages for browsing
+  const isSelected = scope !== undefined
+  const isAllPages = scope?.selectedPageIds === null
+  const isSpecific =
+    scope !== undefined && scope.selectedPageIds !== null
+  const isSearching = search.trim().length > 0
+
+  const checkboxState = !isSelected
+    ? false
+    : isAllPages
+      ? true
+      : "indeterminate"
+
+  // Tree mode: top-level pages, loaded when expanded
   const { data: pages, isFetching: isFetchingPages } = useQuery({
     queryKey: ["connector-pages", connectorId, space.key],
     queryFn: async () => {
@@ -176,15 +207,15 @@ function SpaceRow({
     throwOnError: false,
   })
 
-  // Search mode: server-side CQL search — fires for all spaces when query is active
+  // Search mode: server-side CQL per space
   const { data: searchResults, isFetching: isFetchingSearch } = useQuery({
-    queryKey: ["connector-page-search", connectorId, space.key, pageSearch],
+    queryKey: ["connector-page-search", connectorId, space.key, search],
     queryFn: async () => {
       const res = await client[":orgSlug"].api.v1.connectors[":id"][
         "available-spaces"
       ][":spaceKey"]["search"].$get({
         param: { orgSlug, id: connectorId, spaceKey: space.key },
-        query: { q: pageSearch },
+        query: { q: search },
       })
       if (!res.ok) throw new Error(`Failed to search pages (${res.status})`)
       const json = await res.json()
@@ -197,142 +228,136 @@ function SpaceRow({
   const isFetching = isFetchingPages || isFetchingSearch
   const displayPages = isSearching ? (searchResults ?? []) : (pages ?? [])
 
-  const spaceCheckboxState = !isSpaceSelected
-    ? false
-    : scope?.selectedPageIds === null
-      ? true
-      : "indeterminate"
-
-  // Show the pages panel when manually expanded, or in search mode only if
-  // there are results or a search is in-flight (avoids opening all 52 space
-  // panels when nothing matches — that buries the actual results).
+  // Auto-expand space when it has search results
+  const hasSearchResults = isSearching && (searchResults ?? []).length > 0
   const showPanel =
-    expanded || (isSearching && (isFetchingSearch || (searchResults ?? []).length > 0))
+    expanded || (isSearching && (isFetchingSearch || hasSearchResults))
+
+  const statusLabel = !isSelected
+    ? null
+    : isAllPages
+      ? "all pages"
+      : `${scope!.selectedPageIds!.length} page${scope!.selectedPageIds!.length === 1 ? "" : "s"}`
 
   return (
     <div className="border-b border-zinc-800 last:border-b-0">
       <div className="flex items-center gap-2 px-3 py-2.5 hover:bg-zinc-800/40">
+        {/* Expand chevron */}
+        <button
+          type="button"
+          onClick={() => !isSearching && setExpanded((v) => !v)}
+          className={[
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded text-zinc-500 hover:text-zinc-300 transition-colors",
+            isSearching ? "pointer-events-none opacity-30" : "",
+          ].join(" ")}
+          aria-label={expanded ? "Collapse" : "Expand pages"}
+        >
+          {isFetchingPages && !isSearching ? (
+            <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <IconChevronRight
+              className={[
+                "h-3.5 w-3.5 transition-transform duration-150",
+                showPanel ? "rotate-90" : "",
+              ].join(" ")}
+            />
+          )}
+        </button>
+
+        {/* Space icon */}
+        <IconStack2 className="h-4 w-4 shrink-0 text-zinc-400" />
+
+        {/* Checkbox + label */}
         <Checkbox
-          isSelected={isSpaceSelected}
-          isIndeterminate={spaceCheckboxState === "indeterminate"}
+          isSelected={isSelected}
+          isIndeterminate={checkboxState === "indeterminate"}
           onChange={() => onToggleSpace(space)}
           className="flex-1 font-medium text-zinc-200"
         >
           <span className="flex items-center gap-2">
             {space.name}
-            {isPersonal ? (
-              <span className="rounded bg-zinc-700 px-1.5 py-0.5 text-xs text-zinc-400">
-                Personal
-              </span>
-            ) : (
-              <span className="text-xs font-mono text-zinc-500">{space.key}</span>
-            )}
+            <span className="text-xs font-mono font-normal text-zinc-500">
+              {space.key}
+            </span>
           </span>
         </Checkbox>
 
-        {/* Only show browse button when not in search mode */}
-        {!isSearching && (
-          <button
-            type="button"
-            onClick={() => setExpanded((v) => !v)}
-            className="ml-auto flex shrink-0 items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
-            aria-label={expanded ? "Collapse pages" : "Browse pages"}
-          >
-            {isFetchingPages ? (
-              <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <>
-                <span>{expanded ? "Hide pages" : "Browse pages"}</span>
-                <IconChevronRight
-                  className={[
-                    "h-3.5 w-3.5 transition-transform duration-150",
-                    expanded ? "rotate-90" : "",
-                  ].join(" ")}
-                />
-              </>
-            )}
-          </button>
+        {/* Status / spinner */}
+        {isFetchingSearch && (
+          <IconLoader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-zinc-500" />
         )}
-
-        {/* In search mode show a spinner inline if fetching */}
-        {isSearching && isFetchingSearch && (
-          <IconLoader2 className="ml-auto h-3.5 w-3.5 shrink-0 animate-spin text-zinc-500" />
+        {statusLabel && !isFetchingSearch && (
+          <span className="shrink-0 rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-400">
+            {statusLabel}
+          </span>
         )}
       </div>
 
+      {/* Expanded page tree */}
       {showPanel && (
         <div className="border-t border-zinc-800/60 bg-zinc-800/20 pb-2">
-          {/* Select all / none controls */}
-          <div className="flex items-center gap-2 px-3 py-1.5">
-            <button
-              type="button"
-              className="text-xs text-teal-400 hover:text-teal-300"
-              onClick={() => {
-                if (!isSpaceSelected) {
-                  // Add space with selectedPageIds:null = "all pages" in one update.
-                  // Cannot call onTogglePage next — React batches both setScope calls
-                  // and the second (which uses stale value) would overwrite the first.
-                  onToggleSpace(space)
-                } else {
-                  onTogglePage(space.key, "__all__", "")
-                }
-              }}
-            >
-              Select all
-            </button>
-            <span className="text-zinc-600">·</span>
-            <button
-              type="button"
-              className="text-xs text-zinc-500 hover:text-zinc-300"
-              onClick={() => {
-                if (isSpaceSelected) onTogglePage(space.key, "__none__", "")
-              }}
-            >
-              Deselect all
-            </button>
-
-            {/* Status label */}
-            <span className="ml-auto text-xs text-zinc-500">
-              {!isSpaceSelected
-                ? "not included"
-                : scope?.selectedPageIds === null
-                  ? "all pages"
-                  : `${scope.selectedPageIds.length} selected`}
-            </span>
-          </div>
-
-          {/* Help text when in "all pages" mode so individual checkboxes aren't confusing */}
-          {isSpaceSelected && scope?.selectedPageIds === null && (
-            <p className="px-3 pb-1 text-xs text-zinc-600">
-              All pages synced. Use <span className="text-zinc-400">Deselect all</span> to choose specific pages.
+          {/* "All pages" mode hint */}
+          {isSelected && isAllPages && !isSearching && (
+            <p className="px-4 pt-2 pb-1 text-xs text-zinc-600">
+              All pages included.{" "}
+              <span className="text-zinc-500">
+                Click a page to select specific pages instead.
+              </span>
             </p>
           )}
 
-          {(isSearching ? isFetchingSearch : isFetchingPages) && (
-            <div className="flex items-center gap-2 px-3 py-2 text-xs text-zinc-500">
+          {/* Specific pages mode hint */}
+          {isSpecific && !isSearching && (
+            <p className="px-4 pt-2 pb-1 text-xs text-zinc-600">
+              Specific pages selected.{" "}
+              <button
+                type="button"
+                className="text-teal-500 hover:text-teal-400"
+                onClick={() => onToggleSpace(space)}
+              >
+                Switch to all pages
+              </button>
+            </p>
+          )}
+
+          {/* Loading */}
+          {isFetching && displayPages.length === 0 && (
+            <div className="flex items-center gap-2 px-4 py-2 text-xs text-zinc-500">
               <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
               {isSearching ? "Searching…" : "Loading pages…"}
             </div>
           )}
 
+          {/* Empty state */}
           {!isFetching && displayPages.length === 0 && (
-            <p className="px-3 py-2 text-xs text-zinc-600">
-              {isSearching ? `No pages match "${pageSearch}".` : "No root-level pages found."}
+            <p className="px-4 py-2 text-xs text-zinc-600">
+              {isSearching
+                ? `No pages match "${search}".`
+                : "No root-level pages found."}
             </p>
           )}
 
-          {/* In search mode: flat results list. In tree mode: PageNode tree. */}
+          {/* Page list */}
           {isSearching
             ? displayPages.map((page) => (
                 <div
                   key={page.id}
-                  className="flex items-center gap-1.5 py-1 pl-3 rounded hover:bg-zinc-800/50"
+                  className="flex items-center gap-1.5 py-1 pl-4 rounded hover:bg-zinc-800/50"
                 >
                   <div className="h-5 w-5 shrink-0" />
+                  <IconFileText className="h-3.5 w-3.5 shrink-0 text-zinc-500" />
                   <Checkbox
-                    isSelected={scope?.selectedPageIds === null || (scope?.selectedPageIds?.includes(page.id) ?? false)}
-                    onChange={() => onTogglePage(space.key, page.id, page.title)}
-                    className="text-sm text-zinc-300"
+                    isSelected={
+                      scope?.selectedPageIds === null ||
+                      (scope?.selectedPageIds?.includes(page.id) ?? false)
+                    }
+                    onChange={() =>
+                      onTogglePage(space.key, page.id, page.title)
+                    }
+                    className={[
+                      "text-sm text-zinc-300",
+                      isAllPages ? "opacity-60" : "",
+                    ].join(" ")}
                   >
                     {page.title}
                   </Checkbox>
@@ -363,7 +388,7 @@ interface PersonalSpacesGroupProps {
   spaces: ConfluenceSpace[]
   connectorId: string
   orgSlug: string
-  pageSearch: string
+  search: string
   getScope: (key: string) => SpaceScopeItem | undefined
   onToggleSpace: (space: ConfluenceSpace) => void
   onTogglePage: (spaceKey: string, pageId: string, pageTitle: string) => void
@@ -373,7 +398,7 @@ function PersonalSpacesGroup({
   spaces,
   connectorId,
   orgSlug,
-  pageSearch,
+  search,
   getScope,
   onToggleSpace,
   onTogglePage,
@@ -408,7 +433,7 @@ function PersonalSpacesGroup({
       {open && (
         <div className="border-t border-zinc-700/50">
           {spaces.map((space) => (
-            <SpaceRow
+            <SpaceNode
               key={space.id}
               space={space}
               connectorId={connectorId}
@@ -416,7 +441,7 @@ function PersonalSpacesGroup({
               scope={getScope(space.key)}
               onToggleSpace={onToggleSpace}
               onTogglePage={onTogglePage}
-              pageSearch={pageSearch}
+              search={search}
             />
           ))}
         </div>
@@ -426,7 +451,7 @@ function PersonalSpacesGroup({
 }
 
 // ---------------------------------------------------------------------------
-// SpacePageTree — search + space list
+// SpacePageTree — root component
 // ---------------------------------------------------------------------------
 
 interface SpacePageTreeProps {
@@ -442,14 +467,13 @@ export function SpacePageTree({
   value,
   onChange,
 }: SpacePageTreeProps) {
-  const [spaceSearch, setSpaceSearch] = useState("")
-  const [pageSearch, setPageSearch] = useState("")
-  const [debouncedPageSearch, setDebouncedPageSearch] = useState("")
+  const [search, setSearch] = useState("")
+  const [debouncedSearch, setDebouncedSearch] = useState("")
 
   useEffect(() => {
-    const id = setTimeout(() => setDebouncedPageSearch(pageSearch), 300)
+    const id = setTimeout(() => setDebouncedSearch(search), 300)
     return () => clearTimeout(id)
-  }, [pageSearch])
+  }, [search])
 
   const { data: spaces, isLoading, error } = useQuery({
     queryKey: ["connector-available-spaces", connectorId],
@@ -471,16 +495,26 @@ export function SpacePageTree({
     [value],
   )
 
+  // Space checkbox: not selected → all pages → not selected
+  //                 specific pages → all pages (on click)
   const handleToggleSpace = useCallback(
     (space: ConfluenceSpace) => {
       const existing = value.find((s) => s.spaceKey === space.key)
-      if (existing) {
-        onChange(value.filter((s) => s.spaceKey !== space.key))
-      } else {
+      if (!existing) {
         onChange([
           ...value,
           { spaceKey: space.key, spaceName: space.name, selectedPageIds: null },
         ])
+      } else if (existing.selectedPageIds !== null) {
+        // Specific pages → revert to all pages
+        onChange(
+          value.map((s) =>
+            s.spaceKey === space.key ? { ...s, selectedPageIds: null } : s,
+          ),
+        )
+      } else {
+        // All pages → remove
+        onChange(value.filter((s) => s.spaceKey !== space.key))
       }
     },
     [value, onChange],
@@ -488,27 +522,13 @@ export function SpacePageTree({
 
   const handleTogglePage = useCallback(
     (spaceKey: string, pageId: string, _pageTitle: string) => {
-      if (pageId === "__all__") {
-        onChange(
-          value.map((s) =>
-            s.spaceKey === spaceKey ? { ...s, selectedPageIds: null } : s,
-          ),
-        )
-        return
-      }
-      if (pageId === "__none__") {
-        onChange(
-          value.map((s) =>
-            s.spaceKey === spaceKey ? { ...s, selectedPageIds: [] } : s,
-          ),
-        )
-        return
-      }
-
       onChange(
         value.map((s) => {
           if (s.spaceKey !== spaceKey) return s
-          if (s.selectedPageIds === null) return s
+          if (s.selectedPageIds === null) {
+            // Switch from "all pages" to specific, starting with just this page
+            return { ...s, selectedPageIds: [pageId] }
+          }
           const alreadySelected = s.selectedPageIds.includes(pageId)
           return {
             ...s,
@@ -546,50 +566,30 @@ export function SpacePageTree({
   const globalSpaces = spaces.filter((s) => !s.key.startsWith("~"))
   const personalSpaces = spaces.filter((s) => s.key.startsWith("~"))
 
-  const filteredGlobal = spaceSearch
-    ? globalSpaces.filter(
-        (s) =>
-          s.name.toLowerCase().includes(spaceSearch.toLowerCase()) ||
-          s.key.toLowerCase().includes(spaceSearch.toLowerCase()),
-      )
-    : globalSpaces
-
   return (
-    <div className="flex h-full flex-col gap-2">
-      {/* Search bar */}
-      <div className="flex gap-2">
-        <div className="relative flex-1">
-          <IconSearch className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500" />
-          <input
-            type="text"
-            placeholder="Search spaces…"
-            value={spaceSearch}
-            onChange={(e) => setSpaceSearch(e.target.value)}
-            className="w-full rounded-md border border-zinc-700 bg-zinc-800 py-1.5 pl-8 pr-3 text-sm text-zinc-200 placeholder-zinc-600 focus:border-teal-500 focus:outline-none"
-          />
-        </div>
-        <div className="relative flex-1">
-          <IconSearch className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500" />
-          <input
-            type="text"
-            placeholder="Filter pages…"
-            value={pageSearch}
-            onChange={(e) => setPageSearch(e.target.value)}
-            className="w-full rounded-md border border-zinc-700 bg-zinc-800 py-1.5 pl-8 pr-3 text-sm text-zinc-200 placeholder-zinc-600 focus:border-teal-500 focus:outline-none"
-          />
-        </div>
+    <div className="flex h-full flex-col gap-3">
+      {/* Single search bar */}
+      <div className="relative shrink-0">
+        <IconSearch className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500" />
+        <input
+          type="text"
+          placeholder="Search spaces and pages…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full rounded-md border border-zinc-700 bg-zinc-800 py-1.5 pl-8 pr-3 text-sm text-zinc-200 placeholder-zinc-600 focus:border-teal-500 focus:outline-none"
+        />
       </div>
 
-      {/* Space list */}
+      {/* Tree */}
       <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
         <div className="rounded-lg border border-zinc-700 bg-zinc-800/30 overflow-hidden">
-          {filteredGlobal.length === 0 && (
+          {globalSpaces.length === 0 && (
             <p className="px-3 py-2 text-sm text-zinc-500">
-              {spaceSearch ? "No spaces match." : "No team spaces found."}
+              No team spaces found.
             </p>
           )}
-          {filteredGlobal.map((space) => (
-            <SpaceRow
+          {globalSpaces.map((space) => (
+            <SpaceNode
               key={space.id}
               space={space}
               connectorId={connectorId}
@@ -597,17 +597,17 @@ export function SpacePageTree({
               scope={getScope(space.key)}
               onToggleSpace={handleToggleSpace}
               onTogglePage={handleTogglePage}
-              pageSearch={debouncedPageSearch}
+              search={debouncedSearch}
             />
           ))}
         </div>
 
-        {personalSpaces.length > 0 && !spaceSearch && (
+        {personalSpaces.length > 0 && (
           <PersonalSpacesGroup
             spaces={personalSpaces}
             connectorId={connectorId}
             orgSlug={orgSlug}
-            pageSearch={debouncedPageSearch}
+            search={debouncedSearch}
             getScope={getScope}
             onToggleSpace={handleToggleSpace}
             onTogglePage={handleTogglePage}

--- a/apps/ui/src/features/connectors/types.ts
+++ b/apps/ui/src/features/connectors/types.ts
@@ -5,10 +5,17 @@ export interface Connector {
   config: {
     syncMode: "pr" | "auto"
     schedule: "hourly" | "daily" | "manual"
+    githubToken?: string
+    // Legacy basic-auth
     confluenceBaseUrl?: string
     confluenceEmail?: string
     confluenceApiToken?: string
-    githubToken?: string
+    // OAuth 2.0
+    deploymentType?: "cloud" | "datacenter"
+    cloudId?: string
+    oauthRefreshToken?: string  // encrypted — present means connected via OAuth
+    oauthClientId?: string
+    oauthClientSecret?: string
   }
   enabled: boolean
   githubRepoId: string | null

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OrgSlugIndexRouteImport } from './routes/$orgSlug.index'
+import { Route as OauthErrorRouteImport } from './routes/oauth.error'
 import { Route as DotauthSignInRouteImport } from './routes/[.]auth.sign-in'
 import { Route as DotauthResetPasswordRouteImport } from './routes/[.]auth.reset-password'
 import { Route as DotauthConsentRouteImport } from './routes/[.]auth.consent'
@@ -33,6 +34,11 @@ const IndexRoute = IndexRouteImport.update({
 const OrgSlugIndexRoute = OrgSlugIndexRouteImport.update({
   id: '/$orgSlug/',
   path: '/$orgSlug/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OauthErrorRoute = OauthErrorRouteImport.update({
+  id: '/oauth/error',
+  path: '/oauth/error',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DotauthSignInRoute = DotauthSignInRouteImport.update({
@@ -115,6 +121,7 @@ export interface FileRoutesByFullPath {
   '/.auth/consent': typeof DotauthConsentRoute
   '/.auth/reset-password': typeof DotauthResetPasswordRoute
   '/.auth/sign-in': typeof DotauthSignInRoute
+  '/oauth/error': typeof OauthErrorRoute
   '/$orgSlug/': typeof OrgSlugIndexRoute
   '/$orgSlug/chat/$conversationId': typeof OrgSlugChatConversationIdRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
@@ -131,6 +138,7 @@ export interface FileRoutesByTo {
   '/.auth/consent': typeof DotauthConsentRoute
   '/.auth/reset-password': typeof DotauthResetPasswordRoute
   '/.auth/sign-in': typeof DotauthSignInRoute
+  '/oauth/error': typeof OauthErrorRoute
   '/$orgSlug': typeof OrgSlugIndexRoute
   '/$orgSlug/chat/$conversationId': typeof OrgSlugChatConversationIdRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
@@ -149,6 +157,7 @@ export interface FileRoutesById {
   '/.auth/consent': typeof DotauthConsentRoute
   '/.auth/reset-password': typeof DotauthResetPasswordRoute
   '/.auth/sign-in': typeof DotauthSignInRoute
+  '/oauth/error': typeof OauthErrorRoute
   '/$orgSlug/': typeof OrgSlugIndexRoute
   '/$orgSlug/chat/$conversationId': typeof OrgSlugChatConversationIdRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
@@ -168,6 +177,7 @@ export interface FileRouteTypes {
     | '/.auth/consent'
     | '/.auth/reset-password'
     | '/.auth/sign-in'
+    | '/oauth/error'
     | '/$orgSlug/'
     | '/$orgSlug/chat/$conversationId'
     | '/$orgSlug/organization/$organizationView'
@@ -184,6 +194,7 @@ export interface FileRouteTypes {
     | '/.auth/consent'
     | '/.auth/reset-password'
     | '/.auth/sign-in'
+    | '/oauth/error'
     | '/$orgSlug'
     | '/$orgSlug/chat/$conversationId'
     | '/$orgSlug/organization/$organizationView'
@@ -201,6 +212,7 @@ export interface FileRouteTypes {
     | '/.auth/consent'
     | '/.auth/reset-password'
     | '/.auth/sign-in'
+    | '/oauth/error'
     | '/$orgSlug/'
     | '/$orgSlug/chat/$conversationId'
     | '/$orgSlug/organization/$organizationView'
@@ -219,6 +231,7 @@ export interface RootRouteChildren {
   DotauthConsentRoute: typeof DotauthConsentRoute
   DotauthResetPasswordRoute: typeof DotauthResetPasswordRoute
   DotauthSignInRoute: typeof DotauthSignInRoute
+  OauthErrorRoute: typeof OauthErrorRoute
   OrgSlugIndexRoute: typeof OrgSlugIndexRoute
   OrgSlugOrganizationOrganizationViewRoute: typeof OrgSlugOrganizationOrganizationViewRoute
   DotauthOrganizationOrganizationViewRoute: typeof DotauthOrganizationOrganizationViewRoute
@@ -238,6 +251,13 @@ declare module '@tanstack/react-router' {
       path: '/$orgSlug'
       fullPath: '/$orgSlug/'
       preLoaderRoute: typeof OrgSlugIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/oauth/error': {
+      id: '/oauth/error'
+      path: '/oauth/error'
+      fullPath: '/oauth/error'
+      preLoaderRoute: typeof OauthErrorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/.auth/sign-in': {
@@ -370,6 +390,7 @@ const rootRouteChildren: RootRouteChildren = {
   DotauthConsentRoute: DotauthConsentRoute,
   DotauthResetPasswordRoute: DotauthResetPasswordRoute,
   DotauthSignInRoute: DotauthSignInRoute,
+  OauthErrorRoute: OauthErrorRoute,
   OrgSlugIndexRoute: OrgSlugIndexRoute,
   OrgSlugOrganizationOrganizationViewRoute:
     OrgSlugOrganizationOrganizationViewRoute,

--- a/apps/ui/src/routes/$orgSlug.connectors.tsx
+++ b/apps/ui/src/routes/$orgSlug.connectors.tsx
@@ -44,39 +44,6 @@ function ConnectorsPage() {
     },
   })
 
-  const createMutation = useMutation({
-    mutationFn: async (input: {
-      type: string
-      githubRepoName?: string
-      githubBranch?: string
-      config: {
-        confluenceBaseUrl?: string
-        confluenceEmail?: string
-        confluenceApiToken?: string
-        githubToken?: string
-      }
-    }) => {
-      const res = await client[":orgSlug"].api.v1.connectors.$post({
-        json: input,
-        param: { orgSlug },
-      })
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}))
-        throw new Error(
-          (err as { error?: string }).error ?? "Failed to create connector",
-        )
-      }
-      return res.json() as Promise<Connector>
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["connectors"] })
-      setAddModalOpen(false)
-      toast.success("Connector created successfully")
-    },
-    onError: (err: Error) => {
-      toast.error(err.message)
-    },
-  })
 
   const updateMutation = useMutation({
     mutationFn: async ({
@@ -184,9 +151,10 @@ function ConnectorsPage() {
           >
             <AddConnectorModal
               onClose={() => setAddModalOpen(false)}
-              onSubmit={(data) => createMutation.mutate(data)}
-              isPending={createMutation.isPending}
-              error={createMutation.error?.message}
+              onSuccess={() => {
+                queryClient.invalidateQueries({ queryKey: ["connectors"] })
+                setAddModalOpen(false)
+              }}
             />
           </Modal>
         )}

--- a/apps/ui/src/routes/oauth.error.tsx
+++ b/apps/ui/src/routes/oauth.error.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { IconAlertTriangle } from "@tabler/icons-react"
+
+export const Route = createFileRoute("/oauth/error")({
+  component: OAuthErrorPage,
+})
+
+const ERROR_MESSAGES: Record<string, string> = {
+  invalid_state: "The authorisation request expired or was already used. Please try connecting again.",
+  token_exchange_failed: "Failed to exchange the authorisation code for tokens. Please try again.",
+  no_refresh_token: "Atlassian did not return a refresh token. Make sure 'offline_access' is requested.",
+  no_accessible_sites: "No Confluence sites were found on your Atlassian account.",
+  cloudid_resolution_failed: "Could not determine your Confluence Cloud ID. Please try again.",
+  connector_not_found: "The connector associated with this authorisation could not be found.",
+  missing_params: "The callback was missing required parameters.",
+}
+
+function OAuthErrorPage() {
+  const { reason } = Route.useSearch() as { reason?: string }
+  const message = (reason && ERROR_MESSAGES[reason]) ?? "An unexpected error occurred during authorisation."
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-950 px-4">
+      <div className="w-full max-w-md rounded-xl border border-red-800/40 bg-zinc-900 p-8 text-center shadow-xl">
+        <div className="mb-4 flex justify-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-900/30">
+            <IconAlertTriangle className="h-6 w-6 text-red-400" />
+          </div>
+        </div>
+        <h1 className="mb-2 text-xl font-semibold text-zinc-100">
+          Authorisation failed
+        </h1>
+        <p className="mb-6 text-sm text-zinc-400">{message}</p>
+        {reason && (
+          <p className="mb-6 font-mono text-xs text-zinc-600">reason: {reason}</p>
+        )}
+        <Link
+          to="/"
+          className="inline-flex items-center rounded-md bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-500 transition-colors"
+        >
+          Back to app
+        </Link>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Stacked on #30. All UI changes for the OAuth connector flow and scope selection.

**OAuth UI**
- `AddConnectorModal` — deployment type selector (Cloud / Data Center), initiates OAuth flow after connector creation; replaces API token fields
- `EditConnectorModal` — shows OAuth connection status, Reconnect button, hides legacy credential fields for OAuth connectors
- `/oauth/error` route — dedicated error page surfacing reason codes from the OAuth callback

**Scope selection**
- `SpacePageTree` — unified space + page tree with a single search input (server-side CQL); icons distinguish spaces from pages; replaces separate space/page search inputs
- Space checkbox 3-state logic: unchecked → all pages → specific pages → unchecked (cycling). Clicking an individual page while a space is in all-pages mode switches it to specific-pages with that page selected
- `EditScopeModal` — recognises `oauthRefreshToken` as a valid credential (was blocking the scope UI for OAuth connectors)