### PR TITLE
feat(mcp): strengthen ctx_advisor title and description for agent routing

### DIFF
--- a/apps/backend/src/mcp/tools.test.ts
+++ b/apps/backend/src/mcp/tools.test.ts
@@ -8,6 +8,8 @@ const {
   ensureConversationMock,
   touchConversationLastMessageMock,
   requireCurrentUserIdMock,
+  requireCurrentOrgIdMock,
+  requireCurrentOrgSlugMock,
 } = vi.hoisted(() => ({
   generateObjectIdMock: vi.fn(() => "thr_test"),
   streamMock: vi.fn(),
@@ -15,6 +17,8 @@ const {
   ensureConversationMock: vi.fn(async () => ({})),
   touchConversationLastMessageMock: vi.fn(async () => {}),
   requireCurrentUserIdMock: vi.fn(() => "user_test123"),
+  requireCurrentOrgIdMock: vi.fn(() => "org_test"),
+  requireCurrentOrgSlugMock: vi.fn(() => "acme"),
 }))
 
 vi.mock("../graphs/index.js", () => ({
@@ -35,6 +39,8 @@ vi.mock("../models/conversations.js", () => ({
 
 vi.mock("../auth/context.js", () => ({
   requireCurrentUserId: requireCurrentUserIdMock,
+  requireCurrentOrgId: requireCurrentOrgIdMock,
+  requireCurrentOrgSlug: requireCurrentOrgSlugMock,
 }))
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
@@ -65,6 +71,7 @@ describe("registerMcpTools", () => {
     const [name, config, handler] = registerToolMock.mock.calls[0] as [
       string,
       {
+        title: string
         description: string
         inputSchema: { shape: { prompt: { _def: { type: string } } } }
       },
@@ -77,7 +84,10 @@ describe("registerMcpTools", () => {
       ) => Promise<{ content: Array<{ text: string }> }>,
     ]
     expect(name).toBe("ctx_advisor")
+    expect(config.title).toContain("ctx_advisor")
     expect(config.description).toContain("ctx_advisor")
+    expect(config.description).toContain("repository search")
+    expect(config.description).toContain("grep")
     expect(config.inputSchema.shape.prompt._def.type).toBe("string")
     expect("currentProjectName" in config.inputSchema.shape).toBe(true)
     expect("conversationId" in config.inputSchema.shape).toBe(true)

--- a/apps/backend/src/mcp/tools.ts
+++ b/apps/backend/src/mcp/tools.ts
@@ -25,7 +25,15 @@ export function registerMcpTools(server: McpServer): void {
   server.registerTool(
     "ctx_advisor",
     {
+      title:
+        "Primary org knowledge (ctx_advisor) — call before planning & standards",
       description: [
+        "MANDATORY default: Call ctx_advisor early and often whenever org standards, architecture, tooling choices, or plans are involved. When in doubt, call — more calls beats too few. This is the single entrypoint to your organization's knowledge graph (CoALA, memory engine, indexed org context).",
+        "",
+        "RISK — Skipping ctx_advisor risks rework, diverging from org patterns, violating ADRs, and introducing technology that isn't allowed.",
+        "",
+        "ANTI-PATTERN — Local repository search, grep, and file reads do not replace org ADRs, skills, and standards. Call ctx_advisor first when your plan or decision depends on those; search the codebase afterward for implementation details.",
+        "",
         "ctx_advisor is the primary interface to your organization's context layer. It answers using the CoALA framework and is powered by a strong memory engine and knowledge graph.",
         "",
         "It provides: services, interfaces, standards, practices, ADRs, and guidance across the organization. Use it to retrieve any organizational memory that may be useful for the user.",
@@ -55,8 +63,6 @@ export function registerMcpTools(server: McpServer): void {
         "- Relevant context: repo, domain, files, or subsystems involved",
         "- Options you're considering, if any",
         "",
-        "RISK — Skipping this tool risks: rework, diverging from org patterns, violating ADRs, and introducing tech that isn't allowed.",
-        "",
         "EXAMPLE PROMPTS:",
         "- 'User wants to add a database. They mentioned Postgres. Validate: is Postgres allowed? What patterns does this org use for DB access?'",
         "- 'Planning to add rate limiting to the MCP endpoint. What middleware patterns does this org use? Any architectural constraints?'",
@@ -65,7 +71,7 @@ export function registerMcpTools(server: McpServer): void {
         "- currentProjectName: Name of the current project (often the service, app, package, or repo). Pass the same value across the whole conversation.",
         "- conversationId: Unique string identifying this conversation/session. Use the same value for all tool calls within the same conversation.",
         "",
-        "When in doubt, call. More calls is better than fewer. This tool is the single entrypoint to your org's knowledge graph — use it aggressively.",
+        "When in doubt, call. This tool is the single entrypoint to your org's knowledge graph — use it aggressively.",
       ].join("\n"),
       inputSchema: z.object({
         prompt: z.string().min(1),


### PR DESCRIPTION
## Summary

- Add MCP `title` so clients surface a short hook: primary org knowledge, call before planning and standards.
- Reorder `ctx_advisor` description: mandatory default, RISK, and anti-pattern (local repo search/grep vs org ADRs) before the long-form sections.
- Tighten closing line; extend unit tests (title, distinctive phrases, auth context mocks for handler).

## Motivation

Help agents route to `ctx_advisor` instead of defaulting to file search when org standards matter.