### PR TITLE
fix(chat): scope conversations to the signed-in user within an org

### DIFF
--- a/apps/backend/migrations/20260414140000_conversations_user_id/migration.sql
+++ b/apps/backend/migrations/20260414140000_conversations_user_id/migration.sql
@@ -1,0 +1,33 @@
+-- Scope conversations to the owning user (org + user), not org-wide.
+ALTER TABLE "conversations" ADD COLUMN "user_id" text;
+--> statement-breakpoint
+-- Backfill only when the org has a single member (unambiguous owner).
+UPDATE "conversations" AS c
+SET "user_id" = s."user_id"
+FROM (
+  SELECT "organization_id", MIN("user_id") AS "user_id"
+  FROM "members"
+  GROUP BY "organization_id"
+  HAVING COUNT(*) = 1
+) AS s
+WHERE c."org_id" = s."organization_id"
+  AND c."user_id" IS NULL;
+--> statement-breakpoint
+-- Drop legacy rows we cannot assign to one user (prevents cross-user visibility).
+DELETE FROM "conversations" WHERE "user_id" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "conversations" ALTER COLUMN "user_id" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "conversations" ADD CONSTRAINT "conversations_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "conversations_org_id_last_message_at_index";
+--> statement-breakpoint
+DROP INDEX IF EXISTS "conversations_org_id_source_index";
+--> statement-breakpoint
+DROP INDEX IF EXISTS "conversations_org_id_updated_at_index";
+--> statement-breakpoint
+CREATE INDEX "conversations_org_id_user_id_last_message_at_index" ON "conversations" ("org_id", "user_id", "last_message_at");
+--> statement-breakpoint
+CREATE INDEX "conversations_org_id_user_id_source_index" ON "conversations" ("org_id", "user_id", "source");
+--> statement-breakpoint
+CREATE INDEX "conversations_org_id_user_id_updated_at_index" ON "conversations" ("org_id", "user_id", "updated_at");

