### PR TITLE
docs(agents): Cursor Cloud and headless VM development notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,15 @@ Run **`pnpm`** commands from the **repository root** (not inside `apps/*`).
 
 **Documentation site** ([apps/docs](apps/docs/AGENTS.md)): **`pnpm dev:docs`** starts Next.js on **http://localhost:3003** — the docs app is at the site root (**`/`**); **`/docs`** is still the Fumadocs base path for doc URLs. Root **`pnpm dev`** runs backend + UI only; use **`pnpm dev:docs`** or **`pnpm dev --filter @ctxpipe/docs`** (args forwarded in [`scripts/dev-apps.sh`](scripts/dev-apps.sh)) when you need the docs app.
 
+### Cursor Cloud and headless remote VMs
+
+Remote agent environments (for example Cursor Cloud) often run without a desktop browser and may inject extra environment variables. Prefer the same install → **`apps/backend/.env.local`** → **`pnpm dev:infra`** → **`pnpm dev`** flow when Docker and portless behave like a normal host.
+
+- **Docker**: Required for **`pnpm dev:infra`** and for codesearch during **`pnpm dev`**. The daemon must support image pulls and port publishing; some Linux VMs need Docker-in-Docker–style settings (for example `fuse-overlayfs` as the storage driver and legacy iptables) so the daemon can start.
+- **Bun**: Install Bun to match the [root `package.json`](package.json) **`engines.bun`** entry; the backend and several scripts expect it on `PATH`.
+- **`apps/backend/.env.local`**: Do not set optional keys to empty strings (for example `SMTP_CONNECTION_URL=`). Either omit them or comment them out; empty strings fail Zod URL and email validation. Set **`AUTH_SECRET`** (≥ 32 characters) and align **`DATABASE_URL`** / **`GRAPH_DB_URI`** with Compose host ports (see [apps/backend/.env.example](apps/backend/.env.example)).
+- **Portless vs fixed ports**: If injected **`PORT`** or other variables conflict with [portless](https://portless.sh/), run the backend and UI without portless for smoke tests: backend on **`http://localhost:3000`**, UI on **`http://localhost:3002`**, with **`UI_PROXY_URL=http://localhost:3002`**, **`AUTH_BASE_URL=http://localhost:3000`**, and **`AUTH_ALLOWED_ORIGINS`** including both origins (and **`VITE_PUBLIC_API_URL=http://localhost:3000`** for the UI dev server).
+
 ### Container deploy (Compose `deploy` profile)
 
 From the repo root, set **`AUTH_SECRET`** (≥ 32 characters), **`AUTH_BASE_URL`**, **`CTXPIPE_PUBLIC_APP_URL`** (usually the public origin users use for the API / app), and optionally **`AUTH_ALLOWED_ORIGINS`** in a root **`.env`** next to [docker-compose.yml](docker-compose.yml) — see [docker-compose.env.example](docker-compose.env.example). Then run **`pnpm start`** (builds images on first run). TLS and a reverse proxy in front of published ports are left to the operator. Better Auth schema upgrades may require **`pnpm --filter @ctxpipe/backend auth:migrate`** against the same database when upgrading.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a short **Cursor Cloud and headless remote VMs** subsection to the root [AGENTS.md](AGENTS.md) so agents know how to bootstrap in environments that differ from a typical laptop (Docker-in-Docker constraints, Bun on PATH, `.env.local` pitfalls with empty optional strings, and a portless-free localhost smoke-test when injected env conflicts with the standard `pnpm dev` flow).

## Notes

- No application code changes.
- VM startup dependency refresh was suggested as `pnpm install` via the workspace setup helper.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-099ada7b-a569-4ab9-8e4a-a04bcee3b219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-099ada7b-a569-4ab9-8e4a-a04bcee3b219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

