### PR TITLE
docs(mcp): streamable-http default and client-specific MCP config (CTX-25)

### DIFF
--- a/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
+++ b/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
@@ -3,12 +3,15 @@ title: MCP docs
 description: Connect ctx| MCP in one step. OAuth is handled via redirect in your MCP client.
 ---
 
+As of **26 March 2026**, MCP remote servers use the **`streamable-http`** transport type in client configuration. Use that value unless your client is pinned to an older spec (see [Troubleshooting](#troubleshooting)).
+
 Add ctx| as an MCP server like this:
 
 ```json
 {
   "mcpServers": {
     "ctxpipe": {
+      "type": "streamable-http",
       "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org"
     }
   }
@@ -26,13 +29,77 @@ Your MCP client will redirect you to ctx| to sign in and authorise access.
 
 After approval, it returns to the client and the server is ready to use.
 
-No bearer token setup is required.
+No bearer token setup is required when your client supports OAuth redirect for MCP.
+
+## Client-specific configuration
+
+Different clients read the same fields but not every UI exposes them the same way. Always set **`type`** to **`streamable-http`** and **`url`** to your MCP endpoint (including `orgSlug`).
+
+### Cursor
+
+Config file: **`.cursor/mcp.json`** at the root of your project (or the path your workspace uses for MCP).
+
+```json
+{
+  "mcpServers": {
+    "ctxpipe": {
+      "type": "streamable-http",
+      "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org"
+    }
+  }
+}
+```
+
+### Claude (Code / Desktop)
+
+Use the same **`streamable-http`** + **`url`** shape in the MCP server entry your Claude product expects (e.g. managed server list or project config, depending on version).
+
+```json
+{
+  "mcpServers": {
+    "ctxpipe": {
+      "type": "streamable-http",
+      "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org"
+    }
+  }
+}
+```
+
+### Opencode
+
+Opencode expects the server to be **enabled** explicitly in some setups. Include **`enabled`** alongside **`type`** and **`url`**:
+
+```json
+{
+  "mcpServers": {
+    "ctxpipe": {
+      "type": "streamable-http",
+      "enabled": true,
+      "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org"
+    }
+  }
+}
+```
+
+### Other clients
+
+If your client’s docs only mention **`http`** or **SSE**, check for an update that supports **Streamable HTTP** / **`streamable-http`** — that is the current default for new integrations.
+
+## API keys (no OAuth redirect)
+
+If your client **cannot** complete an OAuth redirect for MCP, use an API key and `Authorization` instead. See [Quickstart](/docs/self-hosting/quickstart) for a copy-paste example with `headers.Authorization`.
+
+## Troubleshooting
+
+- **`streamable-http` not recognised** — upgrade the client; older builds may still expect `"type": "http"` or a legacy transport name. Prefer upgrading so you stay on the current transport.
+- **Connection fails after pasting URL only** — add **`"type": "streamable-http"`**; omitting `type` leaves behaviour undefined across clients.
+- **Opencode shows the server but it never connects** — set **`"enabled": true`** on that entry.
 
 ## Notes
 
 - `orgSlug` is required. Replace `your-org` with your organisation slug from ctx|.
 - For self-hosted deployments, keep the same path/query and swap the base URL.
-- If your client does not support OAuth redirect for MCP, it will fail to connect.
+- If your client does not support OAuth redirect for MCP, use [API keys](#api-keys-no-oauth-redirect) instead of expecting the browser flow to work inside the client.
 
 ## Related
 

--- a/apps/docs/content/docs/self-hosting/quickstart.mdx
+++ b/apps/docs/content/docs/self-hosting/quickstart.mdx
@@ -23,6 +23,7 @@ Add the following to your MCP client configuration (e.g. `.cursor/mcp.json`):
 {
   "mcpServers": {
     "ctxpipe": {
+      "type": "streamable-http",
       "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org-slug",
       "headers": {
         "Authorization": "Bearer YOUR_API_KEY"

--- a/apps/ui/src/routes/onboarding.tsx
+++ b/apps/ui/src/routes/onboarding.tsx
@@ -105,6 +105,7 @@ function OnboardingPage() {
   const mcpSnippet = `{
   "mcpServers": {
     "ctxpipe": {
+      "type": "streamable-http",
       "url": "https://app.ctxpipe.ai/mcp?orgSlug=${mcpSnippetOrgSlug}"
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **CTX-25** and incorporates feedback to treat **`streamable-http`** as the default MCP transport (current standard as of 26 March 2026).

## Changes

- **`apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx`**: Expanded MCP guide with `streamable-http` in the main example, **Client-specific configuration** (Cursor, Claude, Opencode), **API keys** cross-link to Quickstart, **Troubleshooting** (legacy `http`, missing `type`, Opencode `enabled`), and updated **Notes** for non-OAuth clients.
- **`apps/docs/content/docs/self-hosting/quickstart.mdx`**: Added `"type": "streamable-http"` to the API-key MCP snippet so it matches the transport docs.
- **`apps/ui/src/routes/onboarding.tsx`**: Onboarding copy-paste MCP snippet now includes `streamable-http` so in-product text matches the docs.

## Verification

- `pnpm install`
- `pnpm --filter @ctxpipe/docs build` — succeeded.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-25](https://linear.app/ctxpipe/issue/CTX-25/add-detail-to-mcp-docs)

<div><a href="https://cursor.com/agents/bc-c947444c-000d-41d0-a7a6-cbad9fe06b2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c947444c-000d-41d0-a7a6-cbad9fe06b2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

