### PR TITLE
Seed bundle: onboarded user+org with better-hub ingested (snapshot+restore)

### DIFF
--- a/.agents/start.sh
+++ b/.agents/start.sh
@@ -63,3 +63,18 @@ AUTH_ALLOWED_ORIGINS=http://localhost:3002,http://localhost:3000
 EOF
   echo "cloud-agent: wrote $ENV_LOCAL from Cursor secrets."
 fi
+
+########################################################
+# 3. Remote-agent seed restore (opt-in)
+########################################################
+
+# Only restore seeds automatically in remote agent containers.
+# Local test runs should NOT set CTXPIPE_REMOTE_AGENT_SEED.
+if [ "${CTXPIPE_REMOTE_AGENT_SEED:-}" = "better_hub_full" ]; then
+  if [ -z "${SEED_USER_PASSWORD:-}" ]; then
+    echo "cloud-agent: CTXPIPE_REMOTE_AGENT_SEED=better_hub_full requires SEED_USER_PASSWORD in Cursor secrets." >&2
+    exit 1
+  fi
+  echo "cloud-agent: restoring seed better_hub_full…" >&2
+  pnpm --filter @ctxpipe/backend seed:better-hub:restore
+fi

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,6 +24,7 @@
     "rerun-skill-derivation": "bun run src/scripts/rerunSkillDerivation.ts",
     "verify-instruction-ingestion": "bun run src/scripts/verifyInstructionIngestion.ts",
     "seed:better-hub": "bun run src/scripts/seed/generateBetterHubSeed.ts",
+    "seed:better-hub:restore": "bun run src/scripts/seed/restoreBetterHubSeed.ts",
     "forward-github-webhook": "NODE_EXTRA_CA_CERTS=$HOME/.portless/ca.pem smee -u ${SMEE_URL:-https://smee.io/naliyA6yt5p9UmLf} -t https://app.ctxpipe.localhost/api/v1/webhook/github"
   },
   "dependencies": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,6 +23,7 @@
     "openworkflow:doctor": "pnpm dlx @openworkflow/cli doctor",
     "rerun-skill-derivation": "bun run src/scripts/rerunSkillDerivation.ts",
     "verify-instruction-ingestion": "bun run src/scripts/verifyInstructionIngestion.ts",
+    "seed:better-hub": "bun run src/scripts/seed/generateBetterHubSeed.ts",
     "forward-github-webhook": "NODE_EXTRA_CA_CERTS=$HOME/.portless/ca.pem smee -u ${SMEE_URL:-https://smee.io/naliyA6yt5p9UmLf} -t https://app.ctxpipe.localhost/api/v1/webhook/github"
   },
   "dependencies": {

--- a/apps/backend/src/scripts/seed/generateBetterHubSeed.ts
+++ b/apps/backend/src/scripts/seed/generateBetterHubSeed.ts
@@ -132,7 +132,7 @@ async function main(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email: SEED_EMAIL, password: SEED_PASSWORD, name: SEED_NAME }),
   })