--- a/apps/backend/src/db/schema/conversations.ts
+++ b/apps/backend/src/db/schema/conversations.ts
@@ -1,10 +1,15 @@
 import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+import { users } from "./auth.js"
 
 export const conversations = pgTable(
   "conversations",
   {
     id: text("id").primaryKey(),
     orgId: text("org_id").notNull(),
+    /** Better Auth user id; conversations are private to this user within the org. */
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
     name: text("name").notNull().default("New Chat"),
     source: text("source"),
     lastMessageAt: timestamp("last_message_at", {
@@ -19,8 +24,8 @@ export const conversations = pgTable(
       .defaultNow(),
   },
   (t) => [
-    index().on(t.orgId, t.lastMessageAt),
-    index().on(t.orgId, t.source),
-    index().on(t.orgId, t.updatedAt),
+    index().on(t.orgId, t.userId, t.lastMessageAt),
+    index().on(t.orgId, t.userId, t.source),
+    index().on(t.orgId, t.userId, t.updatedAt),
   ],
 )

--- a/apps/backend/src/mcp/tools.test.ts
+++ b/apps/backend/src/mcp/tools.test.ts
@@ -8,6 +8,8 @@ const {
   ensureConversationMock,
   touchConversationLastMessageMock,
   requireCurrentUserIdMock,
+  requireCurrentOrgIdMock,
+  requireCurrentOrgSlugMock,
 } = vi.hoisted(() => ({
   generateObjectIdMock: vi.fn(() => "thr_test"),
   streamMock: vi.fn(),
@@ -15,6 +17,8 @@ const {
   ensureConversationMock: vi.fn(async () => ({})),
   touchConversationLastMessageMock: vi.fn(async () => {}),
   requireCurrentUserIdMock: vi.fn(() => "user_test123"),
+  requireCurrentOrgIdMock: vi.fn(() => "org_test"),
+  requireCurrentOrgSlugMock: vi.fn(() => "acme"),
 }))
 
 vi.mock("../graphs/index.js", () => ({
@@ -35,6 +39,8 @@ vi.mock("../models/conversations.js", () => ({
 
 vi.mock("../auth/context.js", () => ({
   requireCurrentUserId: requireCurrentUserIdMock,
+  requireCurrentOrgId: requireCurrentOrgIdMock,
+  requireCurrentOrgSlug: requireCurrentOrgSlugMock,
 }))
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"

--- a/apps/backend/src/models/conversations.ts
+++ b/apps/backend/src/models/conversations.ts
@@ -1,5 +1,5 @@
 import { and, desc, eq, lt, or, sql } from "drizzle-orm"
-import { requireCurrentOrgId } from "../auth/context.js"
+import { requireCurrentOrgId, requireCurrentUserId } from "../auth/context.js"
 import { conversations } from "../db/schema/conversations.js"
 import { getOrgDb } from "../db/client.js"
 import {
@@ -30,12 +30,19 @@ export async function ensureConversation(input: {
   source?: string
 }): Promise<ConversationRecord> {
   const orgId = requireCurrentOrgId()
+  const userId = requireCurrentUserId()
   const db = getOrgDb()
 
   const [existing] = await db
     .select()
     .from(conversations)
-    .where(and(eq(conversations.id, input.id), eq(conversations.orgId, orgId)))
+    .where(
+      and(
+        eq(conversations.id, input.id),
+        eq(conversations.orgId, orgId),
+        eq(conversations.userId, userId),
+      ),
+    )
     .limit(1)
 
   if (existing) return existing
@@ -45,6 +52,7 @@ export async function ensureConversation(input: {
     .values({
       id: input.id,
       orgId,
+      userId,
       source: input.source ?? null,
       name: "New Chat",
     })
@@ -58,6 +66,7 @@ export async function touchConversationLastMessage(
   conversationId: string,
 ): Promise<void> {
   const orgId = requireCurrentOrgId()
+  const userId = requireCurrentUserId()
   const db = getOrgDb()
   await db
     .update(conversations)
@@ -66,7 +75,11 @@ export async function touchConversationLastMessage(
       updatedAt: new Date(),
     })
     .where(
-      and(eq(conversations.id, conversationId), eq(conversations.orgId, orgId)),
+      and(
+        eq(conversations.id, conversationId),
+        eq(conversations.orgId, orgId),
+        eq(conversations.userId, userId),
+      ),
     )
 }
 
@@ -74,11 +87,13 @@ export async function listConversations(input?: {
   source?: string
 }): Promise<ConversationRecord[]> {
   const orgId = requireCurrentOrgId()
+  const userId = requireCurrentUserId()
   const db = getOrgDb()
   if (input?.source) {
     return db.query.conversations.findMany({
       where: {
         orgId: { eq: orgId },
+        userId: { eq: userId },
         source: { eq: input.source },
       },
       orderBy: (t, { desc }) => [
@@ -89,7 +104,7 @@ export async function listConversations(input?: {
     })
   }
   return db.query.conversations.findMany({
-    where: { orgId: { eq: orgId } },
+    where: { orgId: { eq: orgId }, userId: { eq: userId } },
     orderBy: (t, { desc }) => [
       desc(t.lastMessageAt),
       desc(t.createdAt),
@@ -104,11 +119,13 @@ export async function listConversationsPaginated(input: {
   after?: string
 }): Promise<{ items: ConversationRecord[]; pageInfo: PageInfo }> {
   const orgId = requireCurrentOrgId()
+  const userId = requireCurrentUserId()
   const db = getOrgDb()
   const { first, after } = input
 
   const baseConditions = [
     eq(conversations.orgId, orgId),
+    eq(conversations.userId, userId),
     input.source ? eq(conversations.source, input.source) : null,
   ].filter(Boolean) as ReturnType<typeof eq>[]
 
@@ -190,12 +207,14 @@ export async function getConversation(
   conversationId: string,
 ): Promise<ConversationRecord | null> {
   const orgId = requireCurrentOrgId()
+  const userId = requireCurrentUserId()
   const db = getOrgDb()
   return (
     (await db.query.conversations.findFirst({
       where: {
         id: { eq: conversationId },
         orgId: { eq: orgId },
+        userId: { eq: userId },
       },
     })) ?? null
   )
@@ -206,12 +225,17 @@ export async function updateConversation(
   input: { name: string },
 ): Promise<ConversationRecord | null> {
   const orgId = requireCurrentOrgId()
+  const userId = requireCurrentUserId()
   const db = getOrgDb()
   const [updated] = await db
     .update(conversations)
     .set({ name: input.name, updatedAt: new Date() })
     .where(
-      and(eq(conversations.id, conversationId), eq(conversations.orgId, orgId)),
+      and(
+        eq(conversations.id, conversationId),
+        eq(conversations.orgId, orgId),
+        eq(conversations.userId, userId),
+      ),
     )
     .returning()
   return updated ?? null
@@ -221,11 +245,16 @@ export async function deleteConversation(
   conversationId: string,
 ): Promise<boolean> {
   const orgId = requireCurrentOrgId()
+  const userId = requireCurrentUserId()
   const db = getOrgDb()
   const [deleted] = await db
     .delete(conversations)
     .where(
-      and(eq(conversations.id, conversationId), eq(conversations.orgId, orgId)),
+      and(
+        eq(conversations.id, conversationId),
+        eq(conversations.orgId, orgId),
+        eq(conversations.userId, userId),
+      ),
     )
     .returning({ id: conversations.id })
   return deleted != null

--- a/apps/backend/src/routes/v1/conversations.ts
+++ b/apps/backend/src/routes/v1/conversations.ts
@@ -25,6 +25,7 @@ const ConversationSchema = z
   .object({
     id: z.string(),
     orgId: z.string(),
+    userId: z.string(),
     name: z.string(),
     source: z.string().nullable(),
     lastMessageAt: z.string().datetime().nullable(),

--- a/apps/ui/src/features/chat/ChatWorkspace.tsx
+++ b/apps/ui/src/features/chat/ChatWorkspace.tsx
@@ -36,9 +36,16 @@ export function ChatWorkspace(props: {
     () => conversationIdFromParams ?? createObjectId("conv"),
   )
 
+  const sessionUserId = session?.user.id
+
   const detailQuery = useQuery({
-    queryKey: ["conversation", orgSlug, conversationIdFromParams],
-    enabled: Boolean(conversationIdFromParams),
+    queryKey: [
+      "conversation",
+      orgSlug,
+      sessionUserId,
+      conversationIdFromParams,
+    ],
+    enabled: Boolean(conversationIdFromParams && sessionUserId),
     queryFn: async () => {
       if (!conversationIdFromParams) {
         throw new Error("Missing conversation id")
@@ -78,13 +85,15 @@ export function ChatWorkspace(props: {
       ) {
         const name = (data as { name: string }).name
         queryClient.setQueryData<ConversationDetail>(
-          ["conversation", orgSlug, conversationId],
+          ["conversation", orgSlug, sessionUserId, conversationId],
           (old) =>
             old ? { ...old, conversation: { ...old.conversation, name } } : old,
         )
         queryClient.setQueriesData<{
           pages: { items: { id: string; name: string }[] }[]
-        }>({ queryKey: ["conversations", orgSlug], exact: false }, (old) =>
+        }>(
+          { queryKey: ["conversations", orgSlug, sessionUserId], exact: false },
+          (old) =>
           old && "pages" in old
             ? {
                 ...old,
@@ -111,8 +120,10 @@ export function ChatWorkspace(props: {
 
   const handleSendMessage = async (params: { text: string }) => {
     if (isOnIndexRoute) {
+      if (!sessionUserId) return
       const optimisticItem: ConversationListItem = {
         id: conversationId,
+        userId: sessionUserId,
         name: "New Chat",
         source: "ui",
         lastMessageAt: new Date().toISOString(),
@@ -125,7 +136,7 @@ export function ChatWorkspace(props: {
       }
       queryClient.setQueryData<
         InfiniteData<{ items: ConversationListItem[]; pageInfo: PageInfo }>
-      >(["conversations", orgSlug, "ui"], (old) => {
+      >(["conversations", orgSlug, sessionUserId, "ui"], (old) => {
         if (!old) {
           return {
             pages: [{ items: [optimisticItem], pageInfo: emptyPageInfo }],
@@ -143,7 +154,9 @@ export function ChatWorkspace(props: {
       })
     }
     await sendMessage(params)
-    void queryClient.invalidateQueries({ queryKey: ["conversations", orgSlug] })
+    void queryClient.invalidateQueries({
+      queryKey: ["conversations", orgSlug, sessionUserId],
+    })
     if (isOnIndexRoute) {
       void router.navigate({
         to: "/$orgSlug/chat/$conversationId",
@@ -160,6 +173,7 @@ export function ChatWorkspace(props: {
       <div className="flex max-h-[38vh] shrink-0 flex-col border-b border-white/[0.04] md:max-h-none md:h-full md:w-64 md:border-b-0 md:border-r">
         <ConversationList
           orgSlug={orgSlug}
+          sessionUserId={session.user.id}
           currentConversationId={conversationIdFromParams}
         />
       </div>

--- a/apps/ui/src/features/chat/ConversationList.tsx
+++ b/apps/ui/src/features/chat/ConversationList.tsx
@@ -32,9 +32,10 @@ import type { ConversationListItem } from "./types"
 
 export function ConversationList(props: {
   orgSlug: string
+  sessionUserId: string
   currentConversationId: string | undefined
 }) {
-  const { orgSlug, currentConversationId } = props
+  const { orgSlug, sessionUserId, currentConversationId } = props
   const router = useRouter()
   const queryClient = useQueryClient()
   const [sourceFilter, setSourceFilter] = useState<"ui" | "mcp">("ui")
@@ -44,7 +45,7 @@ export function ConversationList(props: {
     useState<ConversationListItem | null>(null)
 
   const conversationsQuery = useInfiniteQuery({
-    queryKey: ["conversations", orgSlug, sourceFilter],
+    queryKey: ["conversations", orgSlug, sessionUserId, sourceFilter],
     queryFn: async ({ pageParam }) => {
       const res = await client[":orgSlug"].api.v1.conversations.$get({
         param: { orgSlug },
@@ -92,7 +93,9 @@ export function ConversationList(props: {
       return res.json()
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["conversations", orgSlug] })
+      queryClient.invalidateQueries({
+        queryKey: ["conversations", orgSlug, sessionUserId],
+      })
       setConversationToRename(null)
       toast.success("Conversation renamed")
     },
@@ -116,7 +119,9 @@ export function ConversationList(props: {
       }
     },
     onSuccess: (_, deletedId) => {
-      queryClient.invalidateQueries({ queryKey: ["conversations", orgSlug] })
+      queryClient.invalidateQueries({
+        queryKey: ["conversations", orgSlug, sessionUserId],
+      })
       setConversationToDelete(null)
       if (deletedId === currentConversationId) {
         router.navigate({ to: "/$orgSlug/chat", params: { orgSlug } })

--- a/apps/ui/src/features/chat/types.ts
+++ b/apps/ui/src/features/chat/types.ts
@@ -9,6 +9,7 @@ export type PageInfo = {
 
 export type ConversationListItem = {
   id: string
+  userId: string
   name: string
   source: string | null
   lastMessageAt: string | null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves cross-member "conversation leak" by making chat rows **private per user** inside an organisation, for both **UI** and **MCP** sources.

## Changes

- **Schema**: `conversations.user_id` (NOT NULL, FK → `users.id`, cascade on user delete).
- **API / model**: All conversation reads and writes filter on `org_id` **and** `user_id` from the current session (`requireCurrentUserId()`).
- **OpenAPI**: Conversation payloads now include `userId`.
- **UI**: React Query keys include `session.user.id` so cached lists/details are not reused across accounts on the same machine.
- **Migration** (`20260414140000_conversations_user_id`):
  - Adds column, backfills **only** when the org has **exactly one** member (unambiguous owner).
  - **Deletes** remaining rows with NULL `user_id` (multi-member orgs with legacy org-wide rows—we cannot safely guess the owner; avoids assigning chats to the wrong person).

## Operational note

After deploy, affected orgs may see **empty** conversation history until users create new chats, if their old rows were dropped by the migration. If you need a different data-retention policy (e.g. manual SQL attribution before cutover), say so and we can adjust the migration strategy.

## Testing

- `pnpm exec vitest run src/mcp/tools.test.ts` (updated auth context mocks).
- Biome lint on touched files.

`drizzle-kit generate` was not usable in this non-interactive agent environment (TTY prompts on index rename); the migration SQL was authored to match the schema diff. Consider running `pnpm run db:generate` locally once if you want Drizzle to reconcile snapshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-14](https://linear.app/ctxpipe/issue/CTX-14/users-can-see-each-others-conversations)

<div><a href="https://cursor.com/agents/bc-64f62b2a-e053-4130-92e6-e5ed77c30507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64f62b2a-e053-4130-92e6-e5ed77c30507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

