### PR TITLE
CI: Blacksmith checkout caching + sticky pnpm store

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,7 @@ jobs:
             dockerfile: apps/otel-collector/Dockerfile
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
@@ -63,14 +63,22 @@ jobs:
       DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - name: Mount pnpm store (sticky disk)
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-pnpm-store
+          path: ~/.pnpm-store
+
+      - uses: useblacksmith/setup-node@v5
         with:
           node-version: "22"
-          cache: "pnpm"
+
+      - name: Ensure pnpm store path
+        run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -115,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -139,14 +147,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - name: Mount pnpm store (sticky disk)
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-pnpm-store
+          path: ~/.pnpm-store
+
+      - uses: useblacksmith/setup-node@v5
         with:
           node-version: "22"
-          cache: "pnpm"
+
+      - name: Ensure pnpm store path
+        run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -42,7 +42,7 @@ jobs:
             dockerfile: apps/otel-collector/Dockerfile
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
@@ -81,14 +81,22 @@ jobs:
       env_id: ${{ steps.railway_env.outputs.env_id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
+
+      - name: Mount pnpm store sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-pnpm-store
+          path: ~/.pnpm-store
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: useblacksmith/setup-node@v5
         with:
           node-version: "22"
-          cache: "pnpm"
+
+      - name: Force pnpm store path
+        run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Install Railway CLI
         run: npm install -g @railway/cli@4.35.2

--- a/.github/workflows/terraform-plan-pr.yaml
+++ b/.github/workflows/terraform-plan-pr.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This updates GitHub Actions workflows to follow Blacksmith caching guides:

- Use `useblacksmith/checkout@v1` (git checkout caching via sticky-disk mirror)
- Mount `useblacksmith/stickydisk@v1` for the pnpm store at `~/.pnpm-store`
- Switch Node setup to `useblacksmith/setup-node@v5`
- Force pnpm store-dir to `~/.pnpm-store` before installs to ensure the sticky disk is used

Workflows updated:
- `.github/workflows/deploy.yaml`
- `.github/workflows/pr-deploy.yaml`
- `.github/workflows/terraform-plan-pr.yaml`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdbe09d7-2d1b-482f-bbad-ed28516fc67b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdbe09d7-2d1b-482f-bbad-ed28516fc67b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

