### PR TITLE
feat: Atlassian OAuth 2.0 (3LO) + Confluence sync engine

### DIFF
--- a/apps/backend/src/app/app.ts
+++ b/apps/backend/src/app/app.ts
@@ -1,10 +1,8 @@
 import { OpenAPIHono } from "@hono/zod-openapi"
-import { evlog } from "evlog/hono"
 import { contextStorage } from "hono/context-storage"
 import { cors } from "hono/cors"
 import { parseEnv } from "../config/env.js"
 import { initDb } from "../db/client.js"
-import { createEvlogDrain } from "../observability/logger.js"
 import { registerAuthRoutes } from "../routes/auth.js"
 import { registerLangsmithRoutes } from "../routes/langsmith.js"
 import { registerMcpRoutes } from "../routes/mcp.js"
@@ -12,6 +10,7 @@ import { registerOpenapiRoutes } from "../routes/openapi.js"
 import { registerStatusRoutes } from "../routes/status"
 import { registerUiRoutes } from "../routes/ui.js"
 import { registerV1Routes } from "../routes/v1/index.js"
+import { oauthRoutes } from "../routes/oauth.js"
 import type { AppEnv } from "./env.js"
 
 export type { AppEnv } from "./env.js"
@@ -35,7 +34,6 @@ export function createApp() {
     }),
   )
   app.use(contextStorage())
