### PR TITLE
Cloud agent: Docker-ready start script, Bun in image, rebuild docs

### DIFF
--- a/.agents/Dockerfile
+++ b/.agents/Dockerfile
@@ -25,6 +25,13 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 RUN corepack enable && corepack prepare pnpm@10.12.1 --activate
 
 ########################################################
+# BUN (repo engines + backend/codesearch dev scripts use `bun`)
+########################################################
+
+RUN curl -fsSL https://bun.sh/install | bash \
+  && install -m 0755 /root/.bun/bin/bun /usr/local/bin/bun
+
+########################################################
 # DOCKER INSTALLATION (Cursor docs — complex setups)
 ########################################################
 

--- a/.agents/environment.json
+++ b/.agents/environment.json
@@ -4,5 +4,5 @@
     "context": ".."
   },
   "install": "corepack enable && pnpm install",
-  "start": "sudo service docker start"
+  "start": "bash .agents/start.sh"
 }

--- a/.agents/start.sh
+++ b/.agents/start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Cursor Cloud Agent: run after `install`, before agent tasks.
+# See https://cursor.com/docs/cloud-agent/setup — "Startup commands" / "Running Docker".
+set -euo pipefail
+
+docker_info() {
+  docker info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "cloud-agent: docker CLI not found. Rebuild the environment from .agents/Dockerfile (see Cursor Cloud setup docs)." >&2
+  exit 1
+fi
+
+sudo service docker start || true
+
+# Wait for the daemon (first boot can be slow inside nested containers).
+for _ in $(seq 1 45); do
+  if docker_info; then
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "cloud-agent: Docker daemon did not become ready in time." >&2
+exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ Agent instructions are **distributed**: this file covers repo-wide rules; apps a
 
 Cloud agents run on an isolated Ubuntu machine. This repo provides a default cloud-agent environment config at **`.cursor/environment.json`** (implemented as `.cursor → .agents` symlink + [`.agents/environment.json`](.agents/environment.json)).
 
-- **Docker image**: the environment is built from [`.agents/Dockerfile`](.agents/Dockerfile) following Cursor’s **Running Docker** guidance ([Cloud Agent setup](https://cursor.com/docs/cloud-agent/setup)): Docker CE + `fuse-overlayfs` + `iptables-legacy`, plus **Node.js** and **pnpm** so `install` can run. **`start`** runs `sudo service docker start` so `docker compose` works before tasks.
+- **Docker image**: the environment is built from [`.agents/Dockerfile`](.agents/Dockerfile) following Cursor’s **Running Docker** guidance ([Cloud Agent setup](https://cursor.com/docs/cloud-agent/setup)): Docker CE + `fuse-overlayfs` + `iptables-legacy`, plus **Node.js**, **pnpm**, and **Bun** (matches root `package.json` `engines` and backend dev scripts). **`start`** runs [`.agents/start.sh`](.agents/start.sh): `sudo service docker start` and wait until `docker info` succeeds so `docker compose` is ready before tasks.
+- **Rebuild after changing the Dockerfile**: Cursor only applies `.cursor/environment.json` when the cloud image is (re)built. If `docker` is missing on the agent VM, the environment is not using this Dockerfile—rebuild at [cursor.com/onboard](https://cursor.com/onboard) or bump the image so the **build** step runs again.
 - **Install/update**: after the image boots, Cursor runs `corepack enable && pnpm install` from the repo root (`install` in `environment.json`).
 - **Docker + Postgres**:
   - **Important**: `localhost` in cloud agents is the **cloud VM**, not your laptop.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Aligns the repo cloud-agent setup with [Cursor Cloud Agent setup](https://cursor.com/docs/cloud-agent/setup) (Docker daemon in `start`, fuse-overlayfs image already present).

**Changes**
- **`start`**: runs `.agents/start.sh` — `sudo service docker start` and polls until `docker info` succeeds (with clear error if the Docker CLI is missing).
- **`.agents/Dockerfile`**: installs **Bun** to `/usr/local/bin/bun` so `pnpm dev` / backend scripts match root `engines` and do not rely on a missing runtime.
- **`AGENTS.md`**: notes that Dockerfile / `environment.json` changes require a **Cursor cloud image rebuild** (onboard); explains why a VM might have no `docker` CLI.

**Operator note:** After merge, trigger or recreate the cloud environment from the repo so the new Dockerfile build runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e974d61-44dc-4239-8217-79ad14c08c9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e974d61-44dc-4239-8217-79ad14c08c9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