-  if (!signUpRes.ok) {
+  if (!signUpRes.ok && signUpRes.status != 409) {
     const text = await signUpRes.text().catch(() => "")
     throw new Error(`sign-up failed: ${signUpRes.status} ${text}`)
   }

--- a/apps/backend/src/scripts/seed/generateBetterHubSeed.ts
+++ b/apps/backend/src/scripts/seed/generateBetterHubSeed.ts
@@ -1,0 +1,302 @@
+import { spawnSync } from "node:child_process"
+import { mkdir, rm, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { config } from "dotenv"
+import { eq } from "drizzle-orm"
+import { withOrgIdContext } from "../../auth/withAuth.js"
+import { parseEnv } from "../../config/env.js"
+import {
+  closeDb,
+  getOrgDb,
+  getSystemDb,
+  initDb,
+  withOrgDbContext,
+} from "../../db/client.js"
+import { members, organizations, users } from "../../db/schema/auth.js"
+import { orgOnboarding } from "../../db/schema/org_onboarding.js"
+import { createRepository } from "../../models/repositories.js"
+import { repositoryIngestion } from "../../openworkflow/repository-ingestion.js"
+import { ow } from "../../openworkflow/client.js"
+import {
+  BETTER_HUB_SEED_BUNDLE_TGZ,
+  BETTER_HUB_SEED_DIR,
+  BETTER_HUB_SEED_MANIFEST_JSON,
+  BETTER_HUB_SEED_PUBLIC_CREDENTIALS_JSON,
+} from "./seedPaths.js"
+import { generateObjectId } from "../../lib/id.js"
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url))
+config({ path: resolve(__dirname, "../../../.env.local") })
+
+type SeedManifest = {
+  schemaVersion: 1
+  createdAt: string
+  app: {
+    orgId: string
+    orgSlug: string
+    userId: string
+    email: string
+    repositoryId: string
+    zoektRepoId: number
+    targetHash: string | null
+  }
+  sources: {
+    gitUrl: string
+  }
+  artifacts: {
+    postgres: string
+    falkor: string
+    zoektIndexTar: string
+    repoCacheTar: string
+  }
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name]
+  if (!v) {
+    console.error(`Missing required env var ${name}`)
+    process.exit(1)
+  }
+  return v
+}
+
+function sh(cmd: string, args: string[], opts?: { env?: Record<string, string> }) {
+  const res = spawnSync(cmd, args, {
+    stdio: "inherit",
+    env: { ...process.env, ...(opts?.env ?? {}) },
+  })
+  if (res.status !== 0) {
+    throw new Error(`Command failed: ${cmd} ${args.join(" ")}`)
+  }
+}
+
+function shOutput(cmd: string, args: string[]): string {
+  const res = spawnSync(cmd, args, {
+    stdio: ["ignore", "pipe", "inherit"],
+    env: process.env,
+    encoding: "utf8",
+  })
+  if (res.status !== 0) {
+    throw new Error(`Command failed: ${cmd} ${args.join(" ")}`)
+  }
+  return (res.stdout ?? "").toString().trim()
+}
+
+async function ensureSeedDir() {
+  await mkdir(BETTER_HUB_SEED_DIR, { recursive: true })
+}
+
+async function waitForHttpOk(url: string, timeoutMs: number) {
+  const start = Date.now()
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const res = await fetch(url, { method: "GET" })
+      if (res.ok) return
+    } catch {
+      // ignore until timeout
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for ${url}`)
+    }
+    await new Promise((r) => setTimeout(r, 500))
+  }
+}
+
+async function main(): Promise<void> {
+  const env = parseEnv(process.env as Record<string, string | undefined>)
+  initDb(env.DATABASE_URL)
+
+  const SEED_EMAIL = requireEnv("SEED_USER_EMAIL")
+  const SEED_NAME = requireEnv("SEED_USER_NAME")
+  const SEED_PASSWORD = requireEnv("SEED_USER_PASSWORD")
+  const SEED_ORG_NAME = requireEnv("SEED_ORG_NAME")
+  const SEED_ORG_SLUG = requireEnv("SEED_ORG_SLUG")
+
+  const GIT_URL = "https://github.com/better-auth/better-hub.git"
+  const REPO_NAME = "better-auth/better-hub"
+
+  await ensureSeedDir()
+  await rm(BETTER_HUB_SEED_BUNDLE_TGZ, { force: true }).catch(() => {})
+
+  // 0) Ensure full dockerized stack is up (so auth HTTP endpoints exist).
+  // Using deploy profile so codesearch+zoekt have stable /data paths for snapshotting.
+  sh("bash", ["-lc", "docker compose --profile deploy up -d --build migrate backend worker ui codesearch"])
+  await waitForHttpOk(`${env.AUTH_BASE_URL.replace(/\/$/, "")}/.docs/openapi`, 120_000)
+
+  // 1) Create user via Better Auth HTTP API (so password hashing etc stays correct).
+  const baseUrl = env.AUTH_BASE_URL.replace(/\/$/, "")
+  const signUpRes = await fetch(`${baseUrl}/.auth/api/v1/auth/sign-up/email`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: SEED_EMAIL, password: SEED_PASSWORD, name: SEED_NAME }),
+  })
+  if (!signUpRes.ok) {
+    const text = await signUpRes.text().catch(() => "")
+    throw new Error(`sign-up failed: ${signUpRes.status} ${text}`)
+  }
+
+  // 2) Create org and membership directly in Postgres (deterministic IDs + no cookie juggling).
+  const systemDb = getSystemDb()
+  const [userRow] = await systemDb
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .where(eq(users.email, SEED_EMAIL))
+    .limit(1)
+  if (!userRow) throw new Error("Seed user not found after signup")
+
+  const orgId = generateObjectId("org")
+  const now = new Date()
+  await systemDb.transaction(async (tx) => {
+    await tx
+      .insert(organizations)
+      .values({
+        id: orgId,
+        name: SEED_ORG_NAME,
+        slug: SEED_ORG_SLUG,
+        logo: null,
+        createdAt: now,
+        metadata: null,
+      })
+      .onConflictDoNothing()
+    await tx
+      .insert(members)
+      .values({
+        id: generateObjectId("mbr"),
+        organizationId: orgId,
+        userId: userRow.id,
+        role: "admin",
+        createdAt: now,
+      })
+      .onConflictDoNothing()
+  })
+
+  // 3) Mark user onboarding complete + org onboarding complete.
+  await systemDb
+    .update(users)
+    .set({ onboardingCompletedAt: now })
+    .where(eq(users.id, userRow.id))
+  await systemDb
+    .insert(orgOnboarding)
+    .values({
+      organizationId: orgId,
+      completedAt: now,
+      completedByUserId: userRow.id,
+      createdAt: now,
+    })
+    .onConflictDoUpdate({
+      target: orgOnboarding.organizationId,
+      set: { completedAt: now, completedByUserId: userRow.id },
+    })
+
+  // 4) Add repo and run ingestion workflow in-process.
+  let repositoryId = ""
+  let zoektRepoId = 0
+  let targetHash: string | null = null
+  await withOrgIdContext({ id: orgId, slug: SEED_ORG_SLUG }, async () =>
+    withOrgDbContext(orgId, async () => {
+      const repo = await createRepository({ name: REPO_NAME, gitUrl: GIT_URL })
+      repositoryId = repo.id
+      zoektRepoId = repo.zoektRepoId
+      const result = await ow.runWorkflow(repositoryIngestion.spec, {
+        repositoryId: repo.id,
+        orgId: repo.orgId,
+      })
+      targetHash = (result as unknown as { targetHash?: string }).targetHash ?? null
+    }),
+  )
+
+  // 5) Write public credentials for automation (no secret).
+  await writeFile(
+    BETTER_HUB_SEED_PUBLIC_CREDENTIALS_JSON,
+    JSON.stringify(
+      {
+        orgSlug: SEED_ORG_SLUG,
+        email: SEED_EMAIL,
+        landingPath: `/${SEED_ORG_SLUG}/repositories`,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  )
+
+  // 6) Export snapshots.
+  // Postgres dump
+  const pgDumpPath = resolve(BETTER_HUB_SEED_DIR, "postgres.sql")
+  sh("bash", [
+    "-lc",
+    `PGPASSWORD=${process.env.POSTGRES_PASSWORD ?? "ctxpipe"} pg_dump "${env.DATABASE_URL}" > "${pgDumpPath}"`,
+  ])
+
+  // FalkorDB dump: use RDB save + copy dump file from container.
+  const falkorDumpPath = resolve(BETTER_HUB_SEED_DIR, "falkor.rdb")
+  const falkorContainer = shOutput("docker", ["compose", "--profile", "deploy", "ps", "-q", "falkordb"])
+  sh("docker", ["exec", falkorContainer, "redis-cli", "SAVE"])
+  sh("docker", ["cp", `${falkorContainer}:/var/lib/falkordb/data/dump.rdb`, falkorDumpPath])
+
+  // Zoekt + repo-cache + kuzu live in codesearch container volumes mounted at /data.
+  const codesearchContainer = shOutput("docker", [
+    "compose",
+    "--profile",
+    "deploy",
+    "ps",
+    "-q",
+    "codesearch",
+  ])
+  const zoektTar = resolve(BETTER_HUB_SEED_DIR, "zoekt_index.tar.gz")
+  const repoCacheTar = resolve(BETTER_HUB_SEED_DIR, "repo_cache.tar.gz")
+  sh("docker", ["exec", codesearchContainer, "tar", "-czf", "/tmp/zoekt_index.tar.gz", "-C", "/data", "zoekt-index"])
+  sh("docker", ["exec", codesearchContainer, "tar", "-czf", "/tmp/repo_cache.tar.gz", "-C", "/data", "repo-cache"])
+  sh("docker", ["cp", `${codesearchContainer}:/tmp/zoekt_index.tar.gz`, zoektTar])
+  sh("docker", ["cp", `${codesearchContainer}:/tmp/repo_cache.tar.gz`, repoCacheTar])
+
+  const manifest: SeedManifest = {
+    schemaVersion: 1,
+    createdAt: new Date().toISOString(),
+    app: {
+      orgId,
+      orgSlug: SEED_ORG_SLUG,
+      userId: userRow.id,
+      email: SEED_EMAIL,
+      repositoryId,
+      zoektRepoId,
+      targetHash,
+    },
+    sources: { gitUrl: GIT_URL },
+    artifacts: {
+      postgres: "postgres.sql",
+      falkor: "falkor.rdb",
+      zoektIndexTar: "zoekt_index.tar.gz",
+      repoCacheTar: "repo_cache.tar.gz",
+    },
+  }
+  await writeFile(BETTER_HUB_SEED_MANIFEST_JSON, JSON.stringify(manifest, null, 2), "utf8")
+
+  // 7) Bundle everything into tar.gz
+  sh("tar", [
+    "-czf",
+    BETTER_HUB_SEED_BUNDLE_TGZ,
+    "-C",
+    BETTER_HUB_SEED_DIR,
+    "postgres.sql",
+    "falkor.rdb",
+    "zoekt_index.tar.gz",
+    "repo_cache.tar.gz",
+    "manifest.json",
+    "credentials.json",
+  ])
+
+  console.log(`Seed bundle written: ${BETTER_HUB_SEED_BUNDLE_TGZ}`)
+}
+
+main()
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await closeDb().catch(() => {})
+  })
+

--- a/apps/backend/src/scripts/seed/restoreBetterHubSeed.ts
+++ b/apps/backend/src/scripts/seed/restoreBetterHubSeed.ts
@@ -1,0 +1,163 @@
+import { spawnSync } from "node:child_process"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { config } from "dotenv"
+import { fileURLToPath } from "node:url"
+import {
+  BETTER_HUB_SEED_BUNDLE_TGZ,
+  BETTER_HUB_SEED_DIR,
+  BETTER_HUB_SEED_MANIFEST_JSON,
+  BETTER_HUB_SEED_PUBLIC_CREDENTIALS_JSON,
+  BETTER_HUB_SEED_RUNTIME_CREDENTIALS_JSON,
+} from "./seedPaths.js"
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url))
+config({ path: resolve(__dirname, "../../../.env.local") })
+
+type SeedManifest = {
+  schemaVersion: 1
+  app: { orgSlug: string; email: string }
+  artifacts: {
+    postgres: string
+    falkor: string
+    zoektIndexTar: string
+    repoCacheTar: string
+  }
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name]
+  if (!v) {
+    console.error(`Missing required env var ${name}`)
+    process.exit(1)
+  }
+  return v
+}
+
+function sh(cmd: string, args: string[]) {
+  const res = spawnSync(cmd, args, { stdio: "inherit", env: process.env })
+  if (res.status !== 0) throw new Error(`Command failed: ${cmd} ${args.join(" ")}`)
+}
+
+function shOutput(cmd: string, args: string[]): string {
+  const res = spawnSync(cmd, args, {
+    stdio: ["ignore", "pipe", "inherit"],
+    env: process.env,
+    encoding: "utf8",
+  })
+  if (res.status !== 0) throw new Error(`Command failed: ${cmd} ${args.join(" ")}`)
+  return (res.stdout ?? "").toString().trim()
+}
+
+async function ensureSeedDir(): Promise<void> {
+  await mkdir(BETTER_HUB_SEED_DIR, { recursive: true })
+}
+
+async function main(): Promise<void> {
+  await ensureSeedDir()
+
+  // Ensure stack is up so we can restore into running services.
+  sh("bash", [
+    "-lc",
+    "docker compose --profile deploy up -d postgres falkordb migrate backend worker ui codesearch",
+  ])
+
+  // Extract seed bundle into seed dir (overwrites expected files).
+  await rm(resolve(BETTER_HUB_SEED_DIR, "postgres.sql"), { force: true }).catch(() => {})
+  await rm(resolve(BETTER_HUB_SEED_DIR, "falkor.rdb"), { force: true }).catch(() => {})
+  await rm(resolve(BETTER_HUB_SEED_DIR, "zoekt_index.tar.gz"), { force: true }).catch(() => {})
+  await rm(resolve(BETTER_HUB_SEED_DIR, "repo_cache.tar.gz"), { force: true }).catch(() => {})
+  sh("tar", ["-xzf", BETTER_HUB_SEED_BUNDLE_TGZ, "-C", BETTER_HUB_SEED_DIR])
+
+  const manifest = JSON.parse(
+    await readFile(BETTER_HUB_SEED_MANIFEST_JSON, "utf8"),
+  ) as SeedManifest
+
+  // Restore Postgres via psql in container.
+  const postgresContainer = shOutput("docker", [
+    "compose",
+    "--profile",
+    "deploy",
+    "ps",
+    "-q",
+    "postgres",
+  ])
+  const pgSql = resolve(BETTER_HUB_SEED_DIR, manifest.artifacts.postgres)
+  sh("docker", ["cp", pgSql, `${postgresContainer}:/tmp/seed.sql`])
+  sh("docker", [
+    "exec",
+    "-i",
+    postgresContainer,
+    "bash",
+    "-lc",
+    "psql -U ctxpipe -d ctxpipe -f /tmp/seed.sql",
+  ])
+
+  // Restore FalkorDB by replacing dump.rdb and restarting container.
+  const falkorContainer = shOutput("docker", [
+    "compose",
+    "--profile",
+    "deploy",
+    "ps",
+    "-q",
+    "falkordb",
+  ])
+  const falkorRdb = resolve(BETTER_HUB_SEED_DIR, manifest.artifacts.falkor)
+  sh("docker", ["cp", falkorRdb, `${falkorContainer}:/var/lib/falkordb/data/dump.rdb`])
+  sh("docker", ["restart", falkorContainer])
+
+  // Restore zoekt index + repo cache into codesearch volumes.
+  const codesearchContainer = shOutput("docker", [
+    "compose",
+    "--profile",
+    "deploy",
+    "ps",
+    "-q",
+    "codesearch",
+  ])
+  const zoektTar = resolve(BETTER_HUB_SEED_DIR, manifest.artifacts.zoektIndexTar)
+  const repoCacheTar = resolve(BETTER_HUB_SEED_DIR, manifest.artifacts.repoCacheTar)
+  sh("docker", ["cp", zoektTar, `${codesearchContainer}:/tmp/zoekt_index.tar.gz`])
+  sh("docker", ["cp", repoCacheTar, `${codesearchContainer}:/tmp/repo_cache.tar.gz`])
+  sh("docker", [
+    "exec",
+    codesearchContainer,
+    "bash",
+    "-lc",
+    "rm -rf /data/zoekt-index /data/repo-cache && mkdir -p /data && tar -xzf /tmp/zoekt_index.tar.gz -C /data && tar -xzf /tmp/repo_cache.tar.gz -C /data",
+  ])
+
+  // Write runtime-only credentials for browser automation.
+  const seedPassword = requireEnv("SEED_USER_PASSWORD")
+  const publicCreds = JSON.parse(
+    await readFile(BETTER_HUB_SEED_PUBLIC_CREDENTIALS_JSON, "utf8"),
+  ) as { orgSlug: string; email: string; landingPath: string }
+  await mkdir(dirname(BETTER_HUB_SEED_RUNTIME_CREDENTIALS_JSON), {
+    recursive: true,
+  })
+  await writeFile(
+    BETTER_HUB_SEED_RUNTIME_CREDENTIALS_JSON,
+    JSON.stringify(
+      {
+        ...publicCreds,
+        password: seedPassword,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  )
+
+  console.log(
+    `Restored better_hub_full seed. Runtime creds at ${BETTER_HUB_SEED_RUNTIME_CREDENTIALS_JSON}`,
+  )
+  console.log(
+    `Landing: /${manifest.app.orgSlug}/repositories (email: ${manifest.app.email})`,
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+

--- a/apps/backend/src/scripts/seed/seedPaths.ts
+++ b/apps/backend/src/scripts/seed/seedPaths.ts
@@ -1,0 +1,32 @@
+import { resolve } from "node:path"
+
+/**
+ * Centralised paths for committed seed artifacts and runtime-only credential files.
+ *
+ * Seed bundle is committed to the repo so remote agents can restore without network calls.
+ * Runtime credentials are written to /tmp so we never commit secrets.
+ */
+export const BETTER_HUB_SEED_DIR = resolve(
+  process.cwd(),
+  "apps/backend/test/seeds/better_hub_full",
+)
+
+export const BETTER_HUB_SEED_BUNDLE_TGZ = resolve(
+  BETTER_HUB_SEED_DIR,
+  "seed_bundle.tar.gz",
+)
+
+export const BETTER_HUB_SEED_MANIFEST_JSON = resolve(
+  BETTER_HUB_SEED_DIR,
+  "manifest.json",
+)
+
+export const BETTER_HUB_SEED_PUBLIC_CREDENTIALS_JSON = resolve(
+  BETTER_HUB_SEED_DIR,
+  "credentials.json",
+)
+
+// Runtime-only file written by remote-agent startup to hand browser automation credentials.
+export const BETTER_HUB_SEED_RUNTIME_CREDENTIALS_JSON =
+  "/tmp/ctxpipe_seed_credentials.json"
+

--- a/apps/backend/test/seeds/better_hub_full/README.md
+++ b/apps/backend/test/seeds/better_hub_full/README.md
@@ -1,0 +1,22 @@
+Seed: better_hub_full
+
+This directory contains a committed snapshot bundle that remote-agent containers can restore to bring up a fully onboarded org + user with the `better-auth/better-hub` repository already ingested.
+
+Artifacts
+- `seed_bundle.tar.gz`: tar.gz containing the files below.
+- `manifest.json`: stable IDs + metadata for the seed.
+- `credentials.json`: non-secret identifiers for browser automation (email, orgSlug, landingPath).
+
+Generation
+- Run: `pnpm --filter @ctxpipe/backend seed:better-hub`
+- Required env:
+  - `SEED_USER_EMAIL`
+  - `SEED_USER_NAME`
+  - `SEED_USER_PASSWORD` (secret; do not commit)
+  - `SEED_ORG_NAME`
+  - `SEED_ORG_SLUG`
+
+Restore (remote agent only)
+- Remote agent startup restores the seed when `CTXPIPE_REMOTE_AGENT_SEED=better_hub_full` is set.
+- Startup writes runtime-only credentials to `/tmp/ctxpipe_seed_credentials.json` for browser automation.
+

--- a/apps/backend/test/seeds/better_hub_full/credentials.json
+++ b/apps/backend/test/seeds/better_hub_full/credentials.json
@@ -1,0 +1,5 @@
+{
+  "orgSlug": "seed-org",
+  "email": "seed@example.com",
+  "landingPath": "/seed-org/repositories"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the seed plan scaffolding.

- Adds generator script for `better_hub_full` seed and a docs/metadata folder.
- Adds a restore script intended for remote-agent/container startup use.
- Wires opt-in restore into cloud-agent startup via `CTXPIPE_REMOTE_AGENT_SEED=better_hub_full`.

Next steps in this PR:
- Run generator to ingest `better-auth/better-hub`, produce `seed_bundle.tar.gz`, and commit it.
- Add validation checks (UI login + repo list + Zoekt search + basic graph query).

Notes:
- Seed metadata lives at `apps/backend/test/seeds/better_hub_full/`.
- Generator: `pnpm --filter @ctxpipe/backend seed:better-hub`.
- Restore: `pnpm --filter @ctxpipe/backend seed:better-hub:restore`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a72e4693-e2d4-4293-9389-6c8b58549ff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a72e4693-e2d4-4293-9389-6c8b58549ff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

