### PR TITLE
Add github_webhook_secret to workflows and terraform

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,6 +96,7 @@ jobs:
       TF_VAR_smtp_connection_url: ${{ secrets.SMTP_CONNECTION_URL }}
       TF_VAR_github_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       TF_VAR_github_client_secret: ${{ secrets.GH_CLIENT_SECRET }}
+      TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
       TF_VAR_atlassian_client_id: ${{ secrets.ATLASSIAN_CLIENT_ID }}
       TF_VAR_atlassian_client_secret: ${{ secrets.ATLASSIAN_CLIENT_SECRET }}
       TF_VAR_falkordb_password: ${{ secrets.FALKORDB_PASSWORD }}

--- a/.github/workflows/terraform-plan-pr.yaml
+++ b/.github/workflows/terraform-plan-pr.yaml
@@ -32,6 +32,7 @@ jobs:
       TF_VAR_smtp_connection_url: ${{ secrets.SMTP_CONNECTION_URL }}
       TF_VAR_github_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       TF_VAR_github_client_secret: ${{ secrets.GH_CLIENT_SECRET }}
+      TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
       TF_VAR_atlassian_client_id: ${{ secrets.ATLASSIAN_CLIENT_ID }}
       TF_VAR_atlassian_client_secret: ${{ secrets.ATLASSIAN_CLIENT_SECRET }}
       TF_VAR_falkordb_password: ${{ secrets.FALKORDB_PASSWORD }}

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -69,5 +69,3 @@ SMEE_URL="https://smee.io/naliyA6yt5p9UmLf"
 ATLASSIAN_CLIENT_ID="SQcoGc4W3Jzi29HPvIkleG2aEP6W0ht2"
 ATLASSIAN_CLIENT_SECRET=
 
-ATLASSIAN_FORGE_REMOTE_JWKS_URL="https://forge.cdn.prod.atlassian-dev.net/.well-known/jwks.json"
-

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -35,6 +35,7 @@ module "ctxpipe" {
   smtp_connection_url            = var.smtp_connection_url
   github_private_key             = var.github_private_key
   github_client_secret           = var.github_client_secret
+  github_webhook_secret          = var.github_webhook_secret
   atlassian_client_id            = var.atlassian_client_id
   atlassian_client_secret        = var.atlassian_client_secret
   falkordb_password              = var.falkordb_password

--- a/infra/module/ctxpipe/railway.tf
+++ b/infra/module/ctxpipe/railway.tf
@@ -84,6 +84,10 @@ locals {
       name  = "ATLASSIAN_CLIENT_SECRET",
       value = var.atlassian_client_secret
     },
+    {
+      name  = "GITHUB_WEBHOOK_SECRET",
+      value = var.github_webhook_secret
+    }
   ]
 }
 

--- a/infra/module/ctxpipe/variables.tf
+++ b/infra/module/ctxpipe/variables.tf
@@ -116,6 +116,12 @@ variable "atlassian_client_secret" {
   sensitive   = true
 }
 
+variable "github_webhook_secret" {
+  type        = string
+  description = "value for GITHUB_WEBHOOK_SECRET"
+  sensitive   = true
+}
+
 variable "falkordb_password" {
   type        = string
   description = "value for FALKORDB_PASSWORD"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -52,6 +52,12 @@ variable "github_client_secret" {
   sensitive   = true
 }
 
+variable "github_webhook_secret" {
+  type        = string
+  description = "value for GITHUB_WEBHOOK_SECRET"
+  sensitive   = true
+}
+
 variable "atlassian_client_id" {
   type        = string
   description = "value for ATLASSIAN_CLIENT_ID (Forge / OAuth)"


### PR DESCRIPTION
- Updated GitHub Actions workflows to include TF_VAR_github_webhook_secret.
- Added github_webhook_secret variable to Terraform configuration.
- Removed unused ATLASSIAN_FORGE_REMOTE_JWKS_URL from .env.example.
- Updated ctxpipe module to utilize the new github_webhook_secret variable.