### PR TITLE
fix(backend): resolve OpenWorkflow worker imports 

### DIFF
--- a/apps/backend/src/auth/withAuth.ts
+++ b/apps/backend/src/auth/withAuth.ts
@@ -10,8 +10,8 @@ import {
 import type { AppEnv } from "../app/env.js"
 import { getSystemDb, withOrgDbContext } from "../db/client.js"
 import { organizations, sessions, users } from "../db/schema/auth.js"
+import { getLogger } from "../observability/logger.js"
 import { getAuth } from "./config.js"
-import { getLogger } from "src/observability/logger.js"
 
 /** Seconds — small skew between issuers, clients, and this server (Better Auth / jose guidance). */
 const JWT_CLOCK_TOLERANCE_SECONDS = 60

--- a/apps/backend/src/graphs/conversationGraph/nodes/retrievalChannels.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/retrievalChannels.ts
@@ -50,9 +50,6 @@ export async function retrievalChannelsNode(
       : Promise.resolve(null),
   ])
 
-  console.log("hybridOutput", hybridOutput)
-  console.log("codeOutput", codeOutput)
-
   if (hybridOutput) {
     hybridResults = [...hybridResults, ...hybridOutput.hybridResults]
     objectIds = [...new Set(objectIds), ...hybridOutput.objectIds]
@@ -83,8 +80,6 @@ export async function retrievalChannelsNode(
     extensionTraversalStep,
     exactStep,
   })
-
-  console.log("graphOutput", graphOutput)
 
   if (graphOutput) {
     graphNodes = [...graphNodes, ...(graphOutput.graphNodes ?? [])]

--- a/apps/backend/src/routes/v1/connectors-atlassian.ts
+++ b/apps/backend/src/routes/v1/connectors-atlassian.ts
@@ -1,13 +1,13 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { AppEnv } from "../../app/env.js"
+import { resolveAtlassianConfluenceApiBaseUrl } from "../../lib/atlassian-api-base-url.js"
 import {
+  type ForgeInstallation,
   getAtlassianUserAccessToken,
   getForgeInstallationByOrgId,
   getPendingForgeInstallationForUserInOtherOrg,
-  type ForgeInstallation,
   upsertPendingForgeInstallation,
 } from "../../models/atlassian-connector.js"
-import { resolveAtlassianConfluenceApiBaseUrl } from "src/lib/atlassian-api-base-url.js"
 
 const ErrorResponseSchema = z
   .object({
@@ -129,10 +129,11 @@ export const atlassianConnectorRoutes = new OpenAPIHono<AppEnv>()
       )
     }
 
-    const pendingInOtherOrg = await getPendingForgeInstallationForUserInOtherOrg({
-      userId: user.id,
-      orgId,
-    })
+    const pendingInOtherOrg =
+      await getPendingForgeInstallationForUserInOtherOrg({
+        userId: user.id,
+        orgId,
+      })
     if (pendingInOtherOrg) {
       return c.json(
         {


### PR DESCRIPTION
Main on dev wasn't starting due to an error:
withAuth.ts imported:

`import { getLogger } from "src/observability/logger.js"`

That works for Bun / TypeScript when baseUrl is apps/backend, but the OpenWorkflow worker loads those files with a plain module resolver that does not apply tsconfig paths / baseUrl. So at runtime it looks for a package literally named src/... and fails.

The worker pulls in repository-ingestion.ts → withAuth.ts → that import → boom. That’s why pnpm dev dies when the worker starts, on main too — it isn’t your MCP branch.

---

Fix (applied)
Use relative imports so Node/Bun and the worker all agree:

withAuth.ts: ../observability/logger.js
connectors-atlassian.ts: ../../lib/atlassian-api-base-url.js (same pattern, same risk)