### PR TITLE
fix(auth): extend web sessions, keep OAuth access tokens short

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -31,7 +31,7 @@ Production traces use Langfuse step `conversation.mcp.ctx_advisor` (session/thre
 - **Postgres**: One server (**`localhost:5433`** typical), **one DB per linked git worktree** (`ctxpipe_<sanitized_branch>`). **`pnpm db:migrate`** (repo root) runs **`source ../../scripts/worktree-db.sh`** before Drizzle; linked worktrees need **`psql`** on `PATH`. **Dev servers** read **`apps/backend/.env.local`** — set **`DATABASE_URL`** there to the same database name migrate uses (see root [AGENTS.md](../../AGENTS.md) runbook).
 - **Public URL**: [portless](https://portless.sh/) or non-default port: align **`AUTH_BASE_URL`** and **`AUTH_ALLOWED_ORIGINS`** with the browser origin (**`PORTLESS_URL`** when applicable). Defaults in `src/config/env.ts`.
 - **MCP URLs**: HTTP MCP is served by this app (see **MCP** above); base URL and org slug follow your dev env — see root [AGENTS.md](../../AGENTS.md) (parallel worktrees + runbook) and [`.env.example`](.env.example).
-- **MCP OAuth**: The OAuth provider issues short-lived JWT access tokens (`oauthProvider` in [`src/auth/config.ts`](src/auth/config.ts); default **1h**). **MCP clients must refresh** using the refresh token before expiry. Stale Bearer tokens yield **401** on `/mcp`.
+- **MCP OAuth**: The OAuth provider issues JWT access tokens (`oauthProvider` in [`src/auth/config.ts`](src/auth/config.ts)); access tokens are long-lived (**4h**) but **MCP clients must still refresh** using the refresh token before expiry. Stale Bearer tokens yield **401** on `/mcp`.
 
 ### Better Auth JWT / `jwkss`
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -31,7 +31,7 @@ Production traces use Langfuse step `conversation.mcp.ctx_advisor` (session/thre
 - **Postgres**: One server (**`localhost:5433`** typical), **one DB per linked git worktree** (`ctxpipe_<sanitized_branch>`). **`pnpm db:migrate`** (repo root) runs **`source ../../scripts/worktree-db.sh`** before Drizzle; linked worktrees need **`psql`** on `PATH`. **Dev servers** read **`apps/backend/.env.local`** — set **`DATABASE_URL`** there to the same database name migrate uses (see root [AGENTS.md](../../AGENTS.md) runbook).
 - **Public URL**: [portless](https://portless.sh/) or non-default port: align **`AUTH_BASE_URL`** and **`AUTH_ALLOWED_ORIGINS`** with the browser origin (**`PORTLESS_URL`** when applicable). Defaults in `src/config/env.ts`.
 - **MCP URLs**: HTTP MCP is served by this app (see **MCP** above); base URL and org slug follow your dev env — see root [AGENTS.md](../../AGENTS.md) (parallel worktrees + runbook) and [`.env.example`](.env.example).
-- **MCP OAuth**: The OAuth provider issues JWT access tokens (`oauthProvider` in [`src/auth/config.ts`](src/auth/config.ts)); access tokens are long-lived (4h) but **MCP clients must still refresh** using the refresh token before expiry. Stale Bearer tokens yield **401** on `/mcp`.
+- **MCP OAuth**: The OAuth provider issues short-lived JWT access tokens (`oauthProvider` in [`src/auth/config.ts`](src/auth/config.ts); default **1h**). **MCP clients must refresh** using the refresh token before expiry. Stale Bearer tokens yield **401** on `/mcp`.
 
 ### Better Auth JWT / `jwkss`
 

--- a/apps/backend/src/auth/config.ts
+++ b/apps/backend/src/auth/config.ts
@@ -71,6 +71,13 @@ export function createBetterAuth() {
         },
       },
     },
+    /** Web cookie + DB session: keep users signed in across days; OAuth MCP tokens stay short (default 1h). */
+    session: {
+      /** Required when `secondaryStorage` is enabled (e.g. infra `dash()`); keeps sessions in Postgres too. */
+      storeSessionInDatabase: true,
+      expiresIn: 60 * 60 * 24 * 30,
+      updateAge: 60 * 60 * 24,
+    },
     advanced: {
       ipAddress: {
         ipAddressHeaders: ["x-forwarded-for", "x-real-ip"],
@@ -172,8 +179,6 @@ export function createBetterAuth() {
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
         validAudiences: [env.AUTH_BASE_URL, `${env.AUTH_BASE_URL}/mcp`],
-        /** 4h — MCP hosts should still refresh via refresh_token before expiry. */
-        accessTokenExpiresIn: 14_400,
         silenceWarnings: { oauthAuthServerConfig: true },
       }),
       dash(),

--- a/apps/backend/src/auth/config.ts
+++ b/apps/backend/src/auth/config.ts
@@ -71,7 +71,7 @@ export function createBetterAuth() {
         },
       },
     },
-    /** Web cookie + DB session: keep users signed in across days; OAuth MCP tokens stay short (default 1h). */
+    /** Web cookie + DB session: keep users signed in across days (MCP OAuth access JWT TTL is separate; see oauthProvider). */
     session: {
       /** Required when `secondaryStorage` is enabled (e.g. infra `dash()`); keeps sessions in Postgres too. */
       storeSessionInDatabase: true,
@@ -179,6 +179,8 @@ export function createBetterAuth() {
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
         validAudiences: [env.AUTH_BASE_URL, `${env.AUTH_BASE_URL}/mcp`],
+        /** 4h — MCP hosts should still refresh via refresh_token before expiry. */
+        accessTokenExpiresIn: 14_400,
         silenceWarnings: { oauthAuthServerConfig: true },
       }),
       dash(),

--- a/apps/backend/src/auth/withAuth.test.ts
+++ b/apps/backend/src/auth/withAuth.test.ts
@@ -139,12 +139,13 @@ describe("auth middleware composition", () => {
         handler(testState.db),
     )
     createLocalJWKSetMock.mockReturnValue("mock-jwks-set")
-    authHandlerMock.mockImplementation(
-      () =>
+    authHandlerMock.mockImplementation(() =>
+      Promise.resolve(
         new Response(JSON.stringify({ keys: [] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
+      ),
     )
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses CTX-31: **longer web / DB sessions** for the app, with **MCP OAuth access tokens** at **4 hours** (`accessTokenExpiresIn: 14_400`).

## Changes

- **`session`**: 30-day expiry, 1-day `updateAge` (sliding refresh), `storeSessionInDatabase: true` (required when secondary storage is used with OAuth provider / infra `dash()`).
- **`oauthProvider`**: **`accessTokenExpiresIn: 14_400`** (4h) — MCP clients should still refresh via refresh_token before expiry.
- **`withAuth.test.ts`**: mock `auth.handler` as async so JWKS `.catch` works.
- **`apps/backend/AGENTS.md`**: documents 4h MCP OAuth access tokens.

## Testing

- `pnpm --filter @ctxpipe/backend exec vitest run src/auth/withAuth.test.ts src/routes/auth.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-31](https://linear.app/ctxpipe/issue/CTX-31/extend-auth-sessions)

<div><a href="https://cursor.com/agents/bc-0f8bbc6e-660d-4e96-a508-5887f6dbfb63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f8bbc6e-660d-4e96-a508-5887f6dbfb63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

