### PR TITLE
fix(ui): chat code snippets copy/download and streaming skeleton (CTX-15)

### DIFF
--- a/apps/ui/src/components/ai-elements/message.tsx
+++ b/apps/ui/src/components/ai-elements/message.tsx
@@ -57,7 +57,9 @@ export const MessageContent = ({
       "group-[.is-user]:overflow-hidden",
       "group-[.is-assistant]:overflow-visible",
       "group-[.is-user]:rounded-none group-[.is-user]:border-0 group-[.is-user]:bg-white/[0.05] group-[.is-user]:p-4 group-[.is-user]:text-foreground",
-      "group-[.is-assistant]:rounded-none group-[.is-assistant]:bg-transparent group-[.is-assistant]:p-0 group-[.is-assistant]:text-foreground/90",
+      /* Assistant: do not set text colour on this wrapper — it flattens Streamdown/Shiki token
+         spans that use color: var(--sdm-c, inherit). Body copy colour comes from Streamdown + CSS. */
+      "group-[.is-assistant]:rounded-none group-[.is-assistant]:bg-transparent group-[.is-assistant]:p-0",
       className,
     )}
     {...props}
@@ -324,12 +326,17 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown>
 
 const streamdownPlugins = { cjk, code, math, mermaid }
 
+/** Light + dark Shiki themes (required pair for codeToTokens); app is `.dark` so dark slot colours apply. */
+const streamdownShikiTheme = ["github-light", "github-dark-dimmed"] as const
+
 export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
     <Streamdown
       {...props}
       className={cn(
         "ctx-streamdown size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        /* Body copy only — fenced code blocks are not inside these, so Shiki keeps token colours */
+        "[&_blockquote]:text-muted-foreground [&_h1]:text-foreground [&_h2]:text-foreground [&_h3]:text-foreground [&_h4]:text-foreground [&_li]:text-foreground/90 [&_ol]:text-foreground/90 [&_p]:text-foreground/90 [&_strong]:text-foreground [&_ul]:text-foreground/90",
         "*:data-[streamdown='table-wrapper']:bg-transparent",
         "*:data-[streamdown='table-wrapper']:my-4",
         "*:data-[streamdown='table-wrapper']:p-0",
@@ -339,8 +346,10 @@ export const MessageResponse = memo(
         "[&>[data-streamdown='table-wrapper']>div:first-child_svg]:w-3",
         className,
       )}
+      controls={{ code: true, mermaid: true, table: true }}
       isAnimating={false}
       plugins={streamdownPlugins}
+      shikiTheme={streamdownShikiTheme}
     />
   ),
   (prevProps, nextProps) => prevProps.children === nextProps.children,

--- a/apps/ui/src/components/ai-elements/message.tsx
+++ b/apps/ui/src/components/ai-elements/message.tsx
@@ -327,20 +327,20 @@ const streamdownPlugins = { cjk, code, math, mermaid }
 export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
     <Streamdown
+      {...props}
       className={cn(
-        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        "ctx-streamdown size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         "*:data-[streamdown='table-wrapper']:bg-transparent",
         "*:data-[streamdown='table-wrapper']:my-4",
         "*:data-[streamdown='table-wrapper']:p-0",
         "*:data-[streamdown='table-wrapper']:border-0",
         "*:data-[streamdown='table-wrapper']:gap-1",
-        // "*:data-[streamdown='table-wrapper']:first-child:*:svg:h-3",
         "[&>[data-streamdown='table-wrapper']>div:first-child_svg]:h-3",
         "[&>[data-streamdown='table-wrapper']>div:first-child_svg]:w-3",
         className,
       )}
+      isAnimating={false}
       plugins={streamdownPlugins}
-      {...props}
     />
   ),
   (prevProps, nextProps) => prevProps.children === nextProps.children,

--- a/apps/ui/src/components/ai-elements/message.tsx
+++ b/apps/ui/src/components/ai-elements/message.tsx
@@ -51,7 +51,11 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "flex w-full min-w-0 max-w-full flex-col gap-2 overflow-hidden text-[15px] leading-relaxed",
+      "flex w-full min-w-0 max-w-full flex-col gap-2 text-[15px] leading-relaxed",
+      /* User bubble: clip to rounded box. Assistant: no overflow-y clip so Streamdown code
+         block sticky copy/download controls (negative top offset) stay visible and clickable. */
+      "group-[.is-user]:overflow-hidden",
+      "group-[.is-assistant]:overflow-visible",
       "group-[.is-user]:rounded-none group-[.is-user]:border-0 group-[.is-user]:bg-white/[0.05] group-[.is-user]:p-4 group-[.is-user]:text-foreground",
       "group-[.is-assistant]:rounded-none group-[.is-assistant]:bg-transparent group-[.is-assistant]:p-0 group-[.is-assistant]:text-foreground/90",
       className,

