### PR TITLE
filter langfuse traces

### DIFF
--- a/.ai/memory/decisions/ADR-011-backend-observability-otel.md
+++ b/.ai/memory/decisions/ADR-011-backend-observability-otel.md
@@ -12,7 +12,7 @@ We need observability for the backend: APM (traces), LLM observability, and stru
 
 2. **evlog for logs**: Use evlog with Hono middleware. When `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` is set, logs drain to OTLP via `createOTLPDrain` with batching and retry. Otherwise logs go to stdout only.
 
-3. **Single endpoint, collector fan-out**: The app sends to one configurable OTLP endpoint per signal. For multiple backends, users run an OpenTelemetry Collector and configure it to fan out. No filtering in the app—LangFuse filters LLM spans on ingest; APM tools receive full traces.
+3. **Single endpoint, collector fan-out**: The app sends to one configurable OTLP endpoint per signal. For multiple backends, users run an OpenTelemetry Collector and configure it to fan out. **Per-destination trace shaping** lives in the collector: the **APM** exporter receives full traces (including DB/HTTP from Node auto-instrumentation); the **LLM/OTLP observability** exporter receives an **allowlist** of spans only (Gen AI `gen_ai.*` attributes and/or Langfuse/LangChain/LangGraph instrumentation scope). No app-side fan-out or LangFuse-specific env in the backend.
 
 4. **Initialization order**: `parseEnv` → `initOtel` → `initEvlog` → `createApp`. OTEL must register before any code that creates spans.
 
@@ -32,10 +32,10 @@ We need observability for the backend: APM (traces), LLM observability, and stru
 ### Alternatives Considered
 
 - **SDK fan-out in app**: Multiple exporters from code. Rejected: env-driven config is simpler; collector handles auth per backend.
-- **Filter traces per target**: Send LLM spans to LangFuse, all to APM. Rejected: LangFuse filters on ingest; no need for app-side filtering.
+- **Filter traces per target**: Initially deferred in favor of “LangFuse filters on ingest.” **Superseded**: OTLP ingest still recorded infra noise; the repo’s OpenTelemetry Collector now applies an **allowlist** on the LLM-bound trace pipeline only (`apps/otel-collector/config.yaml`), while the APM pipeline stays full-fidelity.
 
 ### Notes
 
-- See `apps/backend/src/observability/otel.ts`, `evlog.ts`, and `langfuse.ts`.
+- See `apps/backend/src/observability/otel.ts`, `evlog.ts`, `langfuse.ts`, and `apps/otel-collector/config.yaml` (trace pipelines `traces/apm` vs `traces/llm`).
 - Env vars: `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`.
 - LangFuse integration: `runWithLangfuseContext` wraps graph invocations; nodes call `getLangfuseHandler()` in callbacks. Handler attributes (sessionId, tags) set per request.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ apps/codesearch/.env.local
 core
 .ai/memory/active-context.md
 .ai/memory/progress.md
+.turbo

--- a/apps/docs/content/docs/self-hosting.mdx
+++ b/apps/docs/content/docs/self-hosting.mdx
@@ -99,7 +99,7 @@ See [Model configuration](../../../../docs/self-hosting/models.md) for a full gu
 
 ### Observability (OpenTelemetry)
 
-All configuration is via environment variables. For multiple backends (Better Stack, LangFuse, Jaeger, Grafana, etc.), run an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) and point the app to it. The collector fans out to your chosen tools.
+All configuration is via environment variables. For multiple backends (Better Stack, LangFuse, Jaeger, Grafana, etc.), run an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) and point the app to it. The collector fans out to your chosen tools. The reference collector in this repo (`apps/otel-collector`) splits **full** traces to APM and an **allowlisted** (Gen AI attributes + LangChain/LangGraph/Langfuse scopes) trace stream to the LLM OTLP exporter—see `apps/otel-collector/README.md`.
 
 | Variable | Description |
 |---|---|

--- a/apps/otel-collector/README.md
+++ b/apps/otel-collector/README.md
@@ -2,6 +2,22 @@
 
 Shared OpenTelemetry Collector for Better Stack (logs + traces) and LangFuse (traces). Used by backend and other apps when running via docker compose.
 