-  app.use(evlog({ drain: createEvlogDrain() }))
   app.use("*", async (c, next) => {
     c.set("env", env)
     c.set("user", null)
@@ -48,11 +46,14 @@ export function createApp() {
   // auth
   registerAuthRoutes(app)
 
+  // public OAuth callback — must be before auth middleware
+  app.route("/oauth", oauthRoutes)
+
   // /:orgSlug/api/v1 routes
   const v1 = registerV1Routes(app)
 
   // /.docs/openapi and /.docs/api-reference
-  registerOpenapiRoutes(app, v1 as OpenAPIHono<AppEnv>)
+  registerOpenapiRoutes(app, v1)
   // /.status
   registerStatusRoutes(app)
   // /langsmith mounted only when ENABLE_LANGSMITH=true

--- a/apps/backend/src/db/schema/connectors.ts
+++ b/apps/backend/src/db/schema/connectors.ts
@@ -18,10 +18,22 @@ export const connectors = pgTable(
     config: jsonb("config").notNull().$type<{
       syncMode: "pr" | "auto"
       schedule: "hourly" | "daily" | "manual"
+      githubToken?: string
+
+      // Legacy basic-auth (deprecated — kept for backward compatibility)
       confluenceBaseUrl?: string
       confluenceEmail?: string
       confluenceApiToken?: string
-      githubToken?: string
+
+      // OAuth 2.0 fields
+      deploymentType?: "cloud" | "datacenter"
+      // Cloud: resolved from accessible-resources after OAuth
+      cloudId?: string
+      // Encrypted refresh token (AES-256-GCM via crypto.ts)
+      oauthRefreshToken?: string
+      // Data Center only: customer-provided application link credentials
+      oauthClientId?: string
+      oauthClientSecret?: string
     }>(),
     enabled: boolean("enabled").notNull().default(true),
     githubRepoId: text("github_repo_id"),

--- a/apps/backend/src/models/connectors.ts
+++ b/apps/backend/src/models/connectors.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm"
 import { requireCurrentOrgId } from "src/auth/context.js"
 import { connectors } from "src/db/schema/connectors.js"
 import { generateObjectId } from "src/lib/id.js"
-import { getOrgDb } from "../db/client.js"
+import { getOrgDb, getSystemDb } from "../db/client.js"
 
 export type ConnectorRecord = typeof connectors.$inferSelect
 export type ConnectorConfig = ConnectorRecord["config"]
@@ -22,17 +22,6 @@ export const getConnector = async (connectorId: string) => {
   return db.query.connectors.findFirst({
     where: {
       id: { eq: connectorId },
-      orgId: { eq: orgId },
-    },
-  })
-}
-
-export const getConnectorByType = async (type: string) => {
-  const orgId = requireCurrentOrgId()
-  const db = getOrgDb()
-  return db.query.connectors.findFirst({
-    where: {
-      type: { eq: type },
       orgId: { eq: orgId },
     },
   })
@@ -136,13 +125,11 @@ export const deleteConnector = async (connectorId: string) => {
   return deleted != null
 }
 
-export const getEnabledConnectors = async () => {
-  const orgId = requireCurrentOrgId()
-  const db = getOrgDb()
+/** System-level query: returns all enabled connectors across every org.
+ *  Bypasses RLS — for use only in background workers. */
+export const listAllEnabledConnectors = async () => {
+  const db = getSystemDb()
   return db.query.connectors.findMany({
-    where: {
-      orgId: { eq: orgId },
-      enabled: { eq: true },
-    },
+    where: { enabled: { eq: true } },
   })
 }

--- a/apps/backend/src/routes/oauth.ts
+++ b/apps/backend/src/routes/oauth.ts
@@ -1,0 +1,144 @@
+import { Hono } from "hono"
+import type { AppEnv } from "../app/env.js"
+import { getSystemDb } from "../db/client.js"
+import { connectors } from "../db/schema/connectors.js"
+import { consumeOAuthState } from "../models/oauth-states.js"
+import { encrypt } from "../services/crypto.js"
+import { and, eq } from "drizzle-orm"
+
+export const oauthRoutes = new Hono<AppEnv>()
+
+/**
+ * GET /oauth/atlassian/callback
+ *
+ * Public route — called by Atlassian after the user grants consent.
+ * Exchanges the code for tokens, resolves the cloudId (Cloud only),
+ * encrypts the refresh token, and stores everything on the connector.
+ */
+oauthRoutes.get("/atlassian/callback", async (c) => {
+  const env = c.get("env")
+  const code = c.req.query("code")
+  const stateNonce = c.req.query("state")
+  const errorParam = c.req.query("error")
+
+  // Redirect back to the browser-facing app, not the ngrok tunnel URL.
+  // AUTH_BASE_URL is where the user's session cookie lives.
+  const uiBase = env.AUTH_BASE_URL.replace(/\/$/, "")
+
+  if (errorParam) {
+    return c.redirect(`${uiBase}/oauth/error?reason=${encodeURIComponent(errorParam)}`)
+  }
+
+  if (!code || !stateNonce) {
+    return c.redirect(`${uiBase}/oauth/error?reason=missing_params`)
+  }
+
+  // Validate and consume state nonce
+  const state = await consumeOAuthState(stateNonce)
+  if (!state) {
+    return c.redirect(`${uiBase}/oauth/error?reason=invalid_state`)
+  }
+
+  const { connectorId, orgId, orgSlug } = state
+  const callbackUrl = `${env.PUBLIC_URL}/oauth/atlassian/callback`
+  const db = getSystemDb()
+
+  // Look up the connector (raw query — no org context middleware here)
+  const [connector] = await db
+    .select()
+    .from(connectors)
+    .where(and(eq(connectors.id, connectorId), eq(connectors.orgId, orgId)))
+    .limit(1)
+
+  if (!connector) {
+    return c.redirect(`${uiBase}/oauth/error?reason=connector_not_found`)
+  }
+
+  const isCloud = connector.config.deploymentType !== "datacenter"
+
+  // Determine token endpoint + client credentials
+  const tokenUrl = isCloud
+    ? "https://auth.atlassian.com/oauth/token"
+    : `${connector.config.confluenceBaseUrl?.replace(/\/$/, "")}/rest/oauth2/latest/token`
+
+  const clientId = isCloud
+    ? (env.ATLASSIAN_CLIENT_ID ?? "")
+    : (connector.config.oauthClientId ?? "")
+
+  const clientSecret = isCloud
+    ? (env.ATLASSIAN_CLIENT_SECRET ?? "")
+    : (connector.config.oauthClientSecret ?? "")
+
+  // Exchange authorisation code for tokens
+  let tokenData: { access_token: string; refresh_token?: string; scope?: string }
+  try {
+    const res = await fetch(tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri: callbackUrl,
+      }),
+    })
+    if (!res.ok) {
+      const err = await res.text()
+      console.error("[oauth] token exchange failed", res.status, err)
+      return c.redirect(`${uiBase}/oauth/error?reason=token_exchange_failed`)
+    }
+    tokenData = await res.json() as typeof tokenData
+  } catch (e) {
+    console.error("[oauth] token exchange error", e)
+    return c.redirect(`${uiBase}/oauth/error?reason=token_exchange_error`)
+  }
+
+  if (!tokenData.refresh_token) {
+    console.error("[oauth] no refresh_token in response — was offline_access scope requested?")
+    return c.redirect(`${uiBase}/oauth/error?reason=no_refresh_token`)
+  }
+
+  // Resolve cloudId for Cloud connectors
+  let cloudId: string | undefined
+  if (isCloud) {
+    try {
+      const res = await fetch("https://api.atlassian.com/oauth/token/accessible-resources", {
+        headers: { Authorization: `Bearer ${tokenData.access_token}` },
+      })
+      if (!res.ok) throw new Error(`accessible-resources: ${res.status}`)
+      const sites = await res.json() as Array<{ id: string; url: string; name: string }>
+
+      if (sites.length === 0) {
+        return c.redirect(`${uiBase}/oauth/error?reason=no_accessible_sites`)
+      }
+
+      // Match against the connector's stored base URL if set, otherwise take first
+      const stored = connector.config.confluenceBaseUrl?.replace(/\/$/, "").toLowerCase()
+      const match = stored
+        ? sites.find((s) => s.url.replace(/\/$/, "").toLowerCase() === stored)
+        : null
+
+      cloudId = (match ?? sites[0])!.id
+    } catch (e) {
+      console.error("[oauth] accessible-resources error", e)
+      return c.redirect(`${uiBase}/oauth/error?reason=cloudid_resolution_failed`)
+    }
+  }
+
+  // Encrypt refresh token and persist to connector
+  const encryptedRefreshToken = encrypt(tokenData.refresh_token)
+  const updatedConfig = {
+    ...connector.config,
+    oauthRefreshToken: encryptedRefreshToken,
+    ...(cloudId ? { cloudId } : {}),
+  }
+
+  await db
+    .update(connectors)
+    .set({ config: updatedConfig, updatedAt: new Date() })
+    .where(and(eq(connectors.id, connectorId), eq(connectors.orgId, orgId)))
+
+  console.log(`[oauth] connector ${connectorId} authorised successfully`)
+  return c.redirect(`${uiBase}/${orgSlug}/connectors?oauth=success`)
+})

--- a/apps/backend/src/routes/v1/connectors.ts
+++ b/apps/backend/src/routes/v1/connectors.ts
@@ -1,0 +1,1112 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { randomBytes } from "crypto"
+import type { AppEnv } from "../../app/env.js"
+import {
+  createConnectorSpaces,
+  listConnectorSpaces,
+  replaceConnectorSpaces,
+} from "../../models/connector-spaces.js"
+import {
+  getLatestSyncLog,
+  listSyncLogs,
+} from "../../models/connector-sync-logs.js"
+import { createOAuthState } from "../../models/oauth-states.js"
+import { syncOrchestrator } from "../../services/confluence/index.js"
+import { ConfluenceClient } from "../../services/confluence/client.js"
+import { buildConfluenceConfig } from "../../services/confluence/config.js"
+import {
+  createConnector,
+  deleteConnector,
+  disableConnector,
+  enableConnector,
+  getConnector,
+  listConnectors,
+  updateConnector,
+  type ConnectorConfig,
+} from "../../models/connectors.js"
+
+const ErrorResponseSchema = z
+  .object({ error: z.string() })
+  .openapi("ErrorResponse")
+
+const ConnectorConfigSchema = z
+  .object({
+    // syncMode and schedule are system-controlled; kept for DB compatibility only
+    syncMode: z.enum(["pr", "auto"]).optional().default("auto"),
+    schedule: z.enum(["hourly", "daily", "manual"]).optional().default("manual"),
+    githubToken: z.string().optional(),
+    // Legacy basic-auth
+    confluenceBaseUrl: z.string().url().optional(),
+    confluenceEmail: z.string().email().optional(),
+    confluenceApiToken: z.string().optional(),
+    // OAuth 2.0
+    deploymentType: z.enum(["cloud", "datacenter"]).optional(),
+    cloudId: z.string().optional(),
+    oauthRefreshToken: z.string().optional(),
+    oauthClientId: z.string().optional(),
+    oauthClientSecret: z.string().optional(),
+  })
+  .openapi("ConnectorConfig")
+
+const ConnectorSchema = z
+  .object({
+    id: z.string(),
+    orgId: z.string(),
+    type: z.string(),
+    config: ConnectorConfigSchema,
+    enabled: z.boolean(),
+    githubRepoId: z.string().nullable(),
+    githubRepoName: z.string().nullable(),
+    githubBranch: z.string().nullable(),
+    lastPrNumber: z.number().nullable(),
+    lastSyncAt: z.string().nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("Connector")
+
+const CreateConnectorRequestSchema = z
+  .object({
+    type: z.string(),
+    githubRepoName: z.string().optional(),
+    githubBranch: z.string().optional(),
+    config: ConnectorConfigSchema,
+    spaces: z
+      .array(
+        z.object({
+          spaceKey: z.string(),
+          spaceName: z.string().optional(),
+        }),
+      )
+      .optional(),
+  })
+  .openapi("CreateConnectorRequest")
+
+const UpdateConnectorRequestSchema = z
+  .object({
+    config: ConnectorConfigSchema.optional(),
+    enabled: z.boolean().optional(),
+    githubRepoName: z.string().optional(),
+    githubBranch: z.string().optional(),
+    spaces: z
+      .array(
+        z.object({
+          spaceKey: z.string(),
+          spaceName: z.string().optional(),
+        }),
+      )
+      .optional(),
+  })
+  .openapi("UpdateConnectorRequest")
+
+const ConnectorSpaceSchema = z
+  .object({
+    id: z.string(),
+    connectorId: z.string(),
+    spaceKey: z.string(),
+    spaceName: z.string().nullable(),
+    selectedPageIds: z.array(z.string()).nullable(),
+    lastSyncedPageId: z.string().nullable(),
+    lastSyncedAt: z.string().nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("ConnectorSpace")
+
+const ConfluenceSpaceInfoSchema = z
+  .object({
+    id: z.string(),
+    key: z.string(),
+    name: z.string(),
+    type: z.string(),
+  })
+  .openapi("ConfluenceSpaceInfo")
+
+const ConfluencePageSummarySchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    spaceId: z.string(),
+    parentId: z.string().optional(),
+  })
+  .openapi("ConfluencePageSummary")
+
+const ScopedSpaceSchema = z.object({
+  spaceKey: z.string(),
+  spaceName: z.string().optional(),
+  selectedPageIds: z.array(z.string()).nullable().optional(),
+})
+
+const SaveScopeRequestSchema = z
+  .object({
+    spaces: z.array(ScopedSpaceSchema),
+  })
+  .openapi("SaveScopeRequest")
+
+const ConfigSyncResultSchema = z
+  .object({
+    noChange: z.boolean().optional(),
+    prNumber: z.number().nullable(),
+    prUrl: z.string().nullable(),
+  })
+  .openapi("ConfigSyncResult")
+
+const SyncLogSchema = z
+  .object({
+    id: z.string(),
+    connectorId: z.string(),
+    status: z.string(),
+    prNumber: z.number().nullable(),
+    prUrl: z.string().nullable(),
+    pagesAdded: z.number(),
+    pagesUpdated: z.number(),
+    pagesDeleted: z.number(),
+    errorMessage: z.string().nullable(),
+    startedAt: z.string(),
+    completedAt: z.string().nullable(),
+  })
+  .openapi("SyncLog")
+
+const ListConnectorsResponseSchema = z
+  .object({
+    items: z.array(ConnectorSchema),
+  })
+  .openapi("ListConnectorsResponse")
+
+const ConnectorWithSpacesSchema = ConnectorSchema.extend({
+  spaces: z.array(ConnectorSpaceSchema),
+  lastSyncLog: SyncLogSchema.nullable(),
+})
+
+const ConnectorDetailResponseSchema = ConnectorWithSpacesSchema.openapi(
+  "ConnectorDetailResponse",
+)
+
+const ListSyncLogsResponseSchema = z
+  .object({
+    items: z.array(SyncLogSchema),
+  })
+  .openapi("ListSyncLogsResponse")
+
+export const listConnectorsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["connectors"],
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ListConnectorsResponseSchema,
+        },
+      },
+      description: "List connectors for the current org",
+    },
+    401: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Unauthorized",
+    },
+  },
+})
+
+export const getConnectorRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ConnectorDetailResponseSchema,
+        },
+      },
+      description: "Connector details with spaces and sync logs",
+    },
+    401: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Unauthorized",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Not found",
+    },
+  },
+})
+
+export const createConnectorRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["connectors"],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: CreateConnectorRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        "application/json": {
+          schema: ConnectorSchema,
+        },
+      },
+      description: "Connector created",
+    },
+    400: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Bad request",
+    },
+    401: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Unauthorized",
+    },
+    409: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Connector of this type already exists",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Internal server error",
+    },
+  },
+})
+
+export const updateConnectorRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: {
+        "application/json": {
+          schema: UpdateConnectorRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ConnectorSchema,
+        },
+      },
+      description: "Connector updated",
+    },
+    401: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Unauthorized",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Not found",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Internal server error",
+    },
+  },
+})
+
+export const deleteConnectorRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    204: {
+      description: "Connector disabled",
+    },
+    401: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Unauthorized",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Not found",
+    },
+  },
+})
+
+export const triggerSyncRoute = createRoute({
+  method: "post",
+  path: "/{id}/sync",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: SyncLogSchema,
+        },
+      },
+      description: "Sync started",
+    },
+    401: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Unauthorized",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Not found",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Internal server error",
+    },
+  },
+})
+
+export const listAvailableSpacesRoute = createRoute({
+  method: "get",
+  path: "/{id}/available-spaces",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ items: z.array(ConfluenceSpaceInfoSchema) }),
+        },
+      },
+      description: "List available Confluence spaces",
+    },
+    400: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Bad request" },
+    401: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Unauthorized" },
+    404: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Not found" },
+  },
+})
+
+export const listSpacePagesRoute = createRoute({
+  method: "get",
+  path: "/{id}/available-spaces/{spaceKey}/pages",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string(), spaceKey: z.string() }),
+    query: z.object({ parentId: z.string().optional() }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ items: z.array(ConfluencePageSummarySchema) }),
+        },
+      },
+      description: "List pages in a Confluence space",
+    },
+    400: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Bad request" },
+    401: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Unauthorized" },
+    404: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Not found" },
+  },
+})
+
+export const searchSpacePagesRoute = createRoute({
+  method: "get",
+  path: "/{id}/available-spaces/{spaceKey}/search",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string(), spaceKey: z.string() }),
+    query: z.object({ q: z.string() }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ items: z.array(ConfluencePageSummarySchema) }),
+        },
+      },
+      description: "Search pages in a Confluence space by title",
+    },
+    400: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Bad request" },
+    401: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Unauthorized" },
+    404: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Not found" },
+    500: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Internal server error" },
+  },
+})
+
+export const saveScopeRoute = createRoute({
+  method: "post",
+  path: "/{id}/scope",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: { "application/json": { schema: SaveScopeRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ConfigSyncResultSchema },
+      },
+      description: "Scope saved and config PR opened (if changed)",
+    },
+    400: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Bad request" },
+    401: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Unauthorized" },
+    404: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Not found" },
+    500: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Internal server error" },
+  },
+})
+
+export const oauthStartRoute = createRoute({
+  method: "get",
+  path: "/{id}/oauth/start",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ url: z.string().url() }),
+        },
+      },
+      description: "Atlassian OAuth authorisation URL to redirect the browser to",
+    },
+    400: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Bad request" },
+    401: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Unauthorized" },
+    404: { content: { "application/json": { schema: ErrorResponseSchema } }, description: "Not found" },
+  },
+})
+
+export const listSyncLogsRoute = createRoute({
+  method: "get",
+  path: "/{id}/logs",
+  tags: ["connectors"],
+  request: {
+    params: z.object({ id: z.string() }),
+    query: z.object({
+      limit: z
+        .string()
+        .transform((v) => parseInt(v, 10))
+        .optional(),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ListSyncLogsResponseSchema,
+        },
+      },
+      description: "List sync logs",
+    },
+    401: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Unauthorized",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+      description: "Not found",
+    },
+  },
+})
+
+type ConnectorResponse = z.infer<typeof ConnectorSchema>
+type ConnectorSpaceResponse = z.infer<typeof ConnectorSpaceSchema>
+type SyncLogResponse = z.infer<typeof SyncLogSchema>
+
+const connectorToResponse = (c: {
+  id: string
+  orgId: string
+  type: string
+  config: { syncMode: string; schedule: string }
+  enabled: boolean
+  githubRepoId: string | null
+  githubRepoName: string | null
+  githubBranch: string | null
+  lastPrNumber: number | null
+  lastSyncAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}): ConnectorResponse => ({
+  id: c.id,
+  orgId: c.orgId,
+  type: c.type,
+  config: c.config as ConnectorResponse["config"],
+  enabled: c.enabled,
+  githubRepoId: c.githubRepoId,
+  githubRepoName: c.githubRepoName,
+  githubBranch: c.githubBranch,
+  lastPrNumber: c.lastPrNumber,
+  lastSyncAt: c.lastSyncAt?.toISOString() ?? null,
+  createdAt: c.createdAt.toISOString(),
+  updatedAt: c.updatedAt.toISOString(),
+})
+
+const spaceToResponse = (s: {
+  id: string
+  connectorId: string
+  spaceKey: string
+  spaceName: string | null
+  selectedPageIds?: string[] | null
+  lastSyncedPageId: string | null
+  lastSyncedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}): ConnectorSpaceResponse => ({
+  id: s.id,
+  connectorId: s.connectorId,
+  spaceKey: s.spaceKey,
+  spaceName: s.spaceName,
+  selectedPageIds: s.selectedPageIds ?? null,
+  lastSyncedPageId: s.lastSyncedPageId,
+  lastSyncedAt: s.lastSyncedAt?.toISOString() ?? null,
+  createdAt: s.createdAt.toISOString(),
+  updatedAt: s.updatedAt.toISOString(),
+})
+
+const getConfluenceClient = (connector: { config: ConnectorConfig }): ConfluenceClient | null => {
+  const confluenceConfig = buildConfluenceConfig(connector.config)
+  if (!confluenceConfig) return null
+  return new ConfluenceClient(confluenceConfig)
+}
+
+const validateSharedRepo = async (
+  githubRepoName: string,
+  excludeConnectorId?: string,
+) => {
+  const existing = await listConnectors()
+  const others = excludeConnectorId
+    ? existing.filter((c) => c.id !== excludeConnectorId)
+    : existing
+
+  const conflict = others.find(
+    (c) => c.githubRepoName && c.githubRepoName !== githubRepoName,
+  )
+  if (conflict) {
+    return `All connectors must point to the same repository. Existing connector uses "${conflict.githubRepoName}".`
+  }
+  return null
+}
+
+const logToResponse = (l: {
+  id: string
+  connectorId: string
+  status: string
+  prNumber: number | null
+  prUrl: string | null
+  pagesAdded: number | null
+  pagesUpdated: number | null
+  pagesDeleted: number | null
+  errorMessage: string | null
+  startedAt: Date
+  completedAt: Date | null
+}): SyncLogResponse => ({
+  id: l.id,
+  connectorId: l.connectorId,
+  status: l.status,
+  prNumber: l.prNumber,
+  prUrl: l.prUrl,
+  pagesAdded: l.pagesAdded ?? 0,
+  pagesUpdated: l.pagesUpdated ?? 0,
+  pagesDeleted: l.pagesDeleted ?? 0,
+  errorMessage: l.errorMessage,
+  startedAt: l.startedAt.toISOString(),
+  completedAt: l.completedAt?.toISOString() ?? null,
+})
+
+export const connectorRoutes = new OpenAPIHono<AppEnv>()
+  .openapi(listConnectorsRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+    const connectors = await listConnectors()
+    return c.json(
+      {
+        items: connectors.map(connectorToResponse),
+      },
+      200,
+    )
+  })
+  .openapi(getConnectorRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+    const id = c.req.param("id")
+    const connector = await getConnector(id)
+    if (!connector) {
+      return c.json({ error: "Not found" }, 404)
+    }
+    const spaces = await listConnectorSpaces(id)
+    const lastSyncLog = await getLatestSyncLog(id)
+    return c.json(
+      {
+        ...connectorToResponse(connector),
+        spaces: spaces.map(spaceToResponse),
+        lastSyncLog: lastSyncLog ? logToResponse(lastSyncLog) : null,
+      },
+      200,
+    )
+  })
+  .openapi(createConnectorRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+    const body = c.req.valid("json")
+    try {
+      if (body.githubRepoName) {
+        const repoConflict = await validateSharedRepo(body.githubRepoName)
+        if (repoConflict) {
+          return c.json({ error: repoConflict }, 400)
+        }
+      }
+      const connector = await createConnector({
+        type: body.type,
+        config: body.config,
+        githubRepoName: body.githubRepoName,
+        githubBranch: body.githubBranch,
+      })
+      if (body.spaces && body.spaces.length > 0) {
+        await createConnectorSpaces({
+          connectorId: connector.id,
+          spaces: body.spaces,
+        })
+      }
+      return c.json(connectorToResponse(connector), 201)
+    } catch (e) {
+      console.error("Error creating connector", e)
+      if (e instanceof Error && e.message.includes("duplicate")) {
+        return c.json({ error: "Connector of this type already exists" }, 409)
+      }
+      return c.json({ error: "Internal server error" }, 500)
+    }
+  })
+  .openapi(updateConnectorRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+    const id = c.req.param("id")
+    // @ts-expect-error - zod-openapi typing issue with valid("json")
+    const body = c.req.valid("json") as z.infer<
+      typeof UpdateConnectorRequestSchema
+    >
+    try {
+      const existing = await getConnector(id)
+      if (!existing) {
+        return c.json({ error: "Not found" }, 404)
+      }
+      const updates: Parameters<typeof updateConnector>[1] = {}
+      if (body.config) {
+        updates.config = body.config
+      }
+      if (body.enabled !== undefined) {
+        if (body.enabled) {
+          await enableConnector(id)
+        } else {
+          await disableConnector(id)
+        }
+      }
+      if (body.githubRepoName !== undefined) {
+        const repoConflict = await validateSharedRepo(body.githubRepoName, id)
+        if (repoConflict) {
+          return c.json({ error: repoConflict }, 400)
+        }
+        updates.githubRepoName = body.githubRepoName
+      }
+      if (body.githubBranch !== undefined) {
+        updates.githubBranch = body.githubBranch
+      }
+      if (body.spaces) {
+        await replaceConnectorSpaces({
+          connectorId: id,
+          spaces: body.spaces,
+        })
+      }
+      const connector = await updateConnector(id, updates)
+      if (!connector) {
+        return c.json({ error: "Not found" }, 404)
+      }
+      return c.json(connectorToResponse(connector), 200)
+    } catch (e) {
+      console.error("Error updating connector", e)
+      return c.json({ error: "Internal server error" }, 500)
+    }
+  })
+  .openapi(deleteConnectorRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+    const id = c.req.param("id")
+    try {
+      const deleted = await deleteConnector(id)
+      if (!deleted) {
+        return c.json({ error: "Not found" }, 404)
+      }
+      return c.body(null, 204)
+    } catch {
+      return c.json({ error: "Internal server error" }, 500)
+    }
+  })
+  .openapi(triggerSyncRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+    const id = c.req.param("id")
+    const connector = await getConnector(id)
+    if (!connector) {
+      return c.json({ error: "Not found" }, 404)
+    }
+    try {
+      const config = connector.config
+      const confluenceClient = getConfluenceClient(connector)
+      if (!confluenceClient) {
+        return c.json(
+          { error: "Confluence not connected — authorise via OAuth or add credentials" },
+          400,
+        )
+      }
+      if (!connector.githubRepoName || !config.githubToken) {
+        return c.json({ error: "GitHub configuration missing" }, 400)
+      }
+
+      const [owner, repo] = connector.githubRepoName.split("/")
+      if (!owner || !repo) {
+        return c.json({ error: "Invalid GitHub repository name" }, 400)
+      }
+
+      const confluenceConfig = buildConfluenceConfig(config)
+      if (!confluenceConfig) {
+        return c.json(
+          { error: "Confluence not connected — authorise via OAuth or add credentials" },
+          400,
+        )
+      }
+
+      const result = await syncOrchestrator.sync({
+        connectorId: id,
+        orgId: connector.orgId,
+        confluenceConfig,
+        githubConfig: {
+          token: config.githubToken,
+          owner,
+          repo,
+          branch: connector.githubBranch ?? "main",
+        },
+        syncMode: config.syncMode,
+      })
+
+      if (!result.success) {
+        return c.json({ error: result.error ?? "Sync failed" }, 500)
+      }
+
+      const syncLog = await getLatestSyncLog(id)
+      if (!syncLog) {
+        return c.json({ error: "Sync log not found" }, 500)
+      }
+
+      return c.json(logToResponse(syncLog), 200)
+    } catch (e) {
+      console.error("Error triggering sync", e)
+      return c.json({ error: "Internal server error" }, 500)
+    }
+  })
+  .openapi(listAvailableSpacesRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
+    const id = c.req.param("id")
+    const connector = await getConnector(id)
+    if (!connector) return c.json({ error: "Not found" }, 404)
+    const client = getConfluenceClient(connector)
+    if (!client) return c.json({ error: "Confluence credentials not configured" }, 400)
+    try {
+      const spaces = await client.listSpaces()
+      return c.json({ items: spaces }, 200)
+    } catch (e) {
+      console.error("Error listing Confluence spaces", e)
+      return c.json({ error: "Internal server error" }, 500)
+    }
+  })
+  .openapi(listSpacePagesRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
+    const id = c.req.param("id")
+    const spaceKey = c.req.param("spaceKey")
+    const parentId = c.req.query("parentId")
+    const connector = await getConnector(id)
+    if (!connector) return c.json({ error: "Not found" }, 404)
+    const client = getConfluenceClient(connector)
+    if (!client) return c.json({ error: "Confluence credentials not configured" }, 400)
+    try {
+      if (parentId) {
+        const pages = await client.getChildPageSummaries(parentId)
+        return c.json({ items: pages }, 200)
+      }
+      const space = await client.getSpace(spaceKey)
+      const pages = await client.getTopLevelPages(space.id, space.homepageId)
+      return c.json({ items: pages }, 200)
+    } catch (e) {
+      console.error("Error listing Confluence pages", e)
+      return c.json({ error: "Internal server error" }, 500)
+    }
+  })
+  .openapi(searchSpacePagesRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
+    const id = c.req.param("id")
+    const spaceKey = c.req.param("spaceKey")
+    const q = c.req.query("q") ?? ""
+    if (!q.trim()) return c.json({ items: [] }, 200)
+    const connector = await getConnector(id)
+    if (!connector) return c.json({ error: "Not found" }, 404)
+    const confluenceClient = getConfluenceClient(connector)
+    if (!confluenceClient) return c.json({ error: "Confluence credentials not configured" }, 400)
+    try {
+      const pages = await confluenceClient.searchPages(spaceKey, q)
+      return c.json({ items: pages }, 200)
+    } catch (e) {
+      console.error("Error searching Confluence pages", e)
+      return c.json({ error: "Internal server error" }, 500)
+    }
+  })
+  .openapi(saveScopeRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
+    const id = c.req.param("id")
+    // @ts-expect-error - zod-openapi typing
+    const body = c.req.valid("json") as z.infer<typeof SaveScopeRequestSchema>
+    const connector = await getConnector(id)
+    if (!connector) return c.json({ error: "Not found" }, 404)
+    const config = connector.config
+    if (!connector.githubRepoName || !config.githubToken) {
+      return c.json({ error: "GitHub configuration missing" }, 400)
+    }
+    try {
+      await replaceConnectorSpaces({
+        connectorId: id,
+        spaces: body.spaces.map((s) => ({
+          spaceKey: s.spaceKey,
+          spaceName: s.spaceName,
+          selectedPageIds: s.selectedPageIds ?? null,
+        })),
+      })
+
+      const [owner, repo] = connector.githubRepoName.split("/")
+
+      const confluenceConfigForScope = buildConfluenceConfig(config)
+      if (!confluenceConfigForScope) {
+        return c.json(
+          { error: "Confluence not connected — authorise via OAuth or add credentials" },
+          400,
+        )
+      }
+
+      const result = await syncOrchestrator.syncConfig({
+        connectorId: id,
+        orgId: connector.orgId,
+        confluenceConfig: confluenceConfigForScope,
+        githubConfig: {
+          token: config.githubToken,
+          owner: owner!,
+          repo: repo!,
+          branch: connector.githubBranch ?? "main",
+        },
+        syncMode: config.syncMode,
+      })
+
+      if (!result.success) {
+        return c.json({ error: result.error ?? "Config sync failed" }, 500)
+      }
+
+      return c.json(
+        {
+          noChange: result.noChange,
+          prNumber: result.prNumber ?? null,
+          prUrl: result.prUrl ?? null,
+        },
+        200,
+      )
+    } catch (e) {
+      console.error("Error saving scope", e)
+      return c.json({ error: "Internal server error" }, 500)
+    }
+  })
+  .openapi(oauthStartRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
+
+    const id = c.req.param("id")
+    const connector = await getConnector(id)
+    if (!connector) return c.json({ error: "Not found" }, 404)
+
+    const env = c.get("env")
+    const isCloud = connector.config.deploymentType !== "datacenter"
+
+    if (isCloud) {
+      if (!env.ATLASSIAN_CLIENT_ID) {
+        return c.json({ error: "ATLASSIAN_CLIENT_ID is not configured" }, 400)
+      }
+      if (!env.PUBLIC_URL) {
+        return c.json({ error: "PUBLIC_URL is not configured" }, 400)
+      }
+    } else {
+      if (!connector.config.oauthClientId || !connector.config.confluenceBaseUrl) {
+        return c.json({ error: "Data Center OAuth credentials not configured on this connector" }, 400)
+      }
+    }
+
+    const orgId = c.get("orgId") ?? connector.orgId
+    const orgSlug = c.get("orgSlug") ?? ""
+
+    const nonce = randomBytes(24).toString("hex")
+    await createOAuthState({ id: nonce, connectorId: id, orgId, orgSlug })
+
+    const callbackUrl = `${env.PUBLIC_URL}/oauth/atlassian/callback`
+    const scopes = [
+      // Classic scopes (v1 REST API + search)
+      "read:confluence-content.all",
+      "read:confluence-space.summary",
+      "read:confluence-content.summary",
+      "search:confluence",
+      // Granular scopes required by v2 API
+      "read:space:confluence",
+      "read:page:confluence",
+      "offline_access",
+    ].join(" ")
+
+    let authUrl: string
+    if (isCloud) {
+      // Build manually to get %20 for spaces — URLSearchParams uses + which
+      // some OAuth servers reject in the scope parameter.
+      authUrl =
+        `https://auth.atlassian.com/authorize` +
+        `?audience=${encodeURIComponent("api.atlassian.com")}` +
+        `&client_id=${encodeURIComponent(env.ATLASSIAN_CLIENT_ID!)}` +
+        `&scope=${encodeURIComponent(scopes)}` +
+        `&redirect_uri=${encodeURIComponent(callbackUrl)}` +
+        `&state=${nonce}` +
+        `&response_type=code` +
+        `&prompt=consent`
+    } else {
+      const baseUrl = connector.config.confluenceBaseUrl!.replace(/\/$/, "")
+      const params = new URLSearchParams({
+        client_id: connector.config.oauthClientId!,
+        redirect_uri: callbackUrl,
+        state: nonce,
+        response_type: "code",
+      })
+      authUrl = `${baseUrl}/rest/oauth2/latest/authorize?${params}`
+    }
+
+    return c.json({ url: authUrl }, 200)
+  })
+  .openapi(listSyncLogsRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+    const id = c.req.param("id")
+    const connector = await getConnector(id)
+    if (!connector) {
+      return c.json({ error: "Not found" }, 404)
+    }
+    const limit = c.req.query("limit")
+    const logs = await listSyncLogs(id, {
+      limit: limit ? parseInt(limit, 10) : 20,
+    })
+    return c.json(
+      {
+        items: logs.map((l) => logToResponse(l.connector_sync_logs)),
+      },
+      200,
+    )
+  })

