### PR TITLE
fix(chat): repair missing tool invocations in UI stream (CTX-37)

### DIFF
--- a/apps/backend/src/domain/conversations/transport.ts
+++ b/apps/backend/src/domain/conversations/transport.ts
@@ -15,6 +15,7 @@ import { generateObjectId } from "../../lib/id.js"
 import { runWithLangfuseContext } from "../../observability/langfuse.js"
 import { langfusePipelineCallbacks } from "../../observability/langfusePipelineMetrics.js"
 import type { StreamEnhancer } from "./renameStream.js"
+import { createToolInvocationRepairTransform } from "./uiMessageStreamToolInvocationRepair.js"
 
 export type StreamInput = {
   conversationId: string
@@ -72,7 +73,9 @@ class DataStreamConversationTransport implements ConversationTransportAdapter {
           wrappedStream as Parameters<typeof toUIMessageStream>[0],
         )
 
-        let stream: ReadableStream<UIMessageChunk> = uiStream
+        let stream: ReadableStream<UIMessageChunk> = uiStream.pipeThrough(
+          createToolInvocationRepairTransform(),
+        )
         for (const transform of flushTransforms) {
           stream = stream.pipeThrough(
             transform as TransformStream<UIMessageChunk, UIMessageChunk>,

--- a/apps/backend/src/domain/conversations/uiMessageStreamToolInvocationRepair.test.ts
+++ b/apps/backend/src/domain/conversations/uiMessageStreamToolInvocationRepair.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import {
+  createToolInvocationRepairTransform,
+  syntheticToolNameFromToolCallId,
+} from "./uiMessageStreamToolInvocationRepair.js"
+
+describe("syntheticToolNameFromToolCallId", () => {
+  it("parses tool_<name>_<opaque> ids (issue CTX-37 shape)", () => {
+    expect(
+      syntheticToolNameFromToolCallId(
+        "tool_list_files_HKlhFchTWEPs9eertVIU",
+      ),
+    ).toBe("list_files")
+  })
+
+  it("returns undefined for non-synthetic ids", () => {
+    expect(syntheticToolNameFromToolCallId("call_abc123")).toBeUndefined()
+    expect(syntheticToolNameFromToolCallId("tool_")).toBeUndefined()
+  })
+})
+
+describe("createToolInvocationRepairTransform", () => {
+  it("prepends tool-input-start when tool output has no prior invocation", async () => {
+    const toolCallId = "tool_list_files_HKlhFchTWEPs9eertVIU"
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          type: "tool-output-available",
+          toolCallId,
+          output: "ok",
+        })
+        controller.close()
+      },
+    })
+
+    const out = input.pipeThrough(createToolInvocationRepairTransform())
+    const reader = out.getReader()
+    const a = await reader.read()
+    const b = await reader.read()
+
+    expect(a.done).toBe(false)
+    expect(a.value).toMatchObject({
+      type: "tool-input-start",
+      toolCallId,
+      toolName: "list_files",
+      dynamic: true,
+    })
+
+    expect(b.done).toBe(false)
+    expect(b.value).toMatchObject({
+      type: "tool-output-available",
+      toolCallId,
+      output: "ok",
+    })
+
+    expect(await reader.read()).toEqual({ done: true, value: undefined })
+  })
+
+  it("does not duplicate when tool-input-start was already seen", async () => {
+    const toolCallId = "tool_list_files_HKlhFchTWEPs9eertVIU"
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          type: "tool-input-start",
+          toolCallId,
+          toolName: "list_files",
+          dynamic: true,
+        })
+        controller.enqueue({
+          type: "tool-output-available",
+          toolCallId,
+          output: "ok",
+        })
+        controller.close()
+      },
+    })
+
+    const out = input.pipeThrough(createToolInvocationRepairTransform())
+    const reader = out.getReader()
+    const chunks: unknown[] = []
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+    }
+
+    expect(chunks).toHaveLength(2)
+    expect((chunks[0] as { type: string }).type).toBe("tool-input-start")
+    expect((chunks[1] as { type: string }).type).toBe("tool-output-available")
+  })
+})

