### PR TITLE
fix: harden cloud agent startup + add cloud VM dev instructions

### DIFF
--- a/.agents/environment.json
+++ b/.agents/environment.json
@@ -3,6 +3,6 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "install": "corepack enable && pnpm install",
+  "install": "corepack enable && command -v bun >/dev/null 2>&1 || (curl -fsSL https://bun.sh/install | bash && sudo install -m 0755 $HOME/.bun/bin/bun /usr/local/bin/bun) && pnpm install",
   "start": "bash .agents/start.sh"
 }

--- a/.agents/start.sh
+++ b/.agents/start.sh
@@ -3,24 +3,63 @@
 # See https://cursor.com/docs/cloud-agent/setup — "Startup commands" / "Running Docker".
 set -euo pipefail
 
-docker_info() {
-  docker info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1
-}
+########################################################
+# 1. Docker daemon
+########################################################
+
+docker_ok() { docker info >/dev/null 2>&1; }
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "cloud-agent: docker CLI not found. Rebuild the environment from .agents/Dockerfile (see Cursor Cloud setup docs)." >&2
   exit 1
 fi
 
-sudo service docker start || true
+if ! docker_ok; then
+  # Try the SysVinit service first (works when systemd/init registered it).
+  sudo service docker start 2>/dev/null || true
+  sleep 2
 
-# Wait for the daemon (first boot can be slow inside nested containers).
-for _ in $(seq 1 45); do
-  if docker_info; then
-    exit 0
+  if ! docker_ok; then
+    # Fallback: start dockerd directly (Firecracker VMs may lack a service entry).
+    sudo dockerd --storage-driver=fuse-overlayfs >/tmp/dockerd.log 2>&1 &
   fi
-  sleep 1
-done
 
-echo "cloud-agent: Docker daemon did not become ready in time." >&2
-exit 1
+  for _ in $(seq 1 45); do
+    if docker_ok; then break; fi
+    sleep 1
+  done
+fi
+
+if ! docker_ok; then
+  echo "cloud-agent: Docker daemon did not become ready in time." >&2
+  exit 1
+fi
+
+# Ensure the current user can talk to the daemon without sudo.
+# Group membership from the Dockerfile may not be effective in the agent shell.
+if [ -S /var/run/docker.sock ] && ! docker info >/dev/null 2>&1; then
+  sudo chmod 666 /var/run/docker.sock
+fi
+
+########################################################
+# 2. Backend .env.local from Cursor secrets
+########################################################
+
+ENV_LOCAL="apps/backend/.env.local"
+
+if [ ! -f "$ENV_LOCAL" ] && [ -n "${AUTH_SECRET:-}" ]; then
+  # Defaults match docker-compose.yml infra profile (see docker-compose.env.example).
+  PG_DEFAULT="postgresql://ctxpipe:ctxpipe@localhost:5433/ctxpipe" # pragma: allowlist secret
+  REDIS_DEFAULT="redis://localhost:6379" # pragma: allowlist secret
+  DB="${DATABASE_URL:-$PG_DEFAULT}"
+  GRAPH="${GRAPH_DB_URI:-$REDIS_DEFAULT}"
+  cat > "$ENV_LOCAL" <<EOF
+DATABASE_URL=${DB}
+GRAPH_DB_URI=${GRAPH}
+AUTH_SECRET=${AUTH_SECRET}
+AUTH_BASE_URL=http://localhost:3000
+UI_PROXY_URL=http://localhost:3002
+AUTH_ALLOWED_ORIGINS=http://localhost:3002,http://localhost:3000
+EOF
+  echo "cloud-agent: wrote $ENV_LOCAL from Cursor secrets."
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,8 @@ Cloud agents run on an isolated Ubuntu machine. This repo provides a default clo
     2. Backend: `cd apps/backend && bun run --hot src/server.ts` (listens on **`http://localhost:3000`**).
     3. UI: `cd apps/ui && VITE_PUBLIC_API_URL=http://localhost:3000 npx vite dev --host 0.0.0.0 --port 3002` (Vite on **`http://localhost:3002`**).
   - **Browser entry point**: access **`http://localhost:3000`** (backend). The backend proxies unmatched routes to `UI_PROXY_URL` (`http://localhost:3002`). The UI auth client resolves `baseURL` from `window.location.origin`, so sign-in only works when the browser origin matches the backend (port 3000). Visiting port 3002 directly will cause auth "Request failed" errors.
