### PR TITLE
fix(mcp): raise recursion limit for ctx_advisor ReAct agent

### DIFF
--- a/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
@@ -13,7 +13,7 @@ import type { ConversationGraphState } from "../state.js"
  * Default (~25) is easy to exceed when the advisor runs several repo/graph tools;
  * explicit limit avoids GraphRecursionError for typical MCP turns.
  */
-const AGENT_RECURSION_LIMIT = 60
+const AGENT_RECURSION_LIMIT = 100
 
 const baseInstructions = `
 You are the organizational context advisor. Your primary job is ORGANIZATIONAL CONTEXT: standards, ADRs, approved patterns, and what is common across the fleet — not speculative precision about the codebase.

--- a/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
@@ -8,6 +8,13 @@ import { standardRepoExplorerTools } from "../../../tools/repoExplorerTools.js"
 import { createAgent } from "../../createAgent.js"
 import type { ConversationGraphState } from "../state.js"
 
+/**
+ * LangGraph step budget for the ReAct tool loop (model → tools → model → …).
+ * Default (~25) is easy to exceed when the advisor runs several repo/graph tools;
+ * explicit limit avoids GraphRecursionError for typical MCP turns.
+ */
+const AGENT_RECURSION_LIMIT = 60
+
 const baseInstructions = `
 You are the organizational context advisor. Your primary job is ORGANIZATIONAL CONTEXT: standards, ADRs, approved patterns, and what is common across the fleet — not speculative precision about the codebase.
 
@@ -94,6 +101,7 @@ export async function agentNode(
     { messages: inputMessages },
     {
       streamMode: "values",
+      recursionLimit: AGENT_RECURSION_LIMIT,
       callbacks: langfusePipelineCallbacks({
         step: "conversation.agent",
         dimensions: { source: source ?? "ui" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ctx_advisor` (MCP) runs the conversation graph’s **agent** node, which uses LangChain `createAgent` (a ReAct loop compiled as a LangGraph). Each model → tools → model cycle consumes **recursion steps** on that inner graph. LangGraph’s default recursion budget is low enough that thorough multi-tool turns hit `GraphRecursionError` (“recursion limit”), which matches reports from Claude Code.

## Change

- Pass `recursionLimit: 100` to `agent.stream()` in `agentNode` so typical advisor tool use stays within budget without a large refactor.

## Testing

- `pnpm --filter @ctxpipe/backend test src/mcp/tools.test.ts`

## Notes

If we still see limits on very long sessions, optional follow-ups (separate tickets): cap tool rounds in the system prompt for MCP, or tune `createAgent` context middleware triggers for the advisor path only.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-44](https://linear.app/ctxpipe/issue/CTX-44/mcp-issue)

<div><a href="https://cursor.com/agents/bc-12ebc6c1-9e61-488e-bc79-3b08902c23bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12ebc6c1-9e61-488e-bc79-3b08902c23bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