+## Trace pipelines
+
+Traces are split into two pipelines so **APM** and **LLM observability** do not receive identical data:
+
+- **`traces/apm`** — Full traces (including PostgreSQL, HTTP, DNS, and other Node auto-instrumentation) → Better Stack.
+- **`traces/llm`** — **Allowlisted** spans only → LangFuse (or any OTLP endpoint you configure on that exporter).
+
+The allowlist (`filter/llm_only`) keeps a span when **either**:
+
+1. **Tier 1 — Gen AI semantics**: the span has any of the checked `gen_ai.*` attributes (OpenTelemetry Gen AI semantic conventions), or  
+2. **Tier 2 — Stack identity**: `instrumentation_scope.name` matches `(langfuse|langchain|langgraph)` (case-insensitive).
+
+Everything else is dropped on the LLM pipeline only. If you point the LLM exporter at another backend (Honeycomb, Tempo, etc.), the same rules apply.
+
+To extend the allowlist (e.g. another framework), edit the OTTL expression in `config.yaml` or add attribute keys under Tier 1.
+
 This is intended to be used only when running in ctx| environment (BetterStack + LangFuse). You can use this as inspiration for your own specific collector when self-hosting but unless you're using the same observability stack it's not good fit.
 
 ## Setup

--- a/apps/otel-collector/config.yaml
+++ b/apps/otel-collector/config.yaml
@@ -9,6 +9,13 @@ receivers:
 
 processors:
   batch:
+  # Allowlist (Tier 1 + 2): keep spans with Gen AI semconv attributes OR Langfuse/LangChain/LangGraph
+  # instrumentation scope. Drops everything else from the LangFuse pipeline only (APM still gets full traces).
+  filter/llm_only:
+    error_mode: ignore
+    traces:
+      span:
+        - 'not ((attributes["gen_ai.system"] != nil) or (attributes["gen_ai.operation.name"] != nil) or (attributes["gen_ai.request.model"] != nil) or (attributes["gen_ai.response.model"] != nil) or (attributes["gen_ai.provider.name"] != nil) or (attributes["gen_ai.usage.input_tokens"] != nil) or (attributes["gen_ai.usage.output_tokens"] != nil) or (attributes["gen_ai.response.id"] != nil) or (attributes["gen_ai.conversation.id"] != nil) or (attributes["gen_ai.tool.name"] != nil) or (attributes["gen_ai.tool.call.id"] != nil) or (attributes["gen_ai.tool.type"] != nil) or (attributes["gen_ai.data_source.id"] != nil) or (attributes["gen_ai.agent.name"] != nil) or (attributes["gen_ai.request.choice.count"] != nil) or (attributes["gen_ai.response.finish_reasons"] != nil) or IsMatch(instrumentation_scope.name, "(?i).*(langfuse|langchain|langgraph).*"))'
 
 exporters:
   otlphttp/betterstack:
@@ -22,10 +29,14 @@ exporters:
 
 service:
   pipelines:
-    traces:
+    traces/apm:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp/betterstack, otlphttp/langfuse]
+      exporters: [otlphttp/betterstack]
+    traces/llm:
+      receivers: [otlp]
+      processors: [filter/llm_only, batch]
+      exporters: [otlphttp/langfuse]
     logs:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the OpenTelemetry Collector trace routing/filtering, which can drop spans for the LLM exporter if the allowlist is too strict; APM traces remain full-fidelity. No application runtime logic changes beyond documentation/ignore rules.
> 
> **Overview**
> Updates the repo’s OpenTelemetry Collector to **split traces into two pipelines**: `traces/apm` exports **full traces** to Better Stack, while `traces/llm` exports an **allowlisted subset** to LangFuse.
> 
> Adds an OTTL-based `filter/llm_only` processor that keeps spans with `gen_ai.*` attributes or Langfuse/LangChain/LangGraph instrumentation scope and drops everything else from the LLM pipeline. Documentation (ADR + self-hosting docs + collector README) is updated to reflect this collector-side trace shaping, and `.turbo` is added to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4675fff31c12d401af0af73e7b224d65237581ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->