--- a/apps/backend/src/domain/conversations/uiMessageStreamToolInvocationRepair.ts
+++ b/apps/backend/src/domain/conversations/uiMessageStreamToolInvocationRepair.ts
@@ -1,0 +1,74 @@
+import type { UIMessageChunk } from "ai"
+
+/**
+ * LangGraph / LangChain sometimes emits tool results whose `tool_call_id` does not match
+ * the id seen in streamed `tool_call_chunks`, so @ai-sdk/langchain never emits
+ * `tool-input-start` for that id. The AI SDK UI stream processor then throws
+ * "No tool invocation found for tool call ID ..." on `tool-output-available`.
+ *
+ * When the id follows the synthetic pattern `tool_<toolName>_<opaqueSuffix>`, infer the
+ * tool name and inject a `tool-input-start` so the client can attach the output.
+ */
+export function syntheticToolNameFromToolCallId(
+  toolCallId: string,
+): string | undefined {
+  if (!toolCallId.startsWith("tool_")) return undefined
+  const rest = toolCallId.slice("tool_".length)
+  const lastUnderscore = rest.lastIndexOf("_")
+  if (lastUnderscore <= 0) return undefined
+  const candidate = rest.slice(0, lastUnderscore)
+  const suffix = rest.slice(lastUnderscore + 1)
+  if (suffix.length < 8 || !/^[a-zA-Z0-9_-]+$/.test(suffix)) return undefined
+  if (candidate.length === 0) return undefined
+  return candidate
+}
+
+function chunkNeedsExistingToolInvocation(
+  chunk: UIMessageChunk,
+): chunk is UIMessageChunk & { toolCallId: string } {
+  if (chunk.type !== "tool-output-available" && chunk.type !== "tool-output-error")
+    return false
+  return typeof (chunk as { toolCallId?: unknown }).toolCallId === "string"
+}
+
+/**
+ * Pass-through transform that prepends a synthetic `tool-input-start` when we would
+ * otherwise hit the AI SDK's missing-invocation error for tool output chunks.
+ */
+export function createToolInvocationRepairTransform(): TransformStream<
+  UIMessageChunk,
+  UIMessageChunk
+> {
+  const seenToolCallIds = new Set<string>()
+
+  return new TransformStream<UIMessageChunk, UIMessageChunk>({
+    transform(chunk, controller) {
+      if (
+        chunk.type === "tool-input-start" ||
+        chunk.type === "tool-input-available" ||
+        chunk.type === "tool-input-delta"
+      ) {
+        const id = (chunk as { toolCallId?: string }).toolCallId
+        if (typeof id === "string" && id.length > 0) seenToolCallIds.add(id)
+      }
+
+      if (chunkNeedsExistingToolInvocation(chunk)) {
+        const { toolCallId } = chunk
+        if (!seenToolCallIds.has(toolCallId)) {
+          const toolName = syntheticToolNameFromToolCallId(toolCallId)
+          if (toolName !== undefined) {
+            controller.enqueue({
+              type: "tool-input-start",
+              toolCallId,
+              toolName,
+              dynamic: true,
+            })
+            seenToolCallIds.add(toolCallId)
+          }
+        }
+      }
+
+      controller.enqueue(chunk)
+    },
+  })
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **CTX-37**: the chat UI could show `No tool invocation found for tool call ID "tool_list_files_..."` and then catch up with content much later.

## Root cause

The AI SDK throws when it receives `tool-output-available` (or `tool-output-error`) before any matching tool part exists for that `toolCallId` (see `process-ui-message-stream.ts` → `getToolInvocation`). LangGraph/LangChain sometimes emits tool results whose `tool_call_id` does not align with the streamed `tool_call_chunks` path, so `@ai-sdk/langchain` never emitted `tool-input-start` for that id.

## Fix

After `toUIMessageStream`, pipe through a small transform that, for synthetic ids shaped like `tool_<toolName>_<opaqueSuffix>`, prepends a `tool-input-start` chunk when we are about to emit tool output and no invocation was seen yet.

## Tests

- `apps/backend/src/domain/conversations/uiMessageStreamToolInvocationRepair.test.ts` covers parsing and the transform behavior (including no duplicate when start was already present).

## Files

- `apps/backend/src/domain/conversations/uiMessageStreamToolInvocationRepair.ts` — repair transform
- `apps/backend/src/domain/conversations/transport.ts` — wire transform into conversation stream response
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-37](https://linear.app/ctxpipe/issue/CTX-37/chat-is-not-working-well-kinda)

<div><a href="https://cursor.com/agents/bc-f68b89de-913f-4d63-97e0-7bc41d56d709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f68b89de-913f-4d63-97e0-7bc41d56d709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