-  - **`apps/backend/.env.local`**: if Cursor secrets (`AUTH_SECRET`, `DATABASE_URL`, `GRAPH_DB_URI`) are set, write them into `.env.local` before starting. For Compose-started Postgres, use the default connection string from [apps/backend/.env.example](apps/backend/.env.example) (user/password `ctxpipe`, host `localhost`, port `5433`, database `ctxpipe`).
-- **Docker daemon bootstrap** (if the Dockerfile image wasn't used): start `dockerd` in the background (`sudo dockerd &`), wait for the socket, and fix permissions (`sudo chmod 666 /var/run/docker.sock`). The `.agents/start.sh` script handles this when the image is built from `.agents/Dockerfile`.
-- **Bun**: if `bun` is not on `PATH`, install with `curl -fsSL https://bun.sh/install | bash` and add `~/.bun/bin` to `PATH`.
+  - **`.env.local` and secrets**: [`.agents/start.sh`](.agents/start.sh) auto-generates `apps/backend/.env.local` from Cursor secrets (`AUTH_SECRET`, `DATABASE_URL`, `GRAPH_DB_URI`) on first boot. No manual file creation needed.
+  - **Docker + Bun**: handled automatically by [`.agents/start.sh`](.agents/start.sh) (dockerd fallback + socket permissions) and [`environment.json`](.agents/environment.json) (bun install fallback). See those files if debugging startup.
 
 ### Agent runbook — host dev (run from repo root)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,15 @@ Cloud agents run on an isolated Ubuntu machine. This repo provides a default clo
   - `pnpm lint`
   - `pnpm --filter @ctxpipe/backend test`
   - `pnpm --filter @ctxpipe/ui test`
+- **Running dev servers on cloud VMs** (without portless):
+  - **Portless requires HTTPS on port 443** and a local CA; this does not work on headless cloud VMs. Skip `pnpm dev` (which invokes portless via `scripts/dev-apps.sh`). Instead start services individually:
+    1. `pnpm dev:infra` — starts Postgres, FalkorDB, OTEL via Docker Compose.
+    2. Backend: `cd apps/backend && bun run --hot src/server.ts` (listens on **`http://localhost:3000`**).
+    3. UI: `cd apps/ui && VITE_PUBLIC_API_URL=http://localhost:3000 npx vite dev --host 0.0.0.0 --port 3002` (Vite on **`http://localhost:3002`**).
+  - **Browser entry point**: access **`http://localhost:3000`** (backend). The backend proxies unmatched routes to `UI_PROXY_URL` (`http://localhost:3002`). The UI auth client resolves `baseURL` from `window.location.origin`, so sign-in only works when the browser origin matches the backend (port 3000). Visiting port 3002 directly will cause auth "Request failed" errors.
+  - **`apps/backend/.env.local`**: if Cursor secrets (`AUTH_SECRET`, `DATABASE_URL`, `GRAPH_DB_URI`) are set, write them into `.env.local` before starting. For Compose-started Postgres, use the default connection string from [apps/backend/.env.example](apps/backend/.env.example) (user/password `ctxpipe`, host `localhost`, port `5433`, database `ctxpipe`).
+- **Docker daemon bootstrap** (if the Dockerfile image wasn't used): start `dockerd` in the background (`sudo dockerd &`), wait for the socket, and fix permissions (`sudo chmod 666 /var/run/docker.sock`). The `.agents/start.sh` script handles this when the image is built from `.agents/Dockerfile`.
+- **Bun**: if `bun` is not on `PATH`, install with `curl -fsSL https://bun.sh/install | bash` and add `~/.bun/bin` to `PATH`.
 
 ### Agent runbook — host dev (run from repo root)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three real issues in the cloud agent environment setup and documents the portless workaround for headless VMs.

### Problems found during setup

| Issue | Root cause | Fix |
|---|---|---|
| Docker daemon won't start | `service docker start` fails in Firecracker VMs (no service entry) | `start.sh` falls back to `sudo dockerd` |
| Docker socket permission denied | `ubuntu` is in `docker` group but group membership isn't effective in the agent shell | `start.sh` fixes socket permissions after daemon starts |
| `.env.local` must be manually created every session | No automation existed | `start.sh` auto-generates from Cursor secrets (`AUTH_SECRET`, `DATABASE_URL`, `GRAPH_DB_URI`) |
| `bun` missing when Dockerfile image isn't used | `environment.json` install didn't handle it | Defensive bun install in `environment.json` install step |
| Auth fails when accessing UI on port 3002 | Auth client uses `window.location.origin`; backend is on 3000 | Documented in AGENTS.md: use port 3000 (backend proxy) |

### Changes

**`.agents/start.sh`** — hardened Docker startup + auto `.env.local`:
- Try `service docker start` first, fall back to `sudo dockerd --storage-driver=fuse-overlayfs`
- Fix `/var/run/docker.sock` permissions for non-root shells
- Generate `apps/backend/.env.local` from Cursor secrets on first boot (idempotent — skips if file exists)

**`.agents/environment.json`** — defensive bun install:
- `install` step now checks for `bun` and installs it if missing

**`AGENTS.md`** — streamlined cloud instructions:
- Kept the non-obvious portless workaround and browser entry-point gotcha
- Replaced manual Docker/bun/env workaround bullets with references to the now-automated `start.sh` and `environment.json`

### Walkthrough

[demo_sign_in_and_onboarding.mp4](https://cursor.com/agents/bc-c39a1974-e4b9-42cb-bffe-36af7c8c1602/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_sign_in_and_onboarding.mp4)
Full sign-in and onboarding flow working via `http://localhost:3000`.

![Sign-in page](https://cursor.com/artifacts/c/art-6ca7f4c2-85fd-42bc-9afd-21e43362e813)
![Onboarding after login](https://cursor.com/artifacts/c/art-59de7b09-07d8-41ea-8b69-3eef5a8c5176)

### Testing

- ✅ `bash .agents/start.sh` — Docker detected running, `.env.local` generated from secrets
- ✅ `bash .agents/start.sh` (second run) — idempotent, skips existing `.env.local`
- ✅ `pnpm lint` — runs (pre-existing warnings in codebase)
- ✅ `pnpm --filter @ctxpipe/ui test` — 3/3 pass
- ✅ `pnpm --filter @ctxpipe/backend test` — 31 pass (15 fail due to pre-existing import issue)
- ✅ Backend + UI dev servers running, auth sign-up/sign-in working
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c39a1974-e4b9-42cb-bffe-36af7c8c1602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c39a1974-e4b9-42cb-bffe-36af7c8c1602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

