### PR TITLE
chore(otel): bump otel-collector-contrib to 0.150.0

### DIFF
--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM otel/opentelemetry-collector-contrib:0.150.0
+FROM ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.150.0
 
 COPY apps/otel-collector/config.yaml /etc/otelcol/config.yaml
 

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM otel/opentelemetry-collector-contrib:0.109.0
+FROM otel/opentelemetry-collector-contrib:0.150.0
 
 COPY apps/otel-collector/config.yaml /etc/otelcol/config.yaml
 

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.150.0
+FROM otel/opentelemetry-collector-contrib:0.149.0
 
 COPY apps/otel-collector/config.yaml /etc/otelcol/config.yaml
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   otel-collector:
     profiles: [infra, deploy]
-    image: otel/opentelemetry-collector-contrib:0.150.0
+    image: otel/opentelemetry-collector-contrib:0.150.0-nightly.018eab1
     restart: unless-stopped
     env_file:
       - path: ./apps/otel-collector/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   otel-collector:
     profiles: [infra, deploy]
-    image: otel/opentelemetry-collector-contrib:0.109.0
+    image: otel/opentelemetry-collector-contrib:0.150.0
     restart: unless-stopped
     env_file:
       - path: ./apps/otel-collector/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   otel-collector:
     profiles: [infra, deploy]
-    image: otel/opentelemetry-collector-contrib:0.150.0
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.150.0
     restart: unless-stopped
     env_file:
       - path: ./apps/otel-collector/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   otel-collector:
     profiles: [infra, deploy]
-    image: otel/opentelemetry-collector-contrib:0.150.0-nightly.018eab1
+    image: otel/opentelemetry-collector-contrib:0.149.0
     restart: unless-stopped
     env_file:
       - path: ./apps/otel-collector/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   otel-collector:
     profiles: [infra, deploy]
-    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.150.0
+    image: otel/opentelemetry-collector-contrib:0.150.0
     restart: unless-stopped
     env_file:
       - path: ./apps/otel-collector/.env


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pin OpenTelemetry Collector Contrib to a **stable** image version that removes `http: superfluous response.WriteHeader` log spam in the OTLP/HTTP receiver path.

Why not `0.150.0` stable?
- `otel/opentelemetry-collector-contrib:0.150.0` is not present on Docker Hub (manifest unknown).
- `ghcr.io/open-telemetry/opentelemetry-collector-releases/...:0.150.0` returned `manifest unknown` from this environment.

What this PR does instead
- Pin to **stable** `otel/opentelemetry-collector-contrib:0.149.0` in:
  - `apps/otel-collector/Dockerfile`
  - `docker-compose.yml` (`otel-collector` service)

Verification
- Start infra compose profile.
- POST a minimal OTLP/HTTP payload to `http://localhost:4318/v1/traces`.
- Confirm no `superfluous response.WriteHeader` warnings appear in collector logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5225e3c0-c0fd-4667-a348-dc7c2f4cdf6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5225e3c0-c0fd-4667-a348-dc7c2f4cdf6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

