### PR TITLE
feat: connector management UI for Atlassian OAuth

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -53,6 +53,7 @@
     "react-aria-components": "^1.15.1",
     "react-dom": "^19.2.4",
     "shadcn": "^3.8.5",
+    "simple-icons": "^16.12.0",
     "sonner": "^2.0.7",
     "streamdown": "^2.3.0",
     "tailwind-merge": "^3.5.0",

--- a/apps/ui/src/features/connectors/AddConnectorModal.tsx
+++ b/apps/ui/src/features/connectors/AddConnectorModal.tsx
@@ -1,0 +1,202 @@
+import { Button } from "@/components/ui/Button"
+import { TextField } from "@/components/ui/TextField"
+import { useState } from "react"
+import { client } from "@/lib/api"
+import { useParams } from "@tanstack/react-router"
+import { toast } from "sonner"
+import { useMutation } from "@tanstack/react-query"
+import type { Connector } from "./types"
+
+interface AddConnectorModalProps {
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function AddConnectorModal({ onClose, onSuccess }: AddConnectorModalProps) {
+  const { orgSlug } = useParams({ from: "/$orgSlug/connectors" })
+
+  const [type] = useState("confluence")
+  const [deploymentType, setDeploymentType] = useState<"cloud" | "datacenter">("cloud")
+  const [confluenceBaseUrl, setConfluenceBaseUrl] = useState("")
+  const [oauthClientId, setOauthClientId] = useState("")
+  const [oauthClientSecret, setOauthClientSecret] = useState("")
+  const [githubToken, setGithubToken] = useState("")
+  const [githubRepoName, setGithubRepoName] = useState("")
+  const [githubBranch, setGithubBranch] = useState("main")
+
+  // Step 1: create connector → Step 2: redirect to Atlassian OAuth
+  const createAndConnect = useMutation({
+    mutationFn: async () => {
+      const createRes = await client[":orgSlug"].api.v1.connectors.$post({
+        json: {
+          type,
+          githubRepoName: githubRepoName || undefined,
+          githubBranch: githubBranch || undefined,
+          config: {
+            deploymentType,
+            githubToken: githubToken || undefined,
+            confluenceBaseUrl: confluenceBaseUrl || undefined,
+            oauthClientId: oauthClientId || undefined,
+            oauthClientSecret: oauthClientSecret || undefined,
+          },
+        },
+        param: { orgSlug },
+      })
+      if (!createRes.ok) {
+        const err = await createRes.json().catch(() => ({}))
+        throw new Error((err as { error?: string }).error ?? "Failed to create connector")
+      }
+      const connector = (await createRes.json()) as Connector
+
+      // Fetch the OAuth start URL
+      const startRes = await client[":orgSlug"].api.v1.connectors[":id"]["oauth"]["start"].$get({
+        param: { orgSlug, id: connector.id },
+      })
+      if (!startRes.ok) {
+        const err = await startRes.json().catch(() => ({}))
+        throw new Error((err as { error?: string }).error ?? "Failed to start OAuth")
+      }
+      const { url } = (await startRes.json()) as { url: string }
+      return url
+    },
+    onSuccess: (url) => {
+      onSuccess()
+      window.location.href = url
+    },
+    onError: (err: Error) => {
+      toast.error(err.message)
+    },
+  })
+
+  const isCloud = deploymentType === "cloud"
+
+  return (
+    <div className="w-full max-w-lg rounded-lg bg-zinc-900 p-6 shadow-xl">
+      <h2 className="mb-1 text-xl font-semibold text-zinc-100">Add Connector</h2>
+      <p className="mb-5 text-sm text-zinc-400">
+        Connect an external source. You'll be redirected to authorise access via OAuth.
+      </p>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          createAndConnect.mutate()
+        }}
+        className="space-y-4"
+      >
+        {/* Deployment type */}
+        <div>
+          <label className="mb-1 block text-sm font-medium text-zinc-300">
+            Confluence deployment
+          </label>
+          <div className="flex gap-3">
+            {(["cloud", "datacenter"] as const).map((dt) => (
+              <label
+                key={dt}
+                className={[
+                  "flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
+                  deploymentType === dt
+                    ? "border-teal-500 bg-teal-900/20 text-teal-300"
+                    : "border-zinc-700 text-zinc-400 hover:border-zinc-500",
+                ].join(" ")}
+              >
+                <input
+                  type="radio"
+                  className="sr-only"
+                  name="deploymentType"
+                  value={dt}
+                  checked={deploymentType === dt}
+                  onChange={() => setDeploymentType(dt)}
+                />
+                {dt === "cloud" ? "Atlassian Cloud" : "Data Center (self-hosted)"}
+              </label>
+            ))}
+          </div>
+          {isCloud && (
+            <p className="mt-1.5 text-xs text-zinc-500">
+              Requires <code className="text-zinc-400">ATLASSIAN_CLIENT_ID</code> and{" "}
+              <code className="text-zinc-400">ATLASSIAN_CLIENT_SECRET</code> to be set in the backend.
+            </p>
+          )}
+        </div>
+
+        {/* Confluence instance URL — always shown */}
+        <TextField
+          label={isCloud ? "Confluence Cloud URL" : "Confluence instance URL"}
+          type="url"
+          value={confluenceBaseUrl}
+          onChange={setConfluenceBaseUrl}
+          placeholder={isCloud ? "https://your-org.atlassian.net" : "https://confluence.company.com"}
+          description={
+            isCloud
+              ? "Used to match your site after OAuth — optional if you only have one Atlassian site"
+              : "Your self-hosted Confluence instance"
+          }
+          isRequired={!isCloud}
+        />
+
+        {/* DC-only: OAuth application link credentials */}
+        {!isCloud && (
+          <>
+            <TextField
+              label="OAuth Client ID"
+              value={oauthClientId}
+              onChange={setOauthClientId}
+              placeholder="From Settings → Application Links"
+              isRequired
+            />
+            <TextField
+              label="OAuth Client Secret"
+              type="password"
+              value={oauthClientSecret}
+              onChange={setOauthClientSecret}
+              placeholder="From Settings → Application Links"
+              isRequired
+            />
+          </>
+        )}
+
+        <hr className="border-zinc-800" />
+
+        <TextField
+          label="GitHub Token"
+          type="password"
+          value={githubToken}
+          onChange={setGithubToken}
+          placeholder="ghp_xxxxxxxxxxxx"
+          isRequired
+        />
+
+        <TextField
+          label="GitHub Repository"
+          value={githubRepoName}
+          onChange={setGithubRepoName}
+          placeholder="owner/repo"
+          description="All connectors in this org share one repository"
+          isRequired
+        />
+
+        <TextField
+          label="GitHub Branch"
+          value={githubBranch}
+          onChange={setGithubBranch}
+          placeholder="main"
+        />
+
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            variant="secondary"
+            onPress={onClose}
+            isDisabled={createAndConnect.isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" isPending={createAndConnect.isPending}>
+            Create & Connect →
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/apps/ui/src/features/connectors/ConnectorCard.tsx
+++ b/apps/ui/src/features/connectors/ConnectorCard.tsx
@@ -1,0 +1,113 @@
+import { Button } from "@/components/ui/Button"
+import { IconTrash, IconRefresh, IconPencil, IconListTree } from "@tabler/icons-react"
+import type { Connector } from "./types"
+import { useState } from "react"
+import { toast } from "sonner"
+import { client } from "@/lib/api"
+import { useParams } from "@tanstack/react-router"
+
+interface ConnectorCardProps {
+  connector: Connector
+  onDelete: (connector: Connector) => void
+  onEdit: (connector: Connector, tab?: "credentials" | "scope") => void
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const m = Math.floor(diff / 60_000)
+  if (m < 1) return "just now"
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.floor(h / 24)}d ago`
+}
+
+export function ConnectorCard({
+  connector,
+  onDelete,
+  onEdit,
+}: ConnectorCardProps) {
+  const [isSyncing, setIsSyncing] = useState(false)
+  const { orgSlug } = useParams({ from: "/$orgSlug/connectors" })
+
+  const handleSync = async () => {
+    setIsSyncing(true)
+    try {
+      const res = await client[":orgSlug"].api.v1.connectors[":id"].sync.$post({
+        param: { orgSlug, id: connector.id },
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error((err as { error?: string }).error ?? "Failed to trigger sync")
+      }
+      toast.success("Sync triggered")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to trigger sync")
+    } finally {
+      setIsSyncing(false)
+    }
+  }
+
+  const label = connector.type.charAt(0).toUpperCase() + connector.type.slice(1)
+
+  return (
+    <div className="flex items-center gap-4 rounded-lg border border-zinc-800 bg-zinc-900/50 px-4 py-3">
+      {/* Name + last sync */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-zinc-100">{label}</span>
+          <span
+            className={[
+              "rounded-full px-2 py-0.5 text-xs",
+              connector.enabled
+                ? "bg-zinc-700 text-zinc-300"
+                : "bg-zinc-800 text-zinc-600",
+            ].join(" ")}
+            title="Whether this connector is enabled — does not indicate connection health"
+          >
+            {connector.enabled ? "Enabled" : "Disabled"}
+          </span>
+        </div>
+        <p className="mt-0.5 text-xs text-zinc-500">
+          {connector.lastSyncAt
+            ? `Last sync ${relativeTime(connector.lastSyncAt)}`
+            : "Never synced"}
+        </p>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-1.5">
+        <Button
+          variant="secondary"
+          onPress={handleSync}
+          isPending={isSyncing}
+          isDisabled={!connector.enabled}
+          aria-label="Sync now"
+        >
+          <IconRefresh className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => onEdit(connector, "scope")}
+          aria-label="Configure scope"
+        >
+          <IconListTree className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => onEdit(connector, "credentials")}
+          aria-label="Edit credentials"
+        >
+          <IconPencil className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => onDelete(connector)}
+          aria-label="Delete connector"
+        >
+          <IconTrash className="h-4 w-4 text-red-400" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/ui/src/features/connectors/ConnectorIcon.tsx
+++ b/apps/ui/src/features/connectors/ConnectorIcon.tsx
@@ -1,0 +1,43 @@
+import {
+  siConfluence,
+  siJira,
+  siNotion,
+  siLinear,
+  siGithub,
+  siGitlab,
+} from "simple-icons"
+import { IconCloud } from "@tabler/icons-react"
+
+const ICON_MAP: Record<string, { path: string; hex: string }> = {
+  confluence: siConfluence,
+  jira: siJira,
+  notion: siNotion,
+  linear: siLinear,
+  github: siGithub,
+  gitlab: siGitlab,
+}
+
+interface ConnectorIconProps {
+  type: string
+  className?: string
+}
+
+export function ConnectorIcon({ type, className = "h-5 w-5" }: ConnectorIconProps) {
+  const icon = ICON_MAP[type.toLowerCase()]
+
+  if (!icon) {
+    return <IconCloud className={className} />
+  }
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill={`#${icon.hex}`}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d={icon.path} />
+    </svg>
+  )
+}

