### PR TITLE
fix(auth): MCP OAuth for hosts that omit JWT session id (sid)

### DIFF
--- a/apps/backend/src/auth/withAuth.test.ts
+++ b/apps/backend/src/auth/withAuth.test.ts
@@ -45,6 +45,14 @@ vi.mock("../db/client.js", () => ({
   withOrgDbContext: withOrgDbContextMock,
 }))
 
+vi.mock("../observability/logger.js", () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  }),
+}))
+
 import {
   requireAuth,
   resetBearerJwksCacheForTests,
@@ -59,9 +67,15 @@ function createMockDb(input: {
     session: { id: string; userId: string }
     user: { id: string; name?: string | null; email?: string | null }
   }>
+  /** When bearer JWT has no `sid`, `withBearerAuth` loads latest session by user id (`sub`). */
+  bearerSubFallbackRows?: Array<{
+    session: { id: string; userId: string }
+    user: { id: string; name?: string | null; email?: string | null }
+  }>
 }) {
   const orgRows = input.orgRows ?? []
   const tokenSessionRows = input.tokenSessionRows ?? []
+  const bearerSubFallbackRows = input.bearerSubFallbackRows ?? tokenSessionRows
 
   return {
     select: vi.fn((fields?: unknown) => {
@@ -76,6 +90,9 @@ function createMockDb(input: {
             innerJoin: vi.fn(() => ({
               where: vi.fn(() => ({
                 limit: vi.fn(async () => tokenSessionRows),
+                orderBy: vi.fn(() => ({
+                  limit: vi.fn(async () => bearerSubFallbackRows),
+                })),
               })),
             })),
           })),
@@ -201,6 +218,59 @@ describe("auth middleware composition", () => {
     })
     expect(jwtVerifyMock).toHaveBeenCalledTimes(1)
     expect(authHandlerMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("withBearerAuth resolves user from sub when JWT omits sid (MCP OAuth clients)", async () => {
+    jwtVerifyMock.mockResolvedValueOnce({
+      payload: { sub: "user_oauth_only" },
+    })
+    testState.db = createMockDb({
+      tokenSessionRows: [],
+      bearerSubFallbackRows: [
+        {
+          session: { id: "sess_latest", userId: "user_oauth_only" },
+          user: { id: "user_oauth_only", email: "oauth@example.com" },
+        },
+      ],
+    })
+
+    const app = createBaseApp()
+    app.use("/mcp", withBearerAuth)
+    app.post("/mcp", (c) =>
+      c.json({ user: c.get("user"), session: c.get("session") }),
+    )
+
+    const response = await app.request("/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer token-value" },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      user: { id: "user_oauth_only", email: "oauth@example.com" },
+      session: { id: "sess_latest", userId: "user_oauth_only" },
+    })
+  })
+
+  it("withBearerAuth returns 401 when JWT has sub but no sid and no DB session for user", async () => {
+    jwtVerifyMock.mockResolvedValueOnce({
+      payload: { sub: "user_unknown" },
+    })
+    testState.db = createMockDb({
+      tokenSessionRows: [],
+      bearerSubFallbackRows: [],
+    })
+
+    const app = createBaseApp()
+    app.use("/mcp", withBearerAuth)
+    app.post("/mcp", (c) => c.text("ok"))
+
+    const response = await app.request("/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer token-value" },
+    })
+
+    expect(response.status).toBe(401)
   })
 
   it("withBearerAuth uses cached JWKS for a second request (single JWKS fetch)", async () => {

--- a/apps/backend/src/auth/withAuth.ts
+++ b/apps/backend/src/auth/withAuth.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks"
-import { eq } from "drizzle-orm"
+import { desc, eq } from "drizzle-orm"
 import type { MiddlewareHandler } from "hono"
 import {
   createLocalJWKSet,
@@ -11,7 +11,7 @@ import type { AppEnv } from "../app/env.js"
 import { getSystemDb, withOrgDbContext } from "../db/client.js"
 import { organizations, sessions, users } from "../db/schema/auth.js"
 import { getLogger } from "../observability/logger.js"
-import { getAuth } from "./config.js"
+import { type AuthSession, type AuthUser, getAuth } from "./config.js"
 
 /** Seconds — small skew between issuers, clients, and this server (Better Auth / jose guidance). */
 const JWT_CLOCK_TOLERANCE_SECONDS = 60
@@ -242,22 +242,49 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
       ? payload.sid
       : null
 
-  if (!tokenSessionId) return next()
-
   const db = getSystemDb()
-  const tokenSessionRows = await db
-    .select({ session: sessions, user: users })
-    .from(sessions)
-    .innerJoin(users, eq(sessions.userId, users.id))
-    .where(eq(sessions.id, tokenSessionId))
-    .limit(1)
+  let tokenSessionContext: { session: AuthSession; user: AuthUser } | undefined
 
-  const tokenSessionContext = tokenSessionRows[0]
+  if (tokenSessionId) {
+    const tokenSessionRows = await db
+      .select({ session: sessions, user: users })
+      .from(sessions)
+      .innerJoin(users, eq(sessions.userId, users.id))
+      .where(eq(sessions.id, tokenSessionId))
+      .limit(1)
+    tokenSessionContext = tokenSessionRows[0]
+  } else {
+    // OAuth access tokens from some MCP clients omit `sid` but still carry `sub`
+    // (user id). Resolve the latest DB session for that user so `/mcp` can auth.
+    const rows = await db
+      .select({ session: sessions, user: users })
+      .from(sessions)
+      .innerJoin(users, eq(sessions.userId, users.id))
+      .where(eq(users.id, payload.sub))
+      .orderBy(desc(sessions.updatedAt))
+      .limit(1)
+    tokenSessionContext = rows[0]
+  }
+
   if (tokenSessionContext) {
     c.set("session", tokenSessionContext.session)
     c.set("user", tokenSessionContext.user)
+    return next()
   }
-  return next()
+
+  logBearerAuthFailure(
+    new Error(
+      tokenSessionId
+        ? "Bearer JWT session id not found"
+        : "Bearer JWT subject has no resolvable session",
+    ),
+    { kid },
+  )
+  return c.json(
+    { error: "Unauthorized" },
+    401,
+    wwwAuthenticateInvalidToken("The access token could not be validated"),
+  )
 }
 
 export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **CTX-16** (CodeRabbit and similar tools failing OAuth with “enter your access token” after a successful browser consent).

## Root cause

`withBearerAuth` only populated `user` / `session` when the JWT contained a non-empty **`sid`** (session id). Some OAuth access tokens (notably from third-party MCP connectors) validate correctly but **omit `sid`**, only carrying **`sub`** (user id). In that case the middleware called `next()` without setting context, so `requireAuth` returned **401** — hosts surface that as a generic “access token” prompt.

## Change

- If **`sid` is present**: unchanged — load session by `sessions.id = sid`.
- If **`sid` is absent**: load the user’s **latest** `sessions` row joined to `users` where `users.id = sub` (`orderBy` `sessions.updatedAt` desc, `limit 1`) and attach that session + user.
- If a **`sid` is present but not found** in the DB, return **401** with `invalid_token` (explicit failure instead of silently continuing).

## Tests

- Extended `withAuth` test DB mock for `orderBy().limit()`.
- Added cases: sub-only bearer success; sub-only with no session → 401.
- Mocked `getLogger` in this file so new failure logging does not require full evlog/Hono context in unit tests.

## Operator note

The screenshot also showed `orgSlug=` with an **empty** value. The MCP URL must be `.../mcp?orgSlug=<your-org-slug>` or the server returns **400** before auth. That is separate from this OAuth fix but worth double-checking in CodeRabbit’s form.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-16](https://linear.app/ctxpipe/issue/CTX-16/coderabbit-not-authorising-app)

<div><a href="https://cursor.com/agents/bc-6e159965-cb89-4a11-8f12-951939150ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e159965-cb89-4a11-8f12-951939150ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

