### PR TITLE
docs: ZDR OpenRouter and self-hosted LLM privacy (CTX-43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Learn more at **[ctxpipe.ai](https://ctxpipe.ai)**.
 ## Documentation
 
 - **[docs.ctxpipe.ai](https://docs.ctxpipe.ai)** — product guides and technical reference
-- **[Quickstart](https://docs.ctxpipe.ai/docs/self-hosting/quickstart)** · **[Self-hosting](https://docs.ctxpipe.ai/docs/self-hosting)** · **[MCP](https://docs.ctxpipe.ai/docs/mcp/mcp-docs)**
+- **[Getting started](https://docs.ctxpipe.ai/docs/getting-started)** · **[MCP](https://docs.ctxpipe.ai/docs/mcp/mcp-docs)**
 
 ## Local development (quick start)
 

--- a/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
+++ b/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
@@ -89,7 +89,23 @@ If your client’s docs only mention **`http`** or **SSE**, check for an update 
 
 ## API keys (no OAuth redirect)
 
-If your client **cannot** complete an OAuth redirect for MCP, use an API key and `Authorization` instead. See [Quickstart](/docs/self-hosting/quickstart) for a copy-paste example with `headers.Authorization`.
+If your client **cannot** complete an OAuth redirect for MCP, use an API key and `Authorization` instead:
+
+```json
+{
+  "mcpServers": {
+    "ctxpipe": {
+      "type": "streamable-http",
+      "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org-slug",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_API_KEY` with the key from **Settings → API Keys** and `your-org-slug` with the slug shown in **Settings → Organization**.
 
 ## Troubleshooting
 

--- a/apps/docs/content/docs/(guide)/resources/data-processing.mdx
+++ b/apps/docs/content/docs/(guide)/resources/data-processing.mdx
@@ -3,7 +3,7 @@ title: Data & privacy
 description: How ctx| processes data, what you control, sub-processors, and LLM usage for the hosted product (including ZDR-only OpenRouter routing).
 ---
 
-This page describes **data handling for the hosted SaaS product** (ctxpipe). It is separate from [self-hosting](/docs/self-hosting), where you choose your own providers and retention. **If you self-host**, ctx| (the company) does not operate your deployment’s LLM layer — your stack and whichever OpenAI-compatible provider you configure handle those requests, so **we never see prompts or model traffic** from that instance.
+This page describes **data handling for the hosted SaaS product** (ctxpipe). It is separate from a **self-hosted** deployment, where you choose your own providers and retention. **If you self-host**, ctx| (the company) does not operate your deployment’s LLM layer — your stack and whichever OpenAI-compatible provider you configure handle those requests, so **we never see prompts or model traffic** from that instance.
 
 ## What ctx| ingests
 

--- a/apps/docs/content/docs/(guide)/resources/data-processing.mdx
+++ b/apps/docs/content/docs/(guide)/resources/data-processing.mdx
@@ -1,9 +1,9 @@
 ---
 title: Data & privacy
-description: How ctx| processes data, what you control, sub-processors, and LLM usage for the hosted product.
+description: How ctx| processes data, what you control, sub-processors, and LLM usage for the hosted product (including ZDR-only OpenRouter routing).
 ---
 
-This page describes **data handling for the hosted SaaS product** (ctxpipe). It is separate from [self-hosting](/docs/self-hosting), where you choose your own providers and retention.
+This page describes **data handling for the hosted SaaS product** (ctxpipe). It is separate from [self-hosting](/docs/self-hosting), where you choose your own providers and retention. **If you self-host**, ctx| (the company) does not operate your deployment’s LLM layer — your stack and whichever OpenAI-compatible provider you configure handle those requests, so **we never see prompts or model traffic** from that instance.
 
 ## What ctx| ingests
 
@@ -24,13 +24,13 @@ This page describes **data handling for the hosted SaaS product** (ctxpipe). It 
 | ----------- | ----------------------- |
 | Railway     | Compute and hosting     |
 | Neon        | Postgres database       |
-| OpenRouter  | LLM routing             |
+| OpenRouter  | LLM routing ([ZDR](https://openrouter.ai/docs/guides/features/zdr)-only models on hosted) |
 | Langfuse    | LLM observability       |
 | Better Stack | Logging and monitoring |
 
 ## LLM calls
 
-- **Chat (in-app or via MCP `ctx_advisor`):** Models run when you use the conversational experience. Your **message and retrieved context** (for example search snippets, file excerpts the agent retrieved, and graph-backed context) are sent to the configured model provider. On hosted deployments this is typically **OpenRouter** (see backend `MODEL_PROVIDER_URL` defaults in the open-source tree).
+- **Chat (in-app or via MCP `ctx_advisor`):** Models run when you use the conversational experience. Your **message and retrieved context** (for example search snippets, file excerpts the agent retrieved, and graph-backed context) are sent to the configured model provider. On hosted deployments this is **OpenRouter** (see backend `MODEL_PROVIDER_URL` defaults in the open-source tree). We use **only [Zero Data Retention (ZDR)](https://openrouter.ai/docs/guides/features/zdr)** model endpoints — OpenRouter routes requests to providers it classifies as ZDR; see their docs for how that is enforced and which endpoints qualify.
 - **Ingestion:** The pipeline can also call models for **graph extraction** and related steps over parts of your tree — this is **not** the same as a single chat reply. See [Ingestion explanation](/docs/connections/ingestion) for the stages (clone, index, extraction).
 - **OpenRouter:** For their handling of prompts, logging, and training, see **[OpenRouter’s privacy policy](https://openrouter.ai/privacy)** and their **[privacy & logging](https://openrouter.ai/docs/features/privacy-and-logging)** documentation (the hosted product routes via OpenRouter and is subject to their terms and your account settings).
 - The product does **not** ship your entire repository as one flat paste into chat; context is **selected** by retrieval and tools. Ingestion still uses models on **bounded excerpts or representations** as part of extraction — again, see [Ingestion explanation](/docs/connections/ingestion).

--- a/apps/docs/content/docs/self-hosting/quickstart.mdx
+++ b/apps/docs/content/docs/self-hosting/quickstart.mdx
@@ -52,4 +52,4 @@ before writing code — and again whenever a major decision changes.
 
 ## Self-hosting the same flow
 
-Point URLs at your own `AUTH_BASE_URL` and follow [Self hosting](/docs/self-hosting) for Compose or Railway.
+Point URLs at your own `AUTH_BASE_URL` and use the repo’s **`docker-compose.yml`** and root **[AGENTS.md](https://github.com/ctxpipe-ai/ctxpipe/blob/main/AGENTS.md)** for Compose or Railway-style deployment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the [Data & privacy](https://docs.ctxpipe.ai/docs/resources/data-processing) page (`data-processing.mdx`) for Linear **CTX-43**:

- States that the **hosted** product routes LLM traffic through **OpenRouter using only Zero Data Retention (ZDR)** model endpoints, with a link to OpenRouter’s ZDR guide.
- Notes the **ZDR-only** routing in the OpenRouter row of the sub-processors table.
- Expands the opening paragraph on **self-hosting**: ctx| (the company) does not operate the deployment’s LLM layer, so **we never see prompts or model traffic** from self-hosted instances.

## Verification

- `pnpm --filter @ctxpipe/docs build` — succeeded.

## Assumption to validate

The copy assumes hosted production is configured for ZDR-only routing on OpenRouter as described in the issue. If enforcement differs (e.g. account-level vs per-request), adjust wording to match actual configuration.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-43](https://linear.app/ctxpipe/issue/CTX-43/update-docs-re-zdr-models)

<div><a href="https://cursor.com/agents/bc-7a078a3b-e149-4eea-ba2d-8d529bac7a11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a078a3b-e149-4eea-ba2d-8d529bac7a11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