--- a/apps/backend/src/routes/v1/index.ts
+++ b/apps/backend/src/routes/v1/index.ts
@@ -6,6 +6,7 @@ import {
   withCookieAuth,
   withNetworkOrgContext,
 } from "../../auth/withAuth.js"
+import { connectorRoutes } from "./connectors.js"
 import { conversationRoutes } from "./conversations.js"
 import { githubInstallationRoutes } from "./github-installation.js"
 import { repositoryRoutes } from "./repositories.js"
@@ -19,6 +20,7 @@ export function registerV1Routes(app: OpenAPIHono<AppEnv>) {
     .use("*", withBearerAuth)
     .use("*", requireAuth)
     .use("*", withNetworkOrgContext)
+    .route("/connectors", connectorRoutes)
     .route("/repositories", repositoryRoutes)
     .route("/conversations", conversationRoutes)
     .route("/github/installation", githubInstallationRoutes)

--- a/apps/backend/src/services/config-yaml.ts
+++ b/apps/backend/src/services/config-yaml.ts
@@ -1,0 +1,120 @@
+import type { GitHubClient } from "./github/client.js"
+
+export interface SpaceScope {
+  key: string
+  name?: string | null
+  selectedPageIds?: string[] | null
+}
+
+export interface ConnectorYamlConfig {
+  type: string
+  baseUrl?: string
+  spaces: SpaceScope[]
+}
+
+export function generateConnectorYaml(config: ConnectorYamlConfig): string {
+  const lines: string[] = [
+    "# ctxpipe connector configuration",
+    "# Changes to this file trigger a pull request for review.",
+    `version: 1`,
+    `type: ${config.type}`,
+  ]
+
+  if (config.baseUrl) {
+    lines.push(`baseUrl: ${config.baseUrl}`)
+  }
+
+  lines.push("spaces:")
+
+  for (const space of config.spaces) {
+    lines.push(`  - key: ${space.key}`)
+    if (space.name) {
+      lines.push(`    name: ${yamlQuote(space.name)}`)
+    }
+    if (space.selectedPageIds && space.selectedPageIds.length > 0) {
+      lines.push("    pages:")
+      for (const pageId of space.selectedPageIds) {
+        lines.push(`      - "${pageId}"`)
+      }
+    }
+  }
+
+  return lines.join("\n") + "\n"
+}
+
+function yamlQuote(value: string): string {
+  if (/[:#\[\]{}&*!,|>'"?]/.test(value) || value.includes("\n")) {
+    return `"${value.replace(/"/g, '\\"')}"`
+  }
+  return value
+}
+
+export async function readCurrentYaml(
+  github: GitHubClient,
+  path: string,
+): Promise<string | null> {
+  try {
+    return await github.getFileContent(path)
+  } catch {
+    return null
+  }
+}
+
+export async function syncConfigYaml(options: {
+  github: GitHubClient
+  connectorType: string
+  config: ConnectorYamlConfig
+  branch: string
+}): Promise<{ prNumber: number; prUrl: string } | null> {
+  const { github, connectorType, config, branch } = options
+  const configPath = `${connectorType}/config.yaml`
+  const newYaml = generateConnectorYaml(config)
+
+  const existingYaml = await readCurrentYaml(github, configPath)
+
+  if (existingYaml !== null && existingYaml.trim() === newYaml.trim()) {
+    return null
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
+  const branchName = `${connectorType}-config/${timestamp}`
+
+  const pr = await github.createPullRequestWithFiles({
+    title: `Update ${connectorType} connector scope`,
+    body: generateConfigPRBody(connectorType, config, existingYaml === null),
+    branchName,
+    base: branch,
+    files: [{ path: configPath, content: newYaml }],
+  })
+
+  return pr
+}
+
+function generateConfigPRBody(
+  connectorType: string,
+  config: ConnectorYamlConfig,
+  isInitial: boolean,
+): string {
+  const spaceList = config.spaces
+    .map((s) => {
+      const pagesNote =
+        s.selectedPageIds && s.selectedPageIds.length > 0
+          ? ` (${s.selectedPageIds.length} page(s) selected)`
+          : " (all pages)"
+      return `- **${s.key}**${s.name ? ` — ${s.name}` : ""}${pagesNote}`
+    })
+    .join("\n")
+
+  return [
+    isInitial
+      ? `## Initial ${connectorType} connector configuration`
+      : `## Updated ${connectorType} connector scope`,
+    "",
+    isInitial
+      ? "This PR records the initial connector scope in version control."
+      : "This PR records a scope change made via the ctxpipe UI. The change is already active — this PR exists for review and audit purposes.",
+    "",
+    "### Spaces",
+    spaceList,
+  ].join("\n")
+}

--- a/apps/backend/src/services/confluence/client.ts
+++ b/apps/backend/src/services/confluence/client.ts
@@ -1,0 +1,387 @@
+import { z } from "zod"
+
+const ConfluencePageSchema = z.object({
+  id: z.string(),
+  status: z.string(),
+  title: z.string(),
+  spaceId: z.string(),
+  parentId: z.string().optional(),
+  version: z.object({
+    number: z.number(),
+    createdAt: z.string(),
+  }),
+  body: z.object({
+    storage: z.object({
+      value: z.string(),
+      representation: z.string(),
+    }),
+  }),
+})
+
+const ConfluenceSpaceSchema = z.object({
+  id: z.string(),
+  key: z.string(),
+  name: z.string(),
+  type: z.string(),
+  // homepageId is the root page of the space; its children are the "top-level" content pages
+  homepageId: z.string().optional(),
+})
+
+const ConfluencePageSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  // spaceId may be absent in /pages/{id}/children responses; make optional
+  // to prevent safeParse from silently dropping valid child pages
+  spaceId: z.string().optional(),
+  parentId: z.string().optional(),
+  childrenCount: z.number().optional(),
+})
+
+export type ConfluencePage = z.infer<typeof ConfluencePageSchema>
+export type ConfluenceSpace = z.infer<typeof ConfluenceSpaceSchema>
+export type ConfluencePageSummary = z.infer<typeof ConfluencePageSummarySchema>
+
+export type ConfluenceClientConfig =
+  | {
+      authType: "basic"
+      baseUrl: string
+      email: string
+      apiToken: string
+    }
+  | {
+      authType: "oauth"
+      /** Confluence API base — e.g. https://api.atlassian.com/ex/confluence/{cloudId} (Cloud)
+       *  or https://confluence.company.com (DC) */
+      apiBaseUrl: string
+      refreshToken: string
+      clientId: string
+      clientSecret: string
+      /** Token endpoint — Atlassian Cloud or DC instance URL */
+      tokenUrl: string
+    }
+
+export class ConfluenceClient {
+  private config: ConfluenceClientConfig
+  private cachedAccessToken: string | null = null
+  private cachedTokenExpiry = 0
+
+  constructor(config: ConfluenceClientConfig) {
+    this.config = config
+  }
+
+  private get apiBaseUrl(): string {
+    return this.config.authType === "basic"
+      ? this.config.baseUrl.replace(/\/$/, "")
+      : this.config.apiBaseUrl.replace(/\/$/, "")
+  }
+
+  private async getAuthHeader(): Promise<string> {
+    if (this.config.authType === "basic") {
+      const creds = Buffer.from(
+        `${this.config.email}:${this.config.apiToken}`,
+      ).toString("base64")
+      return `Basic ${creds}`
+    }
+    // OAuth — refresh access token if missing or expiring within 60s
+    if (!this.cachedAccessToken || Date.now() >= this.cachedTokenExpiry - 60_000) {
+      await this.refreshAccessToken()
+    }
+    return `Bearer ${this.cachedAccessToken}`
+  }
+
+  private async refreshAccessToken(): Promise<void> {
+    if (this.config.authType !== "oauth") return
+    const res = await fetch(this.config.tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: this.config.clientId,
+        client_secret: this.config.clientSecret,
+        refresh_token: this.config.refreshToken,
+      }),
+    })
+    if (!res.ok) {
+      const err = await res.text()
+      throw new Error(`Confluence token refresh failed: ${res.status} - ${err}`)
+    }
+    const data = (await res.json()) as { access_token: string; expires_in: number }
+    this.cachedAccessToken = data.access_token
+    this.cachedTokenExpiry = Date.now() + data.expires_in * 1000
+  }
+
+  private async request<T>(
+    endpoint: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const url = `${this.apiBaseUrl}/wiki/api/v2${endpoint}`
+    const authHeader = await this.getAuthHeader()
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: authHeader,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(
+        `Confluence API error: ${response.status} ${response.statusText} - ${error}`,
+      )
+    }
+
+    return response.json() as Promise<T>
+  }
+
+  private async requestV1<T>(
+    endpoint: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const url = `${this.apiBaseUrl}/wiki/rest/api${endpoint}`
+    const authHeader = await this.getAuthHeader()
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: authHeader,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(
+        `Confluence API error: ${response.status} ${response.statusText} - ${error}`,
+      )
+    }
+
+    return response.json() as Promise<T>
+  }
+
+  async getSpace(spaceKey: string): Promise<ConfluenceSpace> {
+    const data = await this.request<{
+      results: Array<{
+        id: string
+        key: string
+        name: string
+        type: string
+        homepageId?: string
+      }>
+    }>(`/spaces?keys=${encodeURIComponent(spaceKey)}&limit=250`)
+
+    const returnedKeys = data.results.map((r) => r.key)
+
+    // Find by key — defensive against the API ignoring the filter and returning all spaces
+    const match = data.results.find((r) => r.key === spaceKey)
+    if (!match) {
+      throw new Error(
+        `Space not found: ${spaceKey}. API returned keys: [${returnedKeys.join(", ")}]`,
+      )
+    }
+
+    return ConfluenceSpaceSchema.parse(match)
+  }
+
+  async *getPagesInSpace(
+    spaceId: string,
+    options: { limit?: number; cursor?: string } = {},
+  ): AsyncGenerator<ConfluencePage, void, unknown> {
+    const limit = options.limit ?? 50
+    let cursor = options.cursor
+
+    while (true) {
+      const params = new URLSearchParams({
+        limit: limit.toString(),
+        status: "current",
+        "body-format": "storage",
+      })
+
+      if (cursor) {
+        params.append("cursor", cursor)
+      }
+
+      const data = await this.request<{
+        results: unknown[]
+        _links: {
+          next?: string
+        }
+      }>(`/spaces/${spaceId}/pages?${params.toString()}`)
+
+      for (const page of data.results) {
+        const parsed = ConfluencePageSchema.safeParse(page)
+        if (parsed.success) {
+          yield parsed.data
+        } else {
+          console.warn("Confluence page failed schema validation:", JSON.stringify(parsed.error.issues))
+        }
+      }
+
+      if (!data._links.next) {
+        break
+      }
+
+      const nextUrl = new URL(data._links.next, "https://dummy.invalid")
+      cursor = nextUrl.searchParams.get("cursor") ?? undefined
+      if (!cursor) break
+    }
+  }
+
+  async getPage(pageId: string): Promise<ConfluencePage> {
+    const data = await this.request<unknown>(
+      `/pages/${pageId}?body-format=storage`,
+    )
+    return ConfluencePageSchema.parse(data)
+  }
+
+  async getChildPages(pageId: string): Promise<ConfluencePage[]> {
+    const data = await this.request<{
+      results: unknown[]
+    }>(`/pages/${pageId}/children`)
+
+    return data.results
+      .map((page) => ConfluencePageSchema.safeParse(page))
+      .filter(
+        (result): result is { success: true; data: ConfluencePage } =>
+          result.success,
+      )
+      .map((result) => result.data)
+  }
+
+  async listSpaces(limit = 250): Promise<ConfluenceSpace[]> {
+    const allSpaces: ConfluenceSpace[] = []
+    let cursor: string | undefined
+    let page = 0
+
+    while (true) {
+      page++
+      const params = new URLSearchParams({ limit: limit.toString() })
+      if (cursor) params.append("cursor", cursor)
+
+      const data = await this.request<{
+        results: unknown[]
+        _links: { next?: string }
+      }>(`/spaces?${params.toString()}`)
+
+      for (const space of data.results) {
+        const parsed = ConfluenceSpaceSchema.safeParse(space)
+        if (parsed.success) {
+          allSpaces.push(parsed.data)
+        } else {
+          console.warn("[spaces] space failed schema validation:", JSON.stringify(parsed.error.issues))
+        }
+      }
+
+      if (!data._links.next) break
+
+      const nextUrl = new URL(data._links.next, "https://dummy.invalid")
+      cursor = nextUrl.searchParams.get("cursor") ?? undefined
+      if (!cursor) break
+    }
+
+    return allSpaces
+  }
+
+  /**
+   * Returns the pages that should appear at the top level when browsing a space.
+   *
+   * Confluence Cloud's `depth=root` only returns the single space homepage,
+   * which is not useful for navigation. Instead, we fetch the children of
+   * the homepage so users see the real top-level content sections.
+   * Falls back to depth=root if no homepageId is available.
+   */
+  async getTopLevelPages(
+    spaceId: string,
+    homepageId?: string,
+  ): Promise<ConfluencePageSummary[]> {
+    if (homepageId) {
+      return this.getChildPageSummaries(homepageId)
+    }
+
+    // Fallback: depth=root (returns the homepage itself)
+    const params = new URLSearchParams({
+      spaceId,
+      depth: "root",
+      limit: "100",
+      status: "current",
+    })
+    const data = await this.request<{ results: unknown[] }>(
+      `/pages?${params.toString()}`,
+    )
+    const pages: ConfluencePageSummary[] = []
+    for (const page of data.results) {
+      const parsed = ConfluencePageSummarySchema.safeParse(page)
+      if (parsed.success) {
+        pages.push(parsed.data)
+      } else {
+        console.warn("[confluence] root page failed schema parse:", parsed.error.issues, page)
+      }
+    }
+    return pages
+  }
+
+  async getChildPageSummaries(
+    pageId: string,
+  ): Promise<ConfluencePageSummary[]> {
+    const data = await this.request<{ results: unknown[] }>(
+      `/pages/${pageId}/children?limit=100`,
+    )
+
+    const pages: ConfluencePageSummary[] = []
+    for (const page of data.results) {
+      const parsed = ConfluencePageSummarySchema.safeParse(page)
+      if (parsed.success) {
+        pages.push(parsed.data)
+      } else {
+        console.warn("[confluence] child page failed schema parse:", parsed.error.issues, page)
+      }
+    }
+    return pages
+  }
+
+  /**
+   * Search pages within a space by title using CQL (Confluence Query Language).
+   * Uses the v1 REST API which supports full-text CQL search.
+   */
+  async searchPages(
+    spaceKey: string,
+    query: string,
+    limit = 25,
+  ): Promise<ConfluencePageSummary[]> {
+    // Use wildcard ~"*term*" instead of plain ~"term" so Confluence does a
+    // term-level wildcard search rather than full-text analysis. Full-text
+    // analysis strips punctuation (e.g. "&") which breaks queries like "R&D".
+    const safe = query.replace(/"/g, "").replace(/\*/g, "").trim()
+    const cql = `type=page AND space.key="${spaceKey}" AND title ~ "*${safe}*"`
+    const params = new URLSearchParams({
+      cql,
+      limit: limit.toString(),
+      expand: "space",
+    })
+    const url = `${this.apiBaseUrl}/wiki/rest/api/content/search?${params.toString()}`
+    const authHeader = await this.getAuthHeader()
+    const response = await fetch(url, {
+      headers: {
+        Authorization: authHeader,
+        Accept: "application/json",
+      },
+    })
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(
+        `Confluence search error: ${response.status} ${response.statusText} - ${error}`,
+      )
+    }
+    const data = (await response.json()) as {
+      results: Array<{ id: string; title: string; space?: { id: string } }>
+    }
+    return data.results.map((r) => ({
+      id: r.id,
+      title: r.title,
+      spaceId: r.space?.id ?? "",
+    }))
+  }
+}

