### PR TITLE
docs: fix README separation (root vs backend) — CTX-59

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
-# ctxpipe app
+<p align="center">
+  <img src="apps/ui/public/ctx_.svg" alt="ctx|" width="320" />
+</p>
+
+<p align="center">
+  <a href="https://img.shields.io/badge/License-ELv2-0f766e.svg"><img src="https://img.shields.io/badge/License-ELv2-0f766e.svg" alt="License: ELv2" /></a>
+</p>
+
+<p align="center">
+  <a href="https://ctxpipe.ai">Website</a>
+  ·
+  <a href="https://github.com/ctxpipe-ai/ctxpipe/issues">Issues</a>
+  ·
+  <a href="https://docs.ctxpipe.ai">Docs</a>
+</p>
+
+# ctx| (ctxpipe)
 
 **The context layer for AI agents** — infrastructure that helps coding agents understand your codebase, standards, and how work gets done in your organisation. ctx| combines a Git-first instruction hierarchy (`AGENTS.md`, skills, MCP), a knowledge graph that learns from your repositories and usage, and an agent-agnostic MCP surface so Cursor, Claude Code, Copilot, and other tools can share one connection.
 
 Learn more at **[ctxpipe.ai](https://ctxpipe.ai)**.
+
+## How it fits together
+
+<p align="center">
+  <img src="apps/ui/public/images/ctxpipe-onboarding-diagram.svg" alt="ctx| diagram" width="1080" />
+</p>
 
 ## Documentation
 
@@ -35,7 +57,7 @@ pnpm dev
 > [!warning]
 > If your browser warns about the local certificate, run **`pnpm trust`** once from the repo root.
 
-For backend API, OpenAPI, and MCP specifics, see [apps/backend/README.md](apps/backend/README.md).
+For backend API, OpenAPI, MCP, and package scripts, see [apps/backend/README.md](apps/backend/README.md).
 
 ## Self-hosted stack (Docker Compose)
 
@@ -59,3 +81,8 @@ See [.ai/memory/decisions/ADR-015-docker-compose-profiles-and-small-scale-deploy
 | `pnpm build`                | Turborepo build                                                              |
 | `pnpm lint` / `pnpm format` | Biome                                                                        |
 | `pnpm mcp:inspect`          | MCP inspector (backend)                                                      |
+
+## Licence
+
+This project is released under **Elastic License 2.0 (ELv2)**.  
+See the open-source guide: [docs.ctxpipe.ai/docs/resources/open-source](https://docs.ctxpipe.ai/docs/resources/open-source)

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,65 +1,10 @@
-# ctxpipe/backend
+# `@ctxpipe/backend`
 
-<p align="center">
-  <img src="../docs/public/ctxpipe-logo-readme.png" alt="ctx| logo" width="480" />
-</p>
+Core HTTP API and MCP service for [ctx|](https://ctxpipe.ai). Built with **Hono** on **Bun**, **Better Auth**, **PostgreSQL** + **Drizzle**, and workflow orchestration for ingestion and agent tooling.
 
-<p align="center">
-  <a href="https://img.shields.io/badge/License-ELv2-0f766e.svg"><img src="https://img.shields.io/badge/License-ELv2-0f766e.svg" alt="License: ELv2" /></a>
-</p>
+**Monorepo:** clone, environment, Compose deployment, and host dev flows live in the [repository root README](../../README.md). Run **`pnpm dev:infra`** and **`pnpm dev`** from the repo root unless you are intentionally running only this package.
 
-<p align="center">
-  <a href="https://ctxpipe.ai">Website</a>
-  ·
-  <a href="https://github.com/ctxpipe-ai/ctxpipe/issues">Issues</a>
-  ·
-  <a href="https://docs.ctxpipe.ai">Docs</a>
-</p>
-
-The context layer for AI agents — infrastructure that helps coding agents understand your codebase, standards, and how work gets done in your org. Git-first instruction hierarchy (AGENTS.md, skills, MCP), a knowledge graph that learns from your repos, docs, tools, and usage, and an agent-agnostic MCP surface so Cursor, Claude Code, Copilot, and other tools share one connection.
-
-`@ctxpipe/backend` is the core API service for ctx|.
-
-## How does ctx| work? 
-
-<p align="center">
-  <img src="../ui/public/images/ctxpipe-onboarding-diagram.svg" alt="ctx| diagram" width="1080" />
-</p>
-
-
-
-
-## Quick Start (Local Deploy)
-
-For the easiest local deployment experience, use Docker Compose from the repo root:
-
-```bash
-git clone https://github.com/ctxpipe-ai/ctxpipe.git
-cd ctxpipe
-cp docker-compose.env.example .env
-pnpm install
-pnpm start
-```
-
-Before `pnpm start`, set at least these values in `.env`:
-
-- `AUTH_SECRET` (minimum 32 characters)
-- `AUTH_BASE_URL`
-- `CTXPIPE_PUBLIC_APP_URL`
-
-## Developer Mode (Host + Docker Infra)
-
-If you are actively developing code, run app services on host and infra in Docker:
-
-```bash
-pnpm install
-pnpm dev:infra
-pnpm dev
-```
-
-Use `https://app.ctxpipe.localhost` for integrated local development.
-
-## What it provides
+## What this package provides
 
 - org-scoped REST APIs (`/:orgSlug/api/v1/*`)
 - MCP endpoint (`/mcp`) for agent integrations
@@ -76,7 +21,7 @@ Use `https://app.ctxpipe.localhost` for integrated local development.
 - Orchestration: OpenWorkflow + LangGraph
 - Testing: Vitest
 
-## API & Endpoints
+## API & endpoints
 
 - REST (org-scoped): `/:orgSlug/api/v1/*`
 - OpenAPI JSON: `/.docs/openapi`
@@ -91,7 +36,7 @@ Use `https://app.ctxpipe.localhost` for integrated local development.
 - `push` events to default branch trigger repository ingestion workflow enqueue
 - `repository.created` can trigger repository sync when auto-sync options are enabled
 
-## Scripts
+## Scripts (this package)
 
 | Script | Description |
 | --- | --- |
@@ -105,7 +50,7 @@ Use `https://app.ctxpipe.localhost` for integrated local development.
 | `pnpm db:migrate` | Apply migrations |
 | `pnpm db:studio` | Open Drizzle Studio |
 
-## Project Structure
+## Project structure
 
 - `src/app` – Hono app wiring and middleware
 - `src/routes` – REST and webhook routes
@@ -117,5 +62,4 @@ Use `https://app.ctxpipe.localhost` for integrated local development.
 
 ## Licence
 
-This project is released under **Elastic License 2.0 (ELv2)**.  
-See the open-source guide: [docs.ctxpipe.ai/docs/resources/open-source](https://docs.ctxpipe.ai/docs/resources/open-source)
+Released under **Elastic License 2.0 (ELv2)** — same terms as the parent repo; details: [open-source (docs)](https://docs.ctxpipe.ai/docs/resources/open-source).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **CTX-59**: styling and public-facing content that landed on `apps/backend/README.md` now belongs on the **repository root** `README.md`. The backend README is trimmed to **package-specific** developer documentation.

## Changes

- **Root `README.md`**: centred logo (using `apps/ui/public/ctx_.svg` — the previous `docs/public/ctxpipe-logo-readme.png` path does not exist in this tree), licence badge, quick links, architecture diagram, product pitch, docs links, monorepo dev/Compose/scripts table, and ELv2 licence section.
- **`apps/backend/README.md`**: focused on `@ctxpipe/backend` — what the package provides, stack, API/MCP/webhooks, package scripts, source layout, and a short licence pointer to docs; points to the root README for clone/dev/Compose flows (no duplicate full-stack quick start).

## Notes

- Logo: replaced broken `../docs/public/ctxpipe-logo-readme.png` reference with an asset that exists in-repo (`apps/ui/public/ctx_.svg`). If marketing prefers the wide PNG, add it under a stable path and swap the `<img>` `src`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-59](https://linear.app/ctxpipe/issue/CTX-59/fix-readme-work)

<div><a href="https://cursor.com/agents/bc-e0082f60-b8ea-4551-a715-62b48f27793e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0082f60-b8ea-4551-a715-62b48f27793e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

