### PR TITLE
fix(github): unique MCP config PR branch per repository (CTX-45)

### DIFF
--- a/apps/backend/src/models/github-mcp-config-pr.test.ts
+++ b/apps/backend/src/models/github-mcp-config-pr.test.ts
@@ -2,8 +2,22 @@ import { describe, expect, it } from "vitest"
 import {
   buildOrMergeCursorClaudeMcpJson,
   buildOrMergeOpenCodeMcpJson,
+  generateCtxpipeMcpConfigBranchName,
   mcpStreamUrlForOrg,
 } from "./github-mcp-config-pr.js"
+
+describe("generateCtxpipeMcpConfigBranchName", () => {
+  it("returns distinct names suitable for refs/heads/ (batch PRs)", () => {
+    const names = new Set<string>()
+    for (let i = 0; i < 50; i += 1) {
+      names.add(generateCtxpipeMcpConfigBranchName())
+    }
+    expect(names.size).toBe(50)
+    for (const n of names) {
+      expect(n).toMatch(/^ctxpipe\/mcp-config-[0-9a-z]+-[0-9a-z]+$/)
+    }
+  })
+})
 
 describe("mcpStreamUrlForOrg", () => {
   it("strips trailing slash from base and appends org query", () => {

--- a/apps/backend/src/models/github-mcp-config-pr.ts
+++ b/apps/backend/src/models/github-mcp-config-pr.ts
@@ -280,6 +280,11 @@ export async function previewMcpConfigChanges(input: {
   return out
 }
 
+/** One branch name per repository — batch PRs used a single suffix and hit `createRef` collisions. */
+export function generateCtxpipeMcpConfigBranchName(): string {
+  return `ctxpipe/mcp-config-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
 export async function createCtxpipeMcpConfigPullRequests(input: {
   orgId: string
   orgSlug: string
@@ -298,7 +303,6 @@ export async function createCtxpipeMcpConfigPullRequests(input: {
   const octokit = new Octokit({ auth: token })
 
   const results: McpConfigPrResultItem[] = []
-  const branchSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 
   for (const fullName of input.repositories) {
     const [owner, repoName] = fullName.split("/")
@@ -317,7 +321,7 @@ export async function createCtxpipeMcpConfigPullRequests(input: {
     })
     const baseSha = branchRef.commit.sha
 
-    const branch = `ctxpipe/mcp-config-${branchSuffix}`
+    const branch = generateCtxpipeMcpConfigBranchName()
     await octokit.rest.git.createRef({
       owner,
       repo: repoName,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Raising MCP config PRs for multiple repositories in one request failed with GitHub `Reference update failed` on `POST /repos/{owner}/{repo}/git/refs`.

## Cause
`createCtxpipeMcpConfigPullRequests` computed a single `branchSuffix` for the whole batch and reused `ctxpipe/mcp-config-${suffix}` for every repository. The first `createRef` succeeded; the second repo attempted to create the **same** ref name again, which GitHub rejects.

## Fix
Generate a unique branch name per repository (timestamp + random segment) so each `createRef` targets a distinct `refs/heads/...`.

## Testing
- `pnpm exec vitest run src/models/github-mcp-config-pr.test.ts` (from `apps/backend`)

Closes CTX-45.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-45](https://linear.app/ctxpipe/issue/CTX-45/installing-mcp-via-repo-page-throws-error)

<div><a href="https://cursor.com/agents/bc-bbe07d72-c469-429b-9698-0aa881a4f90a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbe07d72-c469-429b-9698-0aa881a4f90a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