--- a/apps/backend/src/services/confluence/config.ts
+++ b/apps/backend/src/services/confluence/config.ts
@@ -1,0 +1,50 @@
+import { decrypt } from "../crypto.js"
+import type { ConfluenceClientConfig } from "./client.js"
+
+type ConnectorConfig = {
+  confluenceBaseUrl?: string
+  confluenceEmail?: string
+  confluenceApiToken?: string
+  deploymentType?: string
+  cloudId?: string
+  oauthRefreshToken?: string
+  oauthClientId?: string
+  oauthClientSecret?: string
+}
+
+/**
+ * Build a ConfluenceClientConfig from a connector's stored config.
+ * Returns null if neither OAuth nor basic-auth credentials are present.
+ */
+export function buildConfluenceConfig(config: ConnectorConfig): ConfluenceClientConfig | null {
+  if (config.oauthRefreshToken) {
+    const isCloud = config.deploymentType !== "datacenter"
+    return {
+      authType: "oauth",
+      apiBaseUrl: isCloud
+        ? `https://api.atlassian.com/ex/confluence/${config.cloudId}`
+        : (config.confluenceBaseUrl ?? "").replace(/\/$/, ""),
+      refreshToken: decrypt(config.oauthRefreshToken),
+      clientId: isCloud
+        ? (process.env.ATLASSIAN_CLIENT_ID ?? "")
+        : (config.oauthClientId ?? ""),
+      clientSecret: isCloud
+        ? (process.env.ATLASSIAN_CLIENT_SECRET ?? "")
+        : (config.oauthClientSecret ?? ""),
+      tokenUrl: isCloud
+        ? "https://auth.atlassian.com/oauth/token"
+        : `${(config.confluenceBaseUrl ?? "").replace(/\/$/, "")}/rest/oauth2/latest/token`,
+    }
+  }
+
+  if (config.confluenceBaseUrl && config.confluenceEmail && config.confluenceApiToken) {
+    return {
+      authType: "basic",
+      baseUrl: config.confluenceBaseUrl,
+      email: config.confluenceEmail,
+      apiToken: config.confluenceApiToken,
+    }
+  }
+
+  return null
+}

