### PR TITLE
Cursor Cloud Agents: add environment.json + repo instructions

### DIFF
--- a/.agents/Dockerfile
+++ b/.agents/Dockerfile
@@ -1,0 +1,67 @@
+# Cursor Cloud Agent: Docker + Compose for `pnpm dev:infra` (see
+# https://cursor.com/docs/cloud-agent/setup — "Running Docker" / recommended Dockerfile).
+# Paths in environment.json `build` are relative to `.cursor` (this repo: `.agents` symlink).
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    git \
+    sudo \
+  && rm -rf /var/lib/apt/lists/*
+
+########################################################
+# NODE + PNPM (repo uses packageManager pnpm@10.12.1)
+########################################################
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+  && apt-get update && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable && corepack prepare pnpm@10.12.1 --activate
+
+########################################################
+# DOCKER INSTALLATION (Cursor docs — complex setups)
+########################################################
+
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y \
+    docker-ce=5:28.5.2-1~ubuntu.24.04~noble \
+    docker-ce-cli=5:28.5.2-1~ubuntu.24.04~noble \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y fuse-overlayfs && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/docker && \
+    printf '%s\n' '{' \
+    '  "storage-driver": "fuse-overlayfs"' \
+    '}' > /etc/docker/daemon.json
+RUN apt-get update && apt-get install -y iptables && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+########################################################
+# CONFIG UBUNTU USER (Cursor docs)
+########################################################
+
+RUN mkdir -p /etc/ssh/sshd_config.d && \
+    echo 'PasswordAuthentication no\nChallengeResponseAuthentication no\nUsePAM no' > /etc/ssh/sshd_config.d/disable_password_auth.conf
+
+RUN id -u ubuntu &>/dev/null || useradd -m -s /bin/bash ubuntu
+RUN groupadd -f docker && usermod -aG docker ubuntu
+RUN usermod -aG sudo ubuntu
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+RUN echo "ubuntu:ubuntu" | chpasswd
+
+WORKDIR /workspace

--- a/.agents/environment.json
+++ b/.agents/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "corepack enable && pnpm install",
+  "start": "command -v docker >/dev/null 2>&1 && (sudo service docker start || true) || true"
+}

--- a/.agents/environment.json
+++ b/.agents/environment.json
@@ -1,4 +1,8 @@
 {
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
   "install": "corepack enable && pnpm install",
-  "start": "command -v docker >/dev/null 2>&1 && (sudo service docker start || true) || true"
+  "start": "sudo service docker start"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ Agent instructions are **distributed**: this file covers repo-wide rules; apps a
 
 Cloud agents run on an isolated Ubuntu machine. This repo provides a default cloud-agent environment config at **`.cursor/environment.json`** (implemented as `.cursor → .agents` symlink + [`.agents/environment.json`](.agents/environment.json)).
 
-- **Install/update**: the cloud agent will run `corepack enable && pnpm install` from the repo root automatically.
+- **Docker image**: the environment is built from [`.agents/Dockerfile`](.agents/Dockerfile) following Cursor’s **Running Docker** guidance ([Cloud Agent setup](https://cursor.com/docs/cloud-agent/setup)): Docker CE + `fuse-overlayfs` + `iptables-legacy`, plus **Node.js** and **pnpm** so `install` can run. **`start`** runs `sudo service docker start` so `docker compose` works before tasks.
+- **Install/update**: after the image boots, Cursor runs `corepack enable && pnpm install` from the repo root (`install` in `environment.json`).
 - **Docker + Postgres**:
   - **Important**: `localhost` in cloud agents is the **cloud VM**, not your laptop.
   - If Docker is available on the VM, the agent can start the same infra stack you use locally with **`pnpm dev:infra`** (Postgres on `localhost:5433`, FalkorDB on `localhost:6379` by default; see [docker-compose.yml](docker-compose.yml) and [docker-compose.env.example](docker-compose.env.example)).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,24 @@ Agent instructions are **distributed**: this file covers repo-wide rules; apps a
 
 - **Docker Compose**: Single [docker-compose.yml](docker-compose.yml) uses **profiles** (see [.ai/memory/decisions/ADR-015-docker-compose-profiles-and-small-scale-deploy.md](.ai/memory/decisions/ADR-015-docker-compose-profiles-and-small-scale-deploy.md)). **`pnpm dev:infra`** runs `docker compose --profile infra up -d` (Postgres, FalkorDB, OTEL only). **`pnpm start`** runs `docker compose --profile deploy up -d` (production images: migrate, backend, worker, UI, codesearch). For day-to-day coding, **`pnpm dev`** runs backend + UI on the host (portless + Turbo) and **codesearch in Docker** ([`scripts/codesearch-docker-dev.sh`](scripts/codesearch-docker-dev.sh): `start.sh` = Zoekt + API, random host port → **`CODESEARCH_URL`**). Override host ports via **`CTXPIPE_*`** — [docker-compose.env.example](docker-compose.env.example). Optional **Amplitude** analytics env (`AMPLITUDE_API_KEY`, `AMPLITUDE_REGION`) is documented there and in [apps/backend/.env.example](apps/backend/.env.example) (ADR-017).
 
+### Cursor Cloud specific instructions
+
+Cloud agents run on an isolated Ubuntu machine. This repo provides a default cloud-agent environment config at **`.cursor/environment.json`** (implemented as `.cursor → .agents` symlink + [`.agents/environment.json`](.agents/environment.json)).
+
+- **Install/update**: the cloud agent will run `corepack enable && pnpm install` from the repo root automatically.
+- **Docker + Postgres**:
+  - **Important**: `localhost` in cloud agents is the **cloud VM**, not your laptop.
+  - If Docker is available on the VM, the agent can start the same infra stack you use locally with **`pnpm dev:infra`** (Postgres on `localhost:5433`, FalkorDB on `localhost:6379` by default; see [docker-compose.yml](docker-compose.yml) and [docker-compose.env.example](docker-compose.env.example)).
+  - If Docker is **not** available or you prefer managed services, use a hosted Postgres and set `DATABASE_URL` via Secrets.
+- **Secrets (Cursor dashboard → Cloud Agents → Secrets)**:
+  - **Required**: `AUTH_SECRET` (≥ 32 chars) for backend auth initialization/tests (see [apps/backend/.env.example](apps/backend/.env.example)).
+  - **Database**: set `DATABASE_URL` unless you intentionally rely on a Compose-started Postgres on the VM (e.g. `postgresql://ctxpipe:ctxpipe@localhost:5433/ctxpipe`).
+  - **Optional**: `GRAPH_DB_URI` (when running graph features; use `redis://localhost:6379` if FalkorDB is started by `pnpm dev:infra`), and any model/API keys you need for specific tasks.
+- **Suggested verification commands** (no full dev stack):
+  - `pnpm lint`
+  - `pnpm --filter @ctxpipe/backend test`
+  - `pnpm --filter @ctxpipe/ui test`
+
 ### Agent runbook — host dev (run from repo root)
 
 Run **`pnpm`** commands from the **repository root** (not inside `apps/*`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds repo-level Cursor Cloud Agent configuration and guidance.

- Adds `.agents/environment.json` (picked up as `.cursor/environment.json` via symlink) to ensure cloud agents run `corepack enable && pnpm install` and attempt to start the Docker daemon when available.
- Updates root `AGENTS.md` with a **Cursor Cloud specific instructions** section covering:
  - required secrets (`AUTH_SECRET`, optional `DATABASE_URL` depending on whether infra is started on the VM)
  - Compose-on-cloud-VM vs hosted DB guidance
  - suggested verification commands (`pnpm lint`, backend/ui tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad576c9b-15a9-4ba1-affb-fe222ae0ff49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad576c9b-15a9-4ba1-affb-fe222ae0ff49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