--- a/apps/ui/src/features/chat/ConversationThread.tsx
+++ b/apps/ui/src/features/chat/ConversationThread.tsx
@@ -80,11 +80,9 @@ function messageHasRenderableParts(message: UIMessage) {
 }
 
 function AgentSenderLabel() {
-  return (
-    <span className="inline-flex items-baseline gap-0 whitespace-nowrap">
-      <span className="ctx-label-muted">ctx</span><span className="font-mono text-[10px] uppercase text-teal-400">|</span>
-    </span>
-  )
+  // biome-ignore format: keep pipe inline so the span has no whitespace around |
+  const pipe = <span key="pipe" className="text-teal-400">|</span>
+  return <span className="ctx-label-muted">{["ctx", pipe]}</span>
 }
 
 export function ConversationThread(props: {

--- a/apps/ui/src/features/chat/ConversationThread.tsx
+++ b/apps/ui/src/features/chat/ConversationThread.tsx
@@ -79,6 +79,14 @@ function messageHasRenderableParts(message: UIMessage) {
   return message.parts.some(isRenderableMessagePart)
 }
 
+function AgentSenderLabel() {
+  return (
+    <span className="inline-flex items-baseline gap-0 whitespace-nowrap">
+      <span className="ctx-label-muted">ctx</span><span className="font-mono text-[10px] uppercase text-teal-400">|</span>
+    </span>
+  )
+}
+
 export function ConversationThread(props: {
   messages: UIMessage[]
   error: Error | null
@@ -138,9 +146,11 @@ export function ConversationThread(props: {
                           )}
                         >
                           <div className="flex items-center gap-2">
-                            <span className="ctx-label-muted">
-                              {isUser ? "you" : "ctx|"}
-                            </span>
+                            {isUser ? (
+                              <span className="ctx-label-muted">you</span>
+                            ) : (
+                              <AgentSenderLabel />
+                            )}
                             {timeLabel ? (
                               <span className="text-[10px] text-muted-foreground/50">
                                 {timeLabel}
@@ -169,7 +179,7 @@ export function ConversationThread(props: {
                         <span className="ctx-indexing-dot" />
                       </div>
                       <div className="min-w-0 flex-1 space-y-0.5">
-                        <span className="ctx-label-muted">ctx|</span>
+                        <AgentSenderLabel />
                         <p className="text-xs text-muted-foreground">
                           Thinking…
                         </p>

--- a/apps/ui/src/features/chat/ConversationThread.tsx
+++ b/apps/ui/src/features/chat/ConversationThread.tsx
@@ -161,26 +161,18 @@ export function ConversationThread(props: {
                     aria-live="polite"
                     aria-label="Waiting for response"
                   >
-                    <div className="max-w-[85%] space-y-1">
-                      <div className="flex items-center gap-2">
-                        <span className="ctx-label-muted">ctx|</span>
-                      </div>
+                    <div className="flex max-w-[85%] items-center gap-3">
                       <div
-                        className={cn(
-                          "flex w-full min-w-0 max-w-full flex-col gap-3 overflow-x-auto text-sm",
-                          "animate-pulse",
-                        )}
+                        className="flex size-8 shrink-0 items-center justify-center rounded-full border border-white/[0.08] bg-foreground/[0.04]"
+                        aria-hidden
                       >
-                        <div className="flex gap-1.5">
-                          <span className="size-2 rounded-full bg-muted-foreground/40" />
-                          <span className="size-2 rounded-full bg-muted-foreground/40" />
-                          <span className="size-2 rounded-full bg-muted-foreground/40" />
-                        </div>
-                        <div className="flex w-full flex-col gap-2">
-                          <div className="h-3 w-[92%] max-w-none rounded-sm bg-muted-foreground/15" />
-                          <div className="h-3 w-[78%] rounded-sm bg-muted-foreground/15" />
-                          <div className="h-3 w-[85%] rounded-sm bg-muted-foreground/12" />
-                        </div>
+                        <span className="ctx-indexing-dot" />
+                      </div>
+                      <div className="min-w-0 space-y-0.5">
+                        <span className="ctx-label-muted">ctx|</span>
+                        <p className="text-xs text-muted-foreground">
+                          Thinking…
+                        </p>
                       </div>
                     </div>
                   </div>

--- a/apps/ui/src/features/chat/ConversationThread.tsx
+++ b/apps/ui/src/features/chat/ConversationThread.tsx
@@ -167,7 +167,7 @@ export function ConversationThread(props: {
                       </div>
                       <div
                         className={cn(
-                          "flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm",
+                          "flex w-full min-w-0 max-w-full flex-col gap-3 overflow-x-auto text-sm",
                           "animate-pulse",
                         )}
                       >
@@ -175,6 +175,11 @@ export function ConversationThread(props: {
                           <span className="size-2 rounded-full bg-muted-foreground/40" />
                           <span className="size-2 rounded-full bg-muted-foreground/40" />
                           <span className="size-2 rounded-full bg-muted-foreground/40" />
+                        </div>
+                        <div className="flex w-full flex-col gap-2">
+                          <div className="h-3 w-[92%] max-w-none rounded-sm bg-muted-foreground/15" />
+                          <div className="h-3 w-[78%] rounded-sm bg-muted-foreground/15" />
+                          <div className="h-3 w-[85%] rounded-sm bg-muted-foreground/12" />
                         </div>
                       </div>
                     </div>

--- a/apps/ui/src/features/chat/ConversationThread.tsx
+++ b/apps/ui/src/features/chat/ConversationThread.tsx
@@ -161,14 +161,14 @@ export function ConversationThread(props: {
                     aria-live="polite"
                     aria-label="Waiting for response"
                   >
-                    <div className="flex max-w-[85%] items-center gap-3">
+                    <div className="flex w-full max-w-[85%] items-center gap-3">
                       <div
                         className="flex size-8 shrink-0 items-center justify-center rounded-full border border-white/[0.08] bg-foreground/[0.04]"
                         aria-hidden
                       >
                         <span className="ctx-indexing-dot" />
                       </div>
-                      <div className="min-w-0 space-y-0.5">
+                      <div className="min-w-0 flex-1 space-y-0.5">
                         <span className="ctx-label-muted">ctx|</span>
                         <p className="text-xs text-muted-foreground">
                           Thinking…

--- a/apps/ui/src/features/chat/components/ChatWorkspaceSkeleton.tsx
+++ b/apps/ui/src/features/chat/components/ChatWorkspaceSkeleton.tsx
@@ -34,8 +34,8 @@ export function ChatWorkspaceSkeleton(props: { orgSlug: string }) {
           <ShimmerPlaceholder className="h-3.5 w-3.5 rounded" />
           <ShimmerPlaceholder className="h-4 w-32" />
         </div>
-        <div className="mx-auto max-w-2xl flex-1 space-y-8 p-6">
-          <div className="flex w-full max-w-[70%] flex-col gap-2">
+        <div className="mx-auto w-full max-w-2xl flex-1 space-y-8 p-6">
+          <div className="flex w-full max-w-[85%] flex-col gap-2">
             <ShimmerPlaceholder className="h-3 w-16" />
             <ShimmerPlaceholder className="h-4 w-full" />
             <ShimmerPlaceholder className="h-4 w-[80%]" />

--- a/apps/ui/src/features/chat/components/ConversationThreadSkeleton.tsx
+++ b/apps/ui/src/features/chat/components/ConversationThreadSkeleton.tsx
@@ -3,8 +3,8 @@ import { ShimmerPlaceholder } from "@/components/ui/ShimmerPlaceholder"
 export function ConversationThreadSkeleton() {
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-transparent">
-      <div className="mx-auto max-w-2xl flex-1 space-y-6 p-6">
-        <div className="flex w-full max-w-[70%] flex-col gap-2">
+      <div className="mx-auto w-full max-w-2xl flex-1 space-y-8 p-6">
+        <div className="flex w-full max-w-[85%] flex-col gap-2">
           <ShimmerPlaceholder className="h-3 w-14" />
           <ShimmerPlaceholder className="h-4 w-full" />
           <ShimmerPlaceholder className="h-4 w-[80%]" />
@@ -14,7 +14,7 @@ export function ConversationThreadSkeleton() {
           <ShimmerPlaceholder className="h-3 w-10" />
           <ShimmerPlaceholder className="h-24 w-full rounded-none" />
         </div>
-        <div className="flex w-full max-w-[70%] flex-col gap-2">
+        <div className="flex w-full max-w-[85%] flex-col gap-2">
           <ShimmerPlaceholder className="h-3 w-12" />
           <ShimmerPlaceholder className="h-4 w-full" />
           <ShimmerPlaceholder className="h-4 w-[85%]" />

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -434,6 +434,67 @@
   .ctx-repo-row {
     @apply flex w-full items-center justify-between gap-4 bg-transparent px-3 py-4 transition-colors hover:bg-foreground/[0.03] rounded-none sm:px-4;
   }
+
+  /*
+   * Streamdown code blocks: one toolbar row (language left, copy/download right).
+   * Library uses flex-col + sticky actions with negative margin; we switch to grid
+   * so the header and actions share row 1, and the highlighted body spans row 2.
+   */
+  .ctx-streamdown [data-streamdown="code-block"] {
+    content-visibility: visible;
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: auto auto;
+    align-items: center;
+  }
+
+  .ctx-streamdown
+    [data-streamdown="code-block"]
+    > [data-streamdown="code-block-header"] {
+    grid-column: 1;
+    grid-row: 1;
+    @apply min-h-8 min-w-0;
+  }
+
+  .ctx-streamdown [data-streamdown="code-block"] > div.pointer-events-none {
+    grid-column: 2;
+    grid-row: 1;
+    position: static !important;
+    inset: auto !important;
+    top: auto !important;
+    margin: 0 !important;
+    height: auto !important;
+    min-height: 2rem;
+    pointer-events: auto !important;
+    align-self: center;
+    justify-self: end;
+    z-index: 2;
+  }
+
+  .ctx-streamdown
+    [data-streamdown="code-block"]
+    > div.pointer-events-none
+    > [data-streamdown="code-block-actions"] {
+    @apply flex shrink-0 items-center gap-0.5 border-0 bg-transparent p-0 shadow-none;
+  }
+
+  .ctx-streamdown [data-streamdown="code-block"] > *:last-child {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    min-width: 0;
+  }
+
+  .ctx-streamdown
+    [data-streamdown="code-block-copy-button"]:not(:disabled):hover,
+  .ctx-streamdown
+    [data-streamdown="code-block-download-button"]:not(:disabled):hover {
+    @apply rounded-sm bg-foreground/[0.08] text-foreground;
+  }
+
+  .ctx-streamdown [data-streamdown="code-block-copy-button"]:disabled,
+  .ctx-streamdown [data-streamdown="code-block-download-button"]:disabled {
+    @apply cursor-not-allowed opacity-50;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -2,6 +2,7 @@
 @import "@daveyplate/better-auth-ui/css";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import "streamdown/styles.css";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -85,6 +86,58 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+}
+
+/*
+ * Streamdown code blocks: toolbar alignment + reliable click targets.
+ * Default layout uses a negative-margin sticky row with pointer-events-none;
+ * some stacks break hit-testing; absolute toolbar matches language row height.
+ * Square corners + muted surfaces to match the rest of the app (no rounded-xl/md).
+ */
+[data-streamdown="code-block"] {
+  position: relative;
+  border-radius: 0 !important;
+}
+
+[data-streamdown="code-block-header"] {
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+  padding-right: 5.5rem;
+}
+
+[data-streamdown="code-block-body"],
+[data-streamdown="code-block-body"] pre,
+[data-streamdown="code-block-actions"],
+[data-streamdown="mermaid-block"] {
+  border-radius: 0 !important;
+}
+
+/*
+ * Shiki (Streamdown): token spans use --sdm-c / --shiki-dark on each span.
+ * Parent text colour must not replace the cascade when Tailwind uses inherit fallback.
+ */
+[data-streamdown="code-block-body"] pre code span {
+  color: var(--sdm-c, inherit);
+}
+
+.dark [data-streamdown="code-block-body"] pre code span {
+  color: var(--shiki-dark, var(--sdm-c, inherit));
+}
+
+[data-streamdown="code-block"] > div.pointer-events-none {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  left: auto;
+  margin-top: 0 !important;
+  width: auto;
+  z-index: 20;
+  pointer-events: auto !important;
+}
+
+[data-streamdown="inline-code"] {
+  border-radius: 0;
 }
 
 .dark {

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -22,6 +22,9 @@ const config = defineConfig({
       usePolling: true,
     },
   },
+  optimizeDeps: {
+    include: ["shiki", "@streamdown/code", "streamdown"],
+  },
   plugins: [
     devtools(),
     tsconfigPaths({ projects: ["./tsconfig.json"] }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **CTX-15** follow-ups from design review: code block toolbar alignment, interactive copy/download, and a calmer assistant “processing” state while streaming.

## Changes

### Code blocks (Streamdown)

- **`MessageResponse`**: `isAnimating={false}` so copy/download are not disabled while the assistant message streams.
- **`styles.css` (`.ctx-streamdown`)**: Override Streamdown’s default **flex column + sticky** action bar (which stacked the language label above the buttons and relied on negative margin). Use **CSS grid** so row 1 = language (column 1) + actions (column 2), row 2 = highlighted body spanning full width. Reset the action wrapper to **static positioning** and **`pointer-events: auto`** so clicks reach the buttons.
- **Hover**: explicit hover styles on `[data-streamdown="code-block-copy-button"]` and `code-block-download-button`.

### Streaming / “agent” state

- **`ConversationThread`**: Replace skeleton bars with a **small circular avatar** (reuses `ctx-indexing-dot`) plus **“Thinking…”** copy next to the `ctx|` label—no fake message skeleton.

## Testing

- `pnpm --filter @ctxpipe/ui test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-15](https://linear.app/ctxpipe/issue/CTX-15/code-snippets-not-accessible-in-ui)

<div><a href="https://cursor.com/agents/bc-bc5c3f77-53b3-4cf7-9aaf-9bdce1697966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc5c3f77-53b3-4cf7-9aaf-9bdce1697966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