--- a/apps/backend/src/services/confluence/converter.ts
+++ b/apps/backend/src/services/confluence/converter.ts
@@ -1,0 +1,185 @@
+import { ConfluencePage } from "./client.js"
+
+interface ConversionResult {
+  markdown: string
+  frontmatter: Record<string, string>
+}
+
+export class ConfluenceToMarkdownConverter {
+  convert(page: ConfluencePage): ConversionResult {
+    const html = page.body.storage.value
+    const markdown = this.htmlToMarkdown(html)
+
+    return {
+      markdown,
+      frontmatter: {
+        title: page.title,
+        confluence_id: page.id,
+        confluence_space: page.spaceId,
+        version: page.version.number.toString(),
+        last_modified: page.version.createdAt,
+      },
+    }
+  }
+
+  private htmlToMarkdown(html: string): string {
+    let md = html
+
+    md = md.replace(/\n\s*/g, " ")
+
+    md = md.replace(
+      /\u003ch1[^\u003e]*\u003e(.*?)\u003c\/h1\u003e/gi,
+      "# $1\n\n",
+    )
+    md = md.replace(
+      /\u003ch2[^\u003e]*\u003e(.*?)\u003c\/h2\u003e/gi,
+      "## $1\n\n",
+    )
+    md = md.replace(
+      /\u003ch3[^\u003e]*\u003e(.*?)\u003c\/h3\u003e/gi,
+      "### $1\n\n",
+    )
+    md = md.replace(
+      /\u003ch4[^\u003e]*\u003e(.*?)\u003c\/h4\u003e/gi,
+      "#### $1\n\n",
+    )
+    md = md.replace(
+      /\u003ch5[^\u003e]*\u003e(.*?)\u003c\/h5\u003e/gi,
+      "##### $1\n\n",
+    )
+    md = md.replace(
+      /\u003ch6[^\u003e]*\u003e(.*?)\u003c\/h6\u003e/gi,
+      "###### $1\n\n",
+    )
+
+    md = md.replace(/\u003cp\u003e(.*?)\u003c\/p\u003e/gi, "$1\n\n")
+
+    md = md.replace(/\u003cstrong\u003e(.*?)\u003c\/strong\u003e/gi, "**$1**")
+    md = md.replace(/\u003cb\u003e(.*?)\u003c\/b\u003e/gi, "**$1**")
+
+    md = md.replace(/\u003cem\u003e(.*?)\u003c\/em\u003e/gi, "_$1_")
+    md = md.replace(/\u003ci\u003e(.*?)\u003c\/i\u003e/gi, "_$1_")
+
+    md = md.replace(/\u003ccode\u003e(.*?)\u003c\/code\u003e/gi, "`$1`")
+
+    md = md.replace(
+      /\u003cpre\u003e\u003ccode\u003e([\s\S]*?)\u003c\/code\u003e\u003c\/pre\u003e/gi,
+      "```\n$1\n```\n\n",
+    )
+
+    md = md.replace(
+      /\u003ca\s+href="([^"]+)"[^\u003e]*\u003e(.*?)\u003c\/a\u003e/gi,
+      "[$2]($1)",
+    )
+
+    md = md.replace(
+      /\u003cul\u003e([\s\S]*?)\u003c\/ul\u003e/gi,
+      (match, content) => {
+        const items = content.replace(
+          /\u003cli\u003e(.*?)\u003c\/li\u003e/gi,
+          "- $1\n",
+        )
+        return items + "\n"
+      },
+    )
+
+    md = md.replace(
+      /\u003col\u003e([\s\S]*?)\u003c\/ol\u003e/gi,
+      (match, content) => {
+        let index = 1
+        const items = content.replace(
+          /\u003cli\u003e(.*?)\u003c\/li\u003e/gi,
+          () => {
+            const result = `${index}. $1\n`
+            index++
+            return result
+          },
+        )
+        return items + "\n"
+      },
+    )
+
+    md = md.replace(/\u003cbr\s*\/?\u003e/gi, "\n")
+    md = md.replace(/\u003chr\s*\/?\u003e/gi, "---\n\n")
+
+    md = md.replace(
+      /\u003ctable[^\u003e]*\u003e([\s\S]*?)\u003c\/table\u003e/gi,
+      (match) => {
+        return this.convertTable(match)
+      },
+    )
+
+    md = md.replace(/\u003c[^\u003e]+\u003e/g, "")
+
+    md = md.replace(/&lt;/g, "<")
+    md = md.replace(/&gt;/g, ">")
+    md = md.replace(/&amp;/g, "&")
+    md = md.replace(/&quot;/g, '"')
+    md = md.replace(/&#39;/g, "'")
+    md = md.replace(/&nbsp;/g, " ")
+
+    md = md.replace(/\n{3,}/g, "\n\n")
+    md = md.trim()
+
+    return md
+  }
+
+  private convertTable(tableHtml: string): string {
+    const rows: string[][] = []
+
+    const trMatches =
+      tableHtml.match(/\u003ctr[^\u003e]*\u003e([\s\S]*?)\u003c\/tr\u003e/gi) ||
+      []
+
+    for (const tr of trMatches) {
+      const cells: string[] = []
+      const cellMatches =
+        tr.match(
+          /\u003c(?:td|th)[^\u003e]*\u003e([\s\S]*?)\u003c\/(?:td|th)\u003e/gi,
+        ) || []
+
+      for (const cell of cellMatches) {
+        const content = cell.replace(/\u003c[^\u003e]+\u003e/g, "").trim()
+        cells.push(content)
+      }
+
+      if (cells.length > 0) {
+        rows.push(cells)
+      }
+    }
+
+    if (rows.length === 0) {
+      return ""
+    }
+
+    let markdown = ""
+
+    const headers = rows[0]
+    markdown += "| " + headers.join(" | ") + " |\n"
+    markdown += "| " + headers.map(() => "---").join(" | ") + " |\n"
+
+    for (let i = 1; i < rows.length; i++) {
+      markdown += "| " + rows[i].join(" | ") + " |\n"
+    }
+
+    return markdown + "\n"
+  }
+
+  generateFilePath(page: ConfluencePage, spaceKey: string): string {
+    const slug = page.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .substring(0, 100)
+
+    return `confluence/${spaceKey}/${slug}.md`
+  }
+
+  formatWithFrontmatter(result: ConversionResult): string {
+    const frontmatter = Object.entries(result.frontmatter)
+      .map(([key, value]) => `${key}: "${value.replace(/"/g, '\\"')}"`)
+      .join("\n")
+
+    return `---\n${frontmatter}\n---\n\n${result.markdown}`
+  }
+}