--- a/apps/ui/src/features/connectors/EditConnectorModal.tsx
+++ b/apps/ui/src/features/connectors/EditConnectorModal.tsx
@@ -1,0 +1,178 @@
+import { Button } from "@/components/ui/Button"
+import { TextField } from "@/components/ui/TextField"
+import { useState } from "react"
+import { useMutation } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { client } from "@/lib/api"
+import { useParams } from "@tanstack/react-router"
+import { IconCheck, IconAlertTriangle } from "@tabler/icons-react"
+import type { Connector } from "./types"
+
+interface EditCredentialsModalProps {
+  connector: Connector
+  onClose: () => void
+  onSubmit: (data: {
+    githubRepoName?: string
+    githubBranch?: string
+    config?: {
+      githubToken?: string
+      confluenceBaseUrl?: string
+      confluenceEmail?: string
+      confluenceApiToken?: string
+    }
+  }) => void
+  isPending?: boolean
+  error?: string
+}
+
+export function EditConnectorModal({
+  connector,
+  onClose,
+  onSubmit,
+  isPending,
+  error,
+}: EditCredentialsModalProps) {
+  const { orgSlug } = useParams({ from: "/$orgSlug/connectors" })
+  const [githubRepoName, setGithubRepoName] = useState(connector.githubRepoName ?? "")
+  const [githubBranch, setGithubBranch] = useState(connector.githubBranch ?? "main")
+  const [githubToken, setGithubToken] = useState("")
+
+  // Legacy fields — only shown for connectors still using basic auth
+  const [confluenceApiToken, setConfluenceApiToken] = useState("")
+
+  const typeLabel = connector.type.charAt(0).toUpperCase() + connector.type.slice(1)
+  const isOAuthConnected = !!connector.config.oauthRefreshToken
+  const isLegacy = !isOAuthConnected && !!connector.config.confluenceApiToken
+  const isCloud = connector.config.deploymentType !== "datacenter"
+
+  const reconnectMutation = useMutation({
+    mutationFn: async () => {
+      const res = await client[":orgSlug"].api.v1.connectors[":id"]["oauth"]["start"].$get({
+        param: { orgSlug, id: connector.id },
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error((err as { error?: string }).error ?? "Failed to start OAuth")
+      }
+      const { url } = (await res.json()) as { url: string }
+      return url
+    },
+    onSuccess: (url) => {
+      window.location.href = url
+    },
+    onError: (err: Error) => {
+      toast.error(err.message)
+    },
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const configUpdates: Record<string, string> = {}
+    if (githubToken) configUpdates.githubToken = githubToken
+    if (confluenceApiToken) configUpdates.confluenceApiToken = confluenceApiToken
+
+    onSubmit({
+      githubRepoName: githubRepoName || undefined,
+      githubBranch: githubBranch || undefined,
+      config: Object.keys(configUpdates).length > 0
+        ? { ...connector.config, ...configUpdates }
+        : undefined,
+    })
+  }
+
+  return (
+    <div className="w-full max-w-lg rounded-lg bg-zinc-900 p-6 shadow-xl">
+      <h2 className="mb-1 text-xl font-semibold text-zinc-100">Edit Credentials</h2>
+      <p className="mb-5 text-sm text-zinc-400">{typeLabel}</p>
+
+      {error && (
+        <div className="mb-4 rounded-md bg-red-900/50 p-3 text-sm text-red-200">{error}</div>
+      )}
+
+      {/* OAuth connection status */}
+      {connector.type === "confluence" && (
+        <div className={[
+          "mb-5 flex items-start gap-3 rounded-lg border p-3",
+          isOAuthConnected
+            ? "border-teal-800 bg-teal-900/20"
+            : "border-amber-800 bg-amber-900/20",
+        ].join(" ")}>
+          {isOAuthConnected ? (
+            <IconCheck className="mt-0.5 h-4 w-4 shrink-0 text-teal-400" />
+          ) : (
+            <IconAlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+          )}
+          <div className="flex-1 min-w-0">
+            <p className={[
+              "text-sm font-medium",
+              isOAuthConnected ? "text-teal-300" : "text-amber-300",
+            ].join(" ")}>
+              {isOAuthConnected
+                ? `Connected via OAuth (${isCloud ? "Atlassian Cloud" : "Data Center"})`
+                : isLegacy
+                  ? "Using legacy API token — consider migrating to OAuth"
+                  : "Not connected — authorise access to start syncing"}
+            </p>
+            {isOAuthConnected && connector.config.cloudId && (
+              <p className="mt-0.5 text-xs text-teal-600">
+                Cloud ID: {connector.config.cloudId}
+              </p>
+            )}
+          </div>
+          <Button
+            variant="secondary"
+            onPress={() => reconnectMutation.mutate()}
+            isPending={reconnectMutation.isPending}
+          >
+            {isOAuthConnected ? "Reconnect" : "Connect via OAuth"}
+          </Button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TextField
+          label="GitHub Repository"
+          value={githubRepoName}
+          onChange={setGithubRepoName}
+          placeholder="owner/repo"
+          description="All connectors in this org must share the same repository"
+          isRequired
+        />
+        <TextField
+          label="GitHub Branch"
+          value={githubBranch}
+          onChange={setGithubBranch}
+          placeholder="main"
+        />
+        <TextField
+          label="GitHub Token (leave blank to keep existing)"
+          type="password"
+          value={githubToken}
+          onChange={setGithubToken}
+          placeholder="ghp_xxxxxxxxxxxx"
+        />
+
+        {/* Legacy: only show if connector still uses basic auth */}
+        {isLegacy && connector.type === "confluence" && (
+          <TextField
+            label="Confluence API Token (leave blank to keep existing)"
+            type="password"
+            value={confluenceApiToken}
+            onChange={setConfluenceApiToken}
+            placeholder="ATATT3x..."
+            description="Legacy — use 'Connect via OAuth' above to migrate"
+          />
+        )}
+
+        <div className="flex justify-end gap-3 pt-2">
+          <Button type="button" variant="secondary" onPress={onClose} isDisabled={isPending}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" isPending={isPending}>
+            Save
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/apps/ui/src/features/connectors/index.ts
+++ b/apps/ui/src/features/connectors/index.ts
@@ -1,0 +1,8 @@
+export type { Connector, ConnectorSpace, SyncLog } from "./types"
+export { AddConnectorModal } from "./AddConnectorModal"
+export { EditConnectorModal } from "./EditConnectorModal"
+export { EditScopeModal } from "./EditScopeModal"
+export { ConnectorCard } from "./ConnectorCard"
+export { ConnectorIcon } from "./ConnectorIcon"
+export { SpacePageTree } from "./SpacePageTree"
+export type { SpaceScopeItem } from "./SpacePageTree"

--- a/apps/ui/src/features/connectors/types.ts
+++ b/apps/ui/src/features/connectors/types.ts
@@ -1,0 +1,54 @@
+export interface Connector {
+  id: string
+  orgId: string
+  type: string
+  config: {
+    syncMode: "pr" | "auto"
+    schedule: "hourly" | "daily" | "manual"
+    githubToken?: string
+    // Legacy basic-auth
+    confluenceBaseUrl?: string
+    confluenceEmail?: string
+    confluenceApiToken?: string
+    // OAuth 2.0
+    deploymentType?: "cloud" | "datacenter"
+    cloudId?: string
+    oauthRefreshToken?: string  // encrypted — present means connected via OAuth
+    oauthClientId?: string
+    oauthClientSecret?: string
+  }
+  enabled: boolean
+  githubRepoId: string | null
+  githubRepoName: string | null
+  githubBranch: string | null
+  lastPrNumber: number | null
+  lastSyncAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ConnectorSpace {
+  id: string
+  connectorId: string
+  spaceKey: string
+  spaceName: string | null
+  selectedPageIds: string[] | null
+  lastSyncedPageId: string | null
+  lastSyncedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SyncLog {
+  id: string
+  connectorId: string
+  status: string
+  prNumber: number | null
+  prUrl: string | null
+  pagesAdded: number
+  pagesUpdated: number
+  pagesDeleted: number
+  errorMessage: string | null
+  startedAt: string
+  completedAt: string | null
+}

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -11,21 +11,20 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OrgSlugIndexRouteImport } from './routes/$orgSlug.index'
-import { Route as DotgithubSetupRouteImport } from './routes/[.]github.setup'
+import { Route as OauthErrorRouteImport } from './routes/oauth.error'
 import { Route as DotauthSignInRouteImport } from './routes/[.]auth.sign-in'
 import { Route as DotauthResetPasswordRouteImport } from './routes/[.]auth.reset-password'
 import { Route as DotauthConsentRouteImport } from './routes/[.]auth.consent'
 import { Route as DotauthAccountRouteImport } from './routes/[.]auth.account'
 import { Route as DotauthAuthViewRouteImport } from './routes/[.]auth.$authView'
 import { Route as OrgSlugRepositoriesRouteImport } from './routes/$orgSlug.repositories'
+import { Route as OrgSlugConnectorsRouteImport } from './routes/$orgSlug.connectors'
 import { Route as OrgSlugChatRouteImport } from './routes/$orgSlug.chat'
-import { Route as OrgSlugRepositoriesIndexRouteImport } from './routes/$orgSlug.repositories.index'
 import { Route as OrgSlugChatIndexRouteImport } from './routes/$orgSlug.chat.index'
 import { Route as DotauthOrganizationOrganizationViewRouteImport } from './routes/[.]auth.organization.$organizationView'
 import { Route as DotauthAccountAccountViewRouteImport } from './routes/[.]auth.account.$accountView'
 import { Route as OrgSlugOrganizationOrganizationViewRouteImport } from './routes/$orgSlug.organization.$organizationView'
 import { Route as OrgSlugChatConversationIdRouteImport } from './routes/$orgSlug.chat.$conversationId'
-import { Route as OrgSlugRepositoriesGithubSetupRouteImport } from './routes/$orgSlug.repositories.github.setup'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -37,9 +36,9 @@ const OrgSlugIndexRoute = OrgSlugIndexRouteImport.update({
   path: '/$orgSlug/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const DotgithubSetupRoute = DotgithubSetupRouteImport.update({
-  id: '/.github/setup',
-  path: '/.github/setup',
+const OauthErrorRoute = OauthErrorRouteImport.update({
+  id: '/oauth/error',
+  path: '/oauth/error',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DotauthSignInRoute = DotauthSignInRouteImport.update({
@@ -72,17 +71,16 @@ const OrgSlugRepositoriesRoute = OrgSlugRepositoriesRouteImport.update({
   path: '/$orgSlug/repositories',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OrgSlugConnectorsRoute = OrgSlugConnectorsRouteImport.update({
+  id: '/$orgSlug/connectors',
+  path: '/$orgSlug/connectors',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const OrgSlugChatRoute = OrgSlugChatRouteImport.update({
   id: '/$orgSlug/chat',
   path: '/$orgSlug/chat',
   getParentRoute: () => rootRouteImport,
 } as any)
-const OrgSlugRepositoriesIndexRoute =
-  OrgSlugRepositoriesIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => OrgSlugRepositoriesRoute,
-  } as any)
 const OrgSlugChatIndexRoute = OrgSlugChatIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -112,137 +110,128 @@ const OrgSlugChatConversationIdRoute =
     path: '/$conversationId',
     getParentRoute: () => OrgSlugChatRoute,
   } as any)
-const OrgSlugRepositoriesGithubSetupRoute =
-  OrgSlugRepositoriesGithubSetupRouteImport.update({
-    id: '/github/setup',
-    path: '/github/setup',
-    getParentRoute: () => OrgSlugRepositoriesRoute,
-  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$orgSlug/chat': typeof OrgSlugChatRouteWithChildren
-  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRouteWithChildren
+  '/$orgSlug/connectors': typeof OrgSlugConnectorsRoute
+  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
   '/.auth/reset-password': typeof DotauthResetPasswordRoute
   '/.auth/sign-in': typeof DotauthSignInRoute
-  '/.github/setup': typeof DotgithubSetupRoute
+  '/oauth/error': typeof OauthErrorRoute
   '/$orgSlug/': typeof OrgSlugIndexRoute
   '/$orgSlug/chat/$conversationId': typeof OrgSlugChatConversationIdRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
   '/.auth/account/$accountView': typeof DotauthAccountAccountViewRoute
   '/.auth/organization/$organizationView': typeof DotauthOrganizationOrganizationViewRoute
   '/$orgSlug/chat/': typeof OrgSlugChatIndexRoute
-  '/$orgSlug/repositories/': typeof OrgSlugRepositoriesIndexRoute
-  '/$orgSlug/repositories/github/setup': typeof OrgSlugRepositoriesGithubSetupRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/$orgSlug/connectors': typeof OrgSlugConnectorsRoute
+  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
   '/.auth/reset-password': typeof DotauthResetPasswordRoute
   '/.auth/sign-in': typeof DotauthSignInRoute
-  '/.github/setup': typeof DotgithubSetupRoute
+  '/oauth/error': typeof OauthErrorRoute
   '/$orgSlug': typeof OrgSlugIndexRoute
   '/$orgSlug/chat/$conversationId': typeof OrgSlugChatConversationIdRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
   '/.auth/account/$accountView': typeof DotauthAccountAccountViewRoute
   '/.auth/organization/$organizationView': typeof DotauthOrganizationOrganizationViewRoute
   '/$orgSlug/chat': typeof OrgSlugChatIndexRoute
-  '/$orgSlug/repositories': typeof OrgSlugRepositoriesIndexRoute
-  '/$orgSlug/repositories/github/setup': typeof OrgSlugRepositoriesGithubSetupRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$orgSlug/chat': typeof OrgSlugChatRouteWithChildren
-  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRouteWithChildren
+  '/$orgSlug/connectors': typeof OrgSlugConnectorsRoute
+  '/$orgSlug/repositories': typeof OrgSlugRepositoriesRoute
   '/.auth/$authView': typeof DotauthAuthViewRoute
   '/.auth/account': typeof DotauthAccountRouteWithChildren
   '/.auth/consent': typeof DotauthConsentRoute
   '/.auth/reset-password': typeof DotauthResetPasswordRoute
   '/.auth/sign-in': typeof DotauthSignInRoute
-  '/.github/setup': typeof DotgithubSetupRoute
+  '/oauth/error': typeof OauthErrorRoute
   '/$orgSlug/': typeof OrgSlugIndexRoute
   '/$orgSlug/chat/$conversationId': typeof OrgSlugChatConversationIdRoute
   '/$orgSlug/organization/$organizationView': typeof OrgSlugOrganizationOrganizationViewRoute
   '/.auth/account/$accountView': typeof DotauthAccountAccountViewRoute
   '/.auth/organization/$organizationView': typeof DotauthOrganizationOrganizationViewRoute
   '/$orgSlug/chat/': typeof OrgSlugChatIndexRoute
-  '/$orgSlug/repositories/': typeof OrgSlugRepositoriesIndexRoute
-  '/$orgSlug/repositories/github/setup': typeof OrgSlugRepositoriesGithubSetupRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/$orgSlug/chat'
+    | '/$orgSlug/connectors'
     | '/$orgSlug/repositories'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
     | '/.auth/reset-password'
     | '/.auth/sign-in'
-    | '/.github/setup'
+    | '/oauth/error'
     | '/$orgSlug/'
     | '/$orgSlug/chat/$conversationId'
     | '/$orgSlug/organization/$organizationView'
     | '/.auth/account/$accountView'
     | '/.auth/organization/$organizationView'
     | '/$orgSlug/chat/'
-    | '/$orgSlug/repositories/'
-    | '/$orgSlug/repositories/github/setup'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/$orgSlug/connectors'
+    | '/$orgSlug/repositories'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
     | '/.auth/reset-password'
     | '/.auth/sign-in'
-    | '/.github/setup'
+    | '/oauth/error'
     | '/$orgSlug'
     | '/$orgSlug/chat/$conversationId'
     | '/$orgSlug/organization/$organizationView'
     | '/.auth/account/$accountView'
     | '/.auth/organization/$organizationView'
     | '/$orgSlug/chat'
-    | '/$orgSlug/repositories'
-    | '/$orgSlug/repositories/github/setup'
   id:
     | '__root__'
     | '/'
     | '/$orgSlug/chat'
+    | '/$orgSlug/connectors'
     | '/$orgSlug/repositories'
     | '/.auth/$authView'
     | '/.auth/account'
     | '/.auth/consent'
     | '/.auth/reset-password'
     | '/.auth/sign-in'
-    | '/.github/setup'
+    | '/oauth/error'
     | '/$orgSlug/'
     | '/$orgSlug/chat/$conversationId'
     | '/$orgSlug/organization/$organizationView'
     | '/.auth/account/$accountView'
     | '/.auth/organization/$organizationView'
     | '/$orgSlug/chat/'
-    | '/$orgSlug/repositories/'
-    | '/$orgSlug/repositories/github/setup'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OrgSlugChatRoute: typeof OrgSlugChatRouteWithChildren
-  OrgSlugRepositoriesRoute: typeof OrgSlugRepositoriesRouteWithChildren
+  OrgSlugConnectorsRoute: typeof OrgSlugConnectorsRoute
+  OrgSlugRepositoriesRoute: typeof OrgSlugRepositoriesRoute
   DotauthAuthViewRoute: typeof DotauthAuthViewRoute
   DotauthAccountRoute: typeof DotauthAccountRouteWithChildren
   DotauthConsentRoute: typeof DotauthConsentRoute
   DotauthResetPasswordRoute: typeof DotauthResetPasswordRoute
   DotauthSignInRoute: typeof DotauthSignInRoute
-  DotgithubSetupRoute: typeof DotgithubSetupRoute
+  OauthErrorRoute: typeof OauthErrorRoute
   OrgSlugIndexRoute: typeof OrgSlugIndexRoute
   OrgSlugOrganizationOrganizationViewRoute: typeof OrgSlugOrganizationOrganizationViewRoute
   DotauthOrganizationOrganizationViewRoute: typeof DotauthOrganizationOrganizationViewRoute
@@ -264,11 +253,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrgSlugIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/.github/setup': {
-      id: '/.github/setup'
-      path: '/.github/setup'
-      fullPath: '/.github/setup'
-      preLoaderRoute: typeof DotgithubSetupRouteImport
+    '/oauth/error': {
+      id: '/oauth/error'
+      path: '/oauth/error'
+      fullPath: '/oauth/error'
+      preLoaderRoute: typeof OauthErrorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/.auth/sign-in': {
@@ -313,19 +302,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrgSlugRepositoriesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/$orgSlug/connectors': {
+      id: '/$orgSlug/connectors'
+      path: '/$orgSlug/connectors'
+      fullPath: '/$orgSlug/connectors'
+      preLoaderRoute: typeof OrgSlugConnectorsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/$orgSlug/chat': {
       id: '/$orgSlug/chat'
       path: '/$orgSlug/chat'
       fullPath: '/$orgSlug/chat'
       preLoaderRoute: typeof OrgSlugChatRouteImport
       parentRoute: typeof rootRouteImport
-    }
-    '/$orgSlug/repositories/': {
-      id: '/$orgSlug/repositories/'
-      path: '/'
-      fullPath: '/$orgSlug/repositories/'
-      preLoaderRoute: typeof OrgSlugRepositoriesIndexRouteImport
-      parentRoute: typeof OrgSlugRepositoriesRoute
     }
     '/$orgSlug/chat/': {
       id: '/$orgSlug/chat/'
@@ -362,13 +351,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrgSlugChatConversationIdRouteImport
       parentRoute: typeof OrgSlugChatRoute
     }
-    '/$orgSlug/repositories/github/setup': {
-      id: '/$orgSlug/repositories/github/setup'
-      path: '/github/setup'
-      fullPath: '/$orgSlug/repositories/github/setup'
-      preLoaderRoute: typeof OrgSlugRepositoriesGithubSetupRouteImport
-      parentRoute: typeof OrgSlugRepositoriesRoute
-    }
   }
 }
 
@@ -386,19 +368,6 @@ const OrgSlugChatRouteWithChildren = OrgSlugChatRoute._addFileChildren(
   OrgSlugChatRouteChildren,
 )
 
-interface OrgSlugRepositoriesRouteChildren {
-  OrgSlugRepositoriesIndexRoute: typeof OrgSlugRepositoriesIndexRoute
-  OrgSlugRepositoriesGithubSetupRoute: typeof OrgSlugRepositoriesGithubSetupRoute
-}
-
-const OrgSlugRepositoriesRouteChildren: OrgSlugRepositoriesRouteChildren = {
-  OrgSlugRepositoriesIndexRoute: OrgSlugRepositoriesIndexRoute,
-  OrgSlugRepositoriesGithubSetupRoute: OrgSlugRepositoriesGithubSetupRoute,
-}
-
-const OrgSlugRepositoriesRouteWithChildren =
-  OrgSlugRepositoriesRoute._addFileChildren(OrgSlugRepositoriesRouteChildren)
-
 interface DotauthAccountRouteChildren {
   DotauthAccountAccountViewRoute: typeof DotauthAccountAccountViewRoute
 }
@@ -414,13 +383,14 @@ const DotauthAccountRouteWithChildren = DotauthAccountRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OrgSlugChatRoute: OrgSlugChatRouteWithChildren,
-  OrgSlugRepositoriesRoute: OrgSlugRepositoriesRouteWithChildren,
+  OrgSlugConnectorsRoute: OrgSlugConnectorsRoute,
+  OrgSlugRepositoriesRoute: OrgSlugRepositoriesRoute,
   DotauthAuthViewRoute: DotauthAuthViewRoute,
   DotauthAccountRoute: DotauthAccountRouteWithChildren,
   DotauthConsentRoute: DotauthConsentRoute,
   DotauthResetPasswordRoute: DotauthResetPasswordRoute,
   DotauthSignInRoute: DotauthSignInRoute,
-  DotgithubSetupRoute: DotgithubSetupRoute,
+  OauthErrorRoute: OauthErrorRoute,
   OrgSlugIndexRoute: OrgSlugIndexRoute,
   OrgSlugOrganizationOrganizationViewRoute:
     OrgSlugOrganizationOrganizationViewRoute,

--- a/apps/ui/src/routes/oauth.error.tsx
+++ b/apps/ui/src/routes/oauth.error.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { IconAlertTriangle } from "@tabler/icons-react"
+
+export const Route = createFileRoute("/oauth/error")({
+  component: OAuthErrorPage,
+})
+
+const ERROR_MESSAGES: Record<string, string> = {
+  invalid_state: "The authorisation request expired or was already used. Please try connecting again.",
+  token_exchange_failed: "Failed to exchange the authorisation code for tokens. Please try again.",
+  no_refresh_token: "Atlassian did not return a refresh token. Make sure 'offline_access' is requested.",
+  no_accessible_sites: "No Confluence sites were found on your Atlassian account.",
+  cloudid_resolution_failed: "Could not determine your Confluence Cloud ID. Please try again.",
+  connector_not_found: "The connector associated with this authorisation could not be found.",
+  missing_params: "The callback was missing required parameters.",
+}
+
+function OAuthErrorPage() {
+  const { reason } = Route.useSearch() as { reason?: string }
+  const message = (reason && ERROR_MESSAGES[reason]) ?? "An unexpected error occurred during authorisation."
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-950 px-4">
+      <div className="w-full max-w-md rounded-xl border border-red-800/40 bg-zinc-900 p-8 text-center shadow-xl">
+        <div className="mb-4 flex justify-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-900/30">
+            <IconAlertTriangle className="h-6 w-6 text-red-400" />
+          </div>
+        </div>
+        <h1 className="mb-2 text-xl font-semibold text-zinc-100">
+          Authorisation failed
+        </h1>
+        <p className="mb-6 text-sm text-zinc-400">{message}</p>
+        {reason && (
+          <p className="mb-6 font-mono text-xs text-zinc-600">reason: {reason}</p>
+        )}
+        <Link
+          to="/"
+          className="inline-flex items-center rounded-md bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-500 transition-colors"
+        >
+          Back to app
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       shadcn:
         specifier: ^3.8.5
         version: 3.8.5(@cfworker/json-schema@4.1.1)(@types/node@25.3.0)(typescript@5.9.3)
+      simple-icons:
+        specifier: ^16.12.0
+        version: 16.12.0
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -9052,6 +9055,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-icons@16.12.0:
+    resolution: {integrity: sha512-fDJDqXUpkb2twqH+eBQpJsCYUE6jEH7VkuuPL9dH16sbLf6KKnwyijULmcx7SCoy3c2L6pl8WCzt+4rpYjoWfw==}
+    engines: {node: '>=0.12.18'}
 
   simple-wcswidth@1.1.2:
     resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
@@ -20372,6 +20379,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-icons@16.12.0: {}
 
   simple-wcswidth@1.1.2: {}
 


### PR DESCRIPTION
## Summary

Stacked on #34. UI changes for connecting and managing OAuth-authenticated Confluence connectors.

- **`AddConnectorModal`** — deployment type selector (Cloud / Data Center), initiates OAuth flow after connector creation; replaces API token credential fields
- **`EditConnectorModal`** — OAuth connection status badge, Reconnect button, hides legacy credential fields for OAuth connectors
- **`/oauth/error` route** — dedicated error page surfacing reason codes from the OAuth callback (`invalid_state`, `token_exchange_failed`, `cloudid_resolution_failed`, etc.)
- **`types.ts`** — `Connector.config` extended with OAuth fields to match backend schema