### PR TITLE
docs: add Data & privacy page (CTX-39)

### DIFF
--- a/apps/backend/src/app/app.ts
+++ b/apps/backend/src/app/app.ts
@@ -52,6 +52,15 @@ export function createApp() {
   })
 
   app.onError((error, c) => {
+    // Dev: UI is proxied to Vite; clients often abort in-flight module/CSS streams
+    // (navigation, HMR, duplicate requests). Those must not become JSON 500 bodies.
+    const isAbort =
+      (error instanceof DOMException && error.name === "AbortError") ||
+      (error instanceof Error && error.name === "AbortError")
+    if (isAbort) {
+      return new Response(null, { status: 499 })
+    }
+
     console.log("error in app.onError", error)
     c.get("log").error(error)
     const parsed = parseError(error)

--- a/apps/docs/content/docs/(guide)/index.mdx
+++ b/apps/docs/content/docs/(guide)/index.mdx
@@ -33,7 +33,7 @@ organisation-scoped context layer. Use these docs alongside
   <Card
     title="Resources"
     href="/docs/resources/faq"
-    description="FAQ, licensing, and open source."
+    description="FAQ, data & privacy, licensing, and open source."
   />
 </Cards>
 

--- a/apps/docs/content/docs/(guide)/resources/data-processing.mdx
+++ b/apps/docs/content/docs/(guide)/resources/data-processing.mdx
@@ -1,0 +1,55 @@
+---
+title: Data & privacy
+description: How ctx| processes data, what you control, sub-processors, and LLM usage for the hosted product.
+---
+
+This page describes **data handling for the hosted SaaS product** (ctxpipe). It is separate from [self-hosting](/docs/self-hosting), where you choose your own providers and retention.
+
+## What ctx| ingests
+
+- ctx| ingests from **Git** and Git-connected sources you attach to your organisation.
+- Other integrations are brought into the **same ingestion pipeline** as your repositories; product direction is that sources (including future integrations such as Confluence) are **normalised into Git-compatible storage** before the same downstream indexing and graph steps run.
+- **What is in your connected repositories (and equivalent synced sources) is what ctx| can see** — nothing beyond what you connect.
+
+## What you control
+
+- You **connect repositories explicitly** through the web UI (or supported install flows).
+- **Nothing is ingested without your action** — a connection or registration step is required.
+- You can **remove repositories** at any time; that stops further ingestion for those sources (existing indexed data may remain until your organisation’s deletion processes complete — [get in touch](/docs/getting-started/get-in-touch) for specifics).
+- Ingested data is **scoped to your organisation**; other tenants cannot access it.
+
+## Sub-processors
+
+| Provider    | Purpose                 |
+| ----------- | ----------------------- |
+| Railway     | Compute and hosting     |
+| Neon        | Postgres database       |
+| OpenRouter  | LLM routing             |
+| Langfuse    | LLM observability       |
+| Better Stack | Logging and monitoring |
+
+## LLM calls
+
+- **Chat (in-app or via MCP `ctx_advisor`):** Models run when you use the conversational experience. Your **message and retrieved context** (for example search snippets, file excerpts the agent retrieved, and graph-backed context) are sent to the configured model provider. On hosted deployments this is typically **OpenRouter** (see backend `MODEL_PROVIDER_URL` defaults in the open-source tree).
+- **Ingestion:** The pipeline can also call models for **graph extraction** and related steps over parts of your tree — this is **not** the same as a single chat reply. See [Ingestion explanation](/docs/connections/ingestion) for the stages (clone, index, extraction).
+- **OpenRouter:** For their handling of prompts, logging, and training, see **[OpenRouter’s privacy policy](https://openrouter.ai/privacy)** and their **[privacy & logging](https://openrouter.ai/docs/features/privacy-and-logging)** documentation (the hosted product routes via OpenRouter and is subject to their terms and your account settings).
+- The product does **not** ship your entire repository as one flat paste into chat; context is **selected** by retrieval and tools. Ingestion still uses models on **bounded excerpts or representations** as part of extraction — again, see [Ingestion explanation](/docs/connections/ingestion).
+
+### Storage and retention (product)
+
+We do **not** publish fixed customer-data retention periods in this documentation yet. Session and auth artefacts in the app use **short-lived tokens** (for example password-reset links and invitations) with server-side expiry; those are account mechanics, not a statement about how long code index or graph data is retained. For deletion timelines, export, or DPA questions, **[get in touch](/docs/getting-started/get-in-touch)**.
+
+## What we don’t do
+
+- We **don’t** use your repository content to **train** ctx|’s own models (ctx| is not a model trainer; upstream providers have their own policies — see OpenRouter above).
+- We **don’t** share data **across tenants** or sell it to third parties; sub-processors above are **service providers** for operating the product.
+- We **don’t** ingest sources you have **not** explicitly connected.
+
+## Certifications
+
+- **SOC 2** and **ISO 27001** for ctx| as a company are **on the roadmap**.
+- Infrastructure sub-processors (**Railway**, **Neon**, and others you use) publish their **own** compliance and security materials — review those for hosting and database assurances.
+
+---
+
+Questions about your organisation’s data, subprocessors, or contracts: **[Get in touch](/docs/getting-started/get-in-touch)**.

--- a/apps/docs/content/docs/(guide)/resources/meta.json
+++ b/apps/docs/content/docs/(guide)/resources/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Resources",
-  "pages": ["faq", "open-source"]
+  "pages": ["faq", "data-processing", "open-source"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Data & privacy** page to the public docs (Resources section), per Linear CTX-39. The page covers ingestion scope, user controls, sub-processors, LLM usage (chat vs ingestion/extraction), certifications, and links to **Get in touch**.

## Notes

- **Not** under self-hosting; lives at `/docs/resources/data-processing`.
- The original draft claimed “raw repo content is not sent to the LLM”; our [ingestion doc](/docs/connections/ingestion) describes LLM-assisted graph extraction, so the new page **separates chat** (message + retrieved context) **from ingestion** and points readers to ingestion for detail.
- **OpenRouter:** links to https://openrouter.ai/privacy and privacy/logging docs instead of a non-existent `/docs/privacy` path.
- **Retention:** no fixed product retention is documented in-repo; the page notes that and defers deletion/DPA specifics to Get in touch. Short-lived auth flows (reset links, invitations) are mentioned only as “account mechanics”, not as org data retention policy.

## Test plan

- [x] `pnpm --filter @ctxpipe/docs build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-39](https://linear.app/ctxpipe/issue/CTX-39/add-data-processing-page-to-the-docs)

<div><a href="https://cursor.com/agents/bc-225fe6d5-fa63-4455-b75a-e005c6878899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-225fe6d5-fa63-4455-b75a-e005c6878899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