--- a/apps/backend/src/services/confluence/index.ts
+++ b/apps/backend/src/services/confluence/index.ts
@@ -1,0 +1,8 @@
+export { ConfluenceClient, type ConfluenceClientConfig } from "./client.js"
+export { ConfluenceToMarkdownConverter } from "./converter.js"
+export {
+  ConfluenceSyncOrchestrator,
+  syncOrchestrator,
+  type SyncOptions,
+  type SyncResult,
+} from "./sync.js"

--- a/apps/backend/src/services/confluence/sync.ts
+++ b/apps/backend/src/services/confluence/sync.ts
@@ -1,0 +1,272 @@
+import {
+  completeSyncLog,
+  createSyncLog,
+  type SyncLogRecord,
+} from "../../models/connector-sync-logs.js"
+import {
+  listConnectorSpaces,
+  updateConnectorSpace,
+} from "../../models/connector-spaces.js"
+import { getConnector, updateConnector } from "../../models/connectors.js"
+import {
+  generateConnectorYaml,
+  syncConfigYaml,
+  type ConnectorYamlConfig,
+} from "../config-yaml.js"
+import { ConfluenceClient, type ConfluenceClientConfig } from "./client.js"
+import { ConfluenceToMarkdownConverter } from "./converter.js"
+import { GitHubClient, type FileChange } from "../github/client.js"
+
+export interface SyncOptions {
+  connectorId: string
+  orgId: string
+  confluenceConfig: ConfluenceClientConfig
+  githubConfig: {
+    token: string
+    owner: string
+    repo: string
+    branch: string
+  }
+  syncMode: "pr" | "auto"
+}
+
+export interface SyncResult {
+  success: boolean
+  pagesAdded: number
+  pagesUpdated: number
+  pagesDeleted: number
+  prNumber?: number
+  prUrl?: string
+  error?: string
+}
+
+export interface ConfigSyncResult {
+  success: boolean
+  prNumber?: number
+  prUrl?: string
+  noChange?: boolean
+  error?: string
+}
+
+export class ConfluenceSyncOrchestrator {
+  private converter = new ConfluenceToMarkdownConverter()
+
+  // Content sync — direct commit to main (no PR).
+  // Respects selectedPageIds per space.
+  async sync(options: SyncOptions): Promise<SyncResult> {
+    const syncLog = await createSyncLog({
+      connectorId: options.connectorId,
+      status: "started",
+    })
+
+    try {
+      const result = await this.performContentSync(options, syncLog)
+
+      await completeSyncLog(syncLog.id, {
+        status: result.success ? "completed" : "failed",
+        prNumber: result.prNumber,
+        prUrl: result.prUrl,
+        pagesAdded: result.pagesAdded,
+        pagesUpdated: result.pagesUpdated,
+        pagesDeleted: result.pagesDeleted,
+        errorMessage: result.error,
+      })
+
+      if (result.success) {
+        await updateConnector(options.connectorId, {
+          lastSyncAt: new Date(),
+          lastPrNumber: result.prNumber,
+        })
+      }
+
+      return result
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error"
+
+      await completeSyncLog(syncLog.id, {
+        status: "failed",
+        errorMessage,
+      })
+
+      return {
+        success: false,
+        pagesAdded: 0,
+        pagesUpdated: 0,
+        pagesDeleted: 0,
+        error: errorMessage,
+      }
+    }
+  }
+
+  // Config sync — generates config.yaml and opens a PR if it differs from main.
+  async syncConfig(options: SyncOptions): Promise<ConfigSyncResult> {
+    const connector = await getConnector(options.connectorId)
+    if (!connector) {
+      return { success: false, error: `Connector not found: ${options.connectorId}` }
+    }
+
+    const spaces = await listConnectorSpaces(options.connectorId)
+    if (spaces.length === 0) {
+      return {
+        success: false,
+        error: "No spaces configured. Add at least one space before saving config.",
+      }
+    }
+
+    const github = new GitHubClient(options.githubConfig)
+
+    const yamlConfig: ConnectorYamlConfig = {
+      type: "confluence",
+      baseUrl: connector.config.confluenceBaseUrl,
+      spaces: spaces.map((s) => ({
+        key: s.spaceKey,
+        name: s.spaceName,
+        selectedPageIds: s.selectedPageIds,
+      })),
+    }
+
+    try {
+      const pr = await syncConfigYaml({
+        github,
+        connectorType: "confluence",
+        config: yamlConfig,
+        branch: options.githubConfig.branch,
+      })
+
+      if (!pr) {
+        return { success: true, noChange: true }
+      }
+
+      return { success: true, prNumber: pr.number, prUrl: pr.url }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error"
+      return { success: false, error: errorMessage }
+    }
+  }
+
+  private async performContentSync(
+    options: SyncOptions,
+    _syncLog: SyncLogRecord,
+  ): Promise<SyncResult> {
+    const connector = await getConnector(options.connectorId)
+    if (!connector) {
+      throw new Error(`Connector not found: ${options.connectorId}`)
+    }
+
+    const confluence = new ConfluenceClient(options.confluenceConfig)
+    const github = new GitHubClient(options.githubConfig)
+
+    const spaces = await listConnectorSpaces(options.connectorId)
+    if (spaces.length === 0) {
+      return {
+        success: false,
+        pagesAdded: 0,
+        pagesUpdated: 0,
+        pagesDeleted: 0,
+        error: "No spaces configured. Add at least one Confluence space key to the connector.",
+      }
+    }
+
+    const files: FileChange[] = []
+    let pagesAdded = 0
+    let pagesUpdated = 0
+
+    for (const space of spaces) {
+      const confluenceSpace = await confluence.getSpace(space.spaceKey)
+
+      for await (const page of confluence.getPagesInSpace(confluenceSpace.id)) {
+        // Defensive: discard any page the API returns that doesn't belong to this space
+        if (page.spaceId !== confluenceSpace.id) {
+          console.warn(`[sync] skipping page id=${page.id} spaceId=${page.spaceId} (expected ${confluenceSpace.id})`)
+          continue
+        }
+
+        // Filter by selectedPageIds if set
+        if (
+          space.selectedPageIds !== null &&
+          space.selectedPageIds !== undefined &&
+          !space.selectedPageIds.includes(page.id)
+        ) {
+          continue
+        }
+
+        const conversion = this.converter.convert(page)
+        // Files go under confluence/{spaceKey}/ within the repo
+        const filePath = this.converter.generateFilePath(page, space.spaceKey)
+        const content = this.converter.formatWithFrontmatter(conversion)
+
+        files.push({ path: filePath, content })
+
+        if (space.lastSyncedPageId) {
+          pagesUpdated++
+        } else {
+          pagesAdded++
+        }
+
+        await updateConnectorSpace(space.id, {
+          lastSyncedPageId: page.id,
+          lastSyncedAt: new Date(),
+        })
+      }
+
+    }
+
+    if (files.length === 0) {
+      return {
+        success: false,
+        pagesAdded: 0,
+        pagesUpdated: 0,
+        pagesDeleted: 0,
+        error: "No pages found in the configured Confluence spaces.",
+      }
+    }
+
+    // Always include a current config.yaml snapshot so the directory is
+    // self-documenting even before the user has run a scope-config PR.
+    const yamlConfig: ConnectorYamlConfig = {
+      type: "confluence",
+      baseUrl: connector.config.confluenceBaseUrl,
+      spaces: spaces.map((s) => ({
+        key: s.spaceKey,
+        name: s.spaceName,
+        selectedPageIds: s.selectedPageIds,
+      })),
+    }
+    files.push({
+      path: "confluence/config.yaml",
+      content: generateConnectorYaml(yamlConfig),
+    })
+
+    // Compute deletions: any file currently in confluence/ that isn't being
+    // written in this sync is either out of scope or was deleted in Confluence.
+    const newPaths = new Set(files.map((f) => f.path))
+    const existingPaths = await github.listFilesInTree(
+      options.githubConfig.branch,
+      "confluence/",
+    )
+    const deletions = existingPaths.filter((p) => !newPaths.has(p))
+    if (deletions.length > 0) {
+      console.log(`[sync] deleting ${deletions.length} out-of-scope file(s) from GitHub`)
+    }
+
+    // Content changes commit directly to main — no PR
+    await github.commitFiles(
+      options.githubConfig.branch,
+      `chore: sync Confluence content - ${new Date().toISOString()}`,
+      files,
+      deletions,
+    )
+
+    return {
+      success: true,
+      pagesAdded,
+      pagesUpdated,
+      pagesDeleted: deletions.length,
+    }
+  }
+
+}
+
+export const syncOrchestrator = new ConfluenceSyncOrchestrator()

--- a/apps/backend/src/services/github/client.ts
+++ b/apps/backend/src/services/github/client.ts
@@ -1,0 +1,310 @@
+import { z } from "zod"
+
+const GitHubFileChangeSchema = z.object({
+  path: z.string(),
+  content: z.string(),
+})
+
+const GitHubTreeItemSchema = z.object({
+  path: z.string(),
+  mode: z.string(),
+  type: z.string(),
+  content: z.string(),
+})
+
+export type FileChange = z.infer<typeof GitHubFileChangeSchema>
+
+export interface GitHubClientConfig {
+  token: string
+  owner: string
+  repo: string
+}
+
+export interface CreatePROptions {
+  title: string
+  body: string
+  head: string
+  base: string
+}
+
+export interface CreatePRResult {
+  number: number
+  url: string
+}
+
+export class GitHubClient {
+  private token: string
+  private owner: string
+  private repo: string
+  private baseUrl = "https://api.github.com"
+
+  constructor(config: GitHubClientConfig) {
+    this.token = config.token
+    this.owner = config.owner
+    this.repo = config.repo
+  }
+
+  private async request<T>(
+    endpoint: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(
+        `GitHub API error: ${response.status} ${response.statusText} - ${error}`,
+      )
+    }
+
+    return response.json() as Promise<T>
+  }
+
+  async getDefaultBranch(): Promise<string> {
+    const data = await this.request<{ default_branch: string }>(
+      `/repos/${this.owner}/${this.repo}`,
+    )
+    return data.default_branch
+  }
+
+  async getBranchRef(branch: string): Promise<string> {
+    const data = await this.request<{ object: { sha: string } }>(
+      `/repos/${this.owner}/${this.repo}/git/refs/heads/${branch}`,
+    )
+    return data.object.sha
+  }
+
+  async createBranch(branchName: string, fromSha: string): Promise<void> {
+    await this.request(`/repos/${this.owner}/${this.repo}/git/refs`, {
+      method: "POST",
+      body: JSON.stringify({
+        ref: `refs/heads/${branchName}`,
+        sha: fromSha,
+      }),
+    })
+  }
+
+  async createBlob(content: string): Promise<string> {
+    const data = await this.request<{ sha: string }>(
+      `/repos/${this.owner}/${this.repo}/git/blobs`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          content,
+          encoding: "utf-8",
+        }),
+      },
+    )
+    return data.sha
+  }
+
+  async createTree(
+    baseTreeSha: string,
+    files: FileChange[],
+    deletions: string[] = [],
+  ): Promise<string> {
+    const tree = [
+      ...files.map((file) => ({
+        path: file.path,
+        mode: "100644" as const,
+        type: "blob" as const,
+        content: file.content,
+      })),
+      // sha: null removes the file from the tree
+      ...deletions.map((path) => ({
+        path,
+        mode: "100644" as const,
+        type: "blob" as const,
+        sha: null,
+      })),
+    ]
+
+    const data = await this.request<{ sha: string }>(
+      `/repos/${this.owner}/${this.repo}/git/trees`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          base_tree: baseTreeSha,
+          tree,
+        }),
+      },
+    )
+    return data.sha
+  }
+
+  /** Returns all blob paths under the given path prefix on the given branch. */
+  async listFilesInTree(branch: string, prefix: string): Promise<string[]> {
+    try {
+      const sha = await this.getBranchRef(branch)
+      const data = await this.request<{
+        tree: Array<{ path: string; type: string }>
+        truncated: boolean
+      }>(`/repos/${this.owner}/${this.repo}/git/trees/${sha}?recursive=1`)
+
+      if (data.truncated) {
+        console.warn("[github] tree response truncated — large repo, some deletions may be missed")
+      }
+
+      return data.tree
+        .filter((item) => item.type === "blob" && item.path.startsWith(prefix))
+        .map((item) => item.path)
+    } catch (err) {
+      console.warn(`[github] listFilesInTree failed (branch=${branch}, prefix=${prefix}):`, err)
+      return []
+    }
+  }
+
+  async createCommit(
+    message: string,
+    treeSha: string,
+    parentSha: string,
+  ): Promise<string> {
+    const data = await this.request<{ sha: string }>(
+      `/repos/${this.owner}/${this.repo}/git/commits`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          message,
+          tree: treeSha,
+          parents: [parentSha],
+        }),
+      },
+    )
+    return data.sha
+  }
+
+  async updateBranchRef(branch: string, commitSha: string): Promise<void> {
+    await this.request(
+      `/repos/${this.owner}/${this.repo}/git/refs/heads/${branch}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          sha: commitSha,
+        }),
+      },
+    )
+  }
+
+  async createPullRequest(options: CreatePROptions): Promise<CreatePRResult> {
+    const data = await this.request<{ number: number; html_url: string }>(
+      `/repos/${this.owner}/${this.repo}/pulls`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          title: options.title,
+          body: options.body,
+          head: options.head,
+          base: options.base,
+        }),
+      },
+    )
+
+    return {
+      number: data.number,
+      url: data.html_url,
+    }
+  }
+
+  async commitFiles(
+    branch: string,
+    message: string,
+    files: FileChange[],
+    deletions: string[] = [],
+  ): Promise<void> {
+    const baseRef = await this.getBranchRef(branch)
+    const treeSha = await this.createTree(baseRef, files, deletions)
+    const commitSha = await this.createCommit(message, treeSha, baseRef)
+    await this.updateBranchRef(branch, commitSha)
+  }
+
+  async getFileContent(path: string): Promise<string> {
+    const data = await this.request<{ content: string; encoding: string }>(
+      `/repos/${this.owner}/${this.repo}/contents/${path}`,
+    )
+    if (data.encoding !== "base64") {
+      throw new Error(`Unexpected encoding: ${data.encoding}`)
+    }
+    return Buffer.from(data.content.replace(/\n/g, ""), "base64").toString(
+      "utf-8",
+    )
+  }
+
+  async isRepoEmpty(): Promise<boolean> {
+    try {
+      await this.request(`/repos/${this.owner}/${this.repo}/git/refs`)
+      return false
+    } catch {
+      return true
+    }
+  }
+
+  async createEmptyRootCommit(branch: string): Promise<string> {
+    const treeData = await this.request<{ sha: string }>(
+      `/repos/${this.owner}/${this.repo}/git/trees`,
+      {
+        method: "POST",
+        body: JSON.stringify({ tree: [] }),
+      },
+    )
+
+    const commitData = await this.request<{ sha: string }>(
+      `/repos/${this.owner}/${this.repo}/git/commits`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          message: "chore: initialise repository",
+          tree: treeData.sha,
+          parents: [],
+        }),
+      },
+    )
+
+    await this.request(`/repos/${this.owner}/${this.repo}/git/refs`, {
+      method: "POST",
+      body: JSON.stringify({
+        ref: `refs/heads/${branch}`,
+        sha: commitData.sha,
+      }),
+    })
+
+    return commitData.sha
+  }
+
+  async createPullRequestWithFiles(
+    options: Omit<CreatePROptions, "head"> & {
+      files: FileChange[]
+      branchName: string
+    },
+  ): Promise<CreatePRResult> {
+    const { files, branchName, ...prOptions } = options
+
+    const baseBranch = prOptions.base || (await this.getDefaultBranch())
+
+    const empty = await this.isRepoEmpty()
+    if (empty) {
+      // Seed an empty root commit on the base branch so a PR can be opened
+      // against it. The PR branch then carries all the Confluence content.
+      await this.createEmptyRootCommit(baseBranch)
+    }
+
+    const baseSha = await this.getBranchRef(baseBranch)
+    await this.createBranch(branchName, baseSha)
+    await this.commitFiles(branchName, prOptions.title, files)
+
+    return this.createPullRequest({
+      ...prOptions,
+      head: branchName,
+      base: baseBranch,
+    })
+  }
+}

--- a/apps/backend/src/services/github/index.ts
+++ b/apps/backend/src/services/github/index.ts
@@ -1,0 +1,1 @@
+export { GitHubClient, type FileChange, type CreatePRResult } from "./client.js"


### PR DESCRIPTION
## Summary

Stacked on #33. Full backend implementation — OAuth round-trip, Confluence client, and sync engine.

**OAuth flow**
- Connector config schema extended: `deploymentType`, `cloudId`, `oauthRefreshToken`, `oauthClientId/Secret`
- `POST /:connectorId/oauth/start` — builds Atlassian authorization URL with required scopes, persists state nonce
- `GET /oauth/atlassian/callback` — exchanges code for tokens, resolves `cloudId` via accessible-resources API, encrypts and stores refresh token
- Supports Cloud (shared app credentials) and Data Center (per-customer app link)

**Confluence client**
- Discriminated union config (`basic | oauth`) with transparent access-token refresh
- Switched to `/wiki/api/v2/spaces/{id}/pages` — fixes `spaceId` query param being silently ignored on the generic `/pages` endpoint (was returning pages from all spaces)
- `buildConfluenceConfig()` shared utility replaces duplicated credential-resolution logic

**Sync engine**
- Reconciliation: `listFilesInTree` diff + `sha: null` deletions purge out-of-scope files from GitHub on every sync
- Defensive `page.spaceId` guard discards pages the API returns from the wrong space
- `listAllEnabledConnectors()` system-level DB query (bypasses RLS) for background worker use

## Notes
Sync is a stateless full re-sync each cycle. Checkpoint-based resumption is a known follow-up — not blocking.