### PR TITLE
fix(auth): validate opaque MCP OAuth access tokens (CTX-16)

### DIFF
--- a/apps/backend/src/auth/withAuth.test.ts
+++ b/apps/backend/src/auth/withAuth.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { AppEnv } from "../app/env.js"
+import { oauthAccessTokens } from "../db/schema/auth.js"
 
 const {
   getSessionMock,
@@ -72,10 +73,18 @@ function createMockDb(input: {
     session: { id: string; userId: string }
     user: { id: string; name?: string | null; email?: string | null }
   }>
+  /** For opaque (non-JWT) bearer tokens, `withBearerAuth` looks up `oauth_access_tokens.token`. */
+  opaqueTokenRows?: Array<{
+    token: string
+    userId: string | null
+    sessionId: string | null
+    expiresAt: Date | null
+  }>
 }) {
   const orgRows = input.orgRows ?? []
   const tokenSessionRows = input.tokenSessionRows ?? []
   const bearerSubFallbackRows = input.bearerSubFallbackRows ?? tokenSessionRows
+  const opaqueTokenRows = input.opaqueTokenRows ?? []
 
   return {
     select: vi.fn((fields?: unknown) => {
@@ -100,11 +109,14 @@ function createMockDb(input: {
       }
 
       return {
-        from: vi.fn(() => ({
-          where: vi.fn(() => ({
-            limit: vi.fn(async () => orgRows),
-          })),
-        })),
+        from: vi.fn((table: unknown) => {
+          const rows = table === oauthAccessTokens ? opaqueTokenRows : orgRows
+          return {
+            where: vi.fn(() => ({
+              limit: vi.fn(async () => rows),
+            })),
+          }
+        }),
       }
     }),
   }
@@ -208,7 +220,7 @@ describe("auth middleware composition", () => {
 
     const response = await app.request("/mcp", {
       method: "POST",
-      headers: { authorization: "Bearer token-value" },
+      headers: { authorization: "Bearer header.payload.signature" },
     })
 
     expect(response.status).toBe(200)
@@ -242,7 +254,7 @@ describe("auth middleware composition", () => {
 
     const response = await app.request("/mcp", {
       method: "POST",
-      headers: { authorization: "Bearer token-value" },
+      headers: { authorization: "Bearer header.payload.signature" },
     })
 
     expect(response.status).toBe(200)
@@ -267,7 +279,85 @@ describe("auth middleware composition", () => {
 
     const response = await app.request("/mcp", {
       method: "POST",
-      headers: { authorization: "Bearer token-value" },
+      headers: { authorization: "Bearer header.payload.signature" },
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it("withBearerAuth validates an opaque (non-JWT) OAuth access token via oauth_access_tokens", async () => {
+    testState.db = createMockDb({
+      opaqueTokenRows: [
+        {
+          token: "hashed-token",
+          userId: "user_opaque",
+          sessionId: "sess_opaque",
+          expiresAt: new Date(Date.now() + 60_000),
+        },
+      ],
+      tokenSessionRows: [
+        {
+          session: { id: "sess_opaque", userId: "user_opaque" },
+          user: { id: "user_opaque", email: "opaque@example.com" },
+        },
+      ],
+    })
+
+    const app = createBaseApp()
+    app.use("/mcp", withBearerAuth)
+    app.post("/mcp", (c) =>
+      c.json({ user: c.get("user"), session: c.get("session") }),
+    )
+
+    const response = await app.request("/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer opaque-random-32-chars" },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      user: { id: "user_opaque", email: "opaque@example.com" },
+      session: { id: "sess_opaque", userId: "user_opaque" },
+    })
+    expect(jwtVerifyMock).not.toHaveBeenCalled()
+    expect(authHandlerMock).not.toHaveBeenCalled()
+  })
+
+  it("withBearerAuth returns 401 for an unknown opaque access token", async () => {
+    testState.db = createMockDb({ opaqueTokenRows: [] })
+
+    const app = createBaseApp()
+    app.use("/mcp", withBearerAuth)
+    app.post("/mcp", (c) => c.text("ok"))
+
+    const response = await app.request("/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer does-not-exist" },
+    })
+
+    expect(response.status).toBe(401)
+    expect(jwtVerifyMock).not.toHaveBeenCalled()
+  })
+
+  it("withBearerAuth returns 401 for an expired opaque access token", async () => {
+    testState.db = createMockDb({
+      opaqueTokenRows: [
+        {
+          token: "hashed-token",
+          userId: "user_opaque",
+          sessionId: "sess_opaque",
+          expiresAt: new Date(Date.now() - 60_000),
+        },
+      ],
+    })
+
+    const app = createBaseApp()
+    app.use("/mcp", withBearerAuth)
+    app.post("/mcp", (c) => c.text("ok"))
+
+    const response = await app.request("/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer expired-opaque" },
     })
 
     expect(response.status).toBe(401)
@@ -294,11 +384,11 @@ describe("auth middleware composition", () => {
 
     await app.request("/mcp", {
       method: "POST",
-      headers: { authorization: "Bearer token-one" },
+      headers: { authorization: "Bearer one.two.three" },
     })
     await app.request("/mcp", {
       method: "POST",
-      headers: { authorization: "Bearer token-two" },
+      headers: { authorization: "Bearer four.five.six" },
     })
 
     expect(authHandlerMock).toHaveBeenCalledTimes(1)
@@ -328,7 +418,7 @@ describe("auth middleware composition", () => {
 
     const response = await app.request("/mcp", {
       method: "POST",
-      headers: { authorization: "Bearer token-value" },
+      headers: { authorization: "Bearer header.payload.signature" },
     })
 
     expect(response.status).toBe(200)
@@ -376,7 +466,7 @@ describe("auth middleware composition", () => {
     const app = createComposedTestApp()
     const response = await app.request("/mcp?orgSlug=acme", {
       method: "POST",
-      headers: { authorization: "Bearer token-value" },
+      headers: { authorization: "Bearer header.payload.signature" },
     })
 
     expect(response.status).toBe(200)
@@ -409,7 +499,7 @@ describe("auth middleware composition", () => {
     const app = createComposedTestApp()
     const response = await app.request("/mcp?orgSlug=acme", {
       method: "POST",
-      headers: { authorization: "Bearer token-value" },
+      headers: { authorization: "Bearer header.payload.signature" },
     })
 
     expect(response.status).toBe(200)

--- a/apps/backend/src/auth/withAuth.ts
+++ b/apps/backend/src/auth/withAuth.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks"
+import { createHash } from "node:crypto"
 import { desc, eq } from "drizzle-orm"
 import type { MiddlewareHandler } from "hono"
 import {
@@ -9,7 +10,12 @@ import {
 } from "jose"
 import type { AppEnv } from "../app/env.js"
 import { getSystemDb, withOrgDbContext } from "../db/client.js"
-import { organizations, sessions, users } from "../db/schema/auth.js"
+import {
+  oauthAccessTokens,
+  organizations,
+  sessions,
+  users,
+} from "../db/schema/auth.js"
 import { getLogger } from "../observability/logger.js"
 import { type AuthSession, type AuthUser, getAuth } from "./config.js"
 
@@ -102,6 +108,51 @@ function isLikelyJwksKeyProblem(err: unknown): boolean {
   return true
 }
 
+/**
+ * `@better-auth/oauth-provider` stores opaque access tokens as
+ * `base64url(sha256(token))` (default `storeTokens: "hashed"`). We hash the
+ * incoming bearer the same way before looking it up.
+ */
+function hashOpaqueAccessToken(token: string): string {
+  return createHash("sha256").update(token).digest("base64url")
+}
+
+async function resolveOpaqueAccessToken(
+  token: string,
+): Promise<{ session: AuthSession; user: AuthUser } | null> {
+  const db = getSystemDb()
+  const hashed = hashOpaqueAccessToken(token)
+  const tokenRows = await db
+    .select()
+    .from(oauthAccessTokens)
+    .where(eq(oauthAccessTokens.token, hashed))
+    .limit(1)
+  const record = tokenRows[0]
+  if (!record || !record.userId) return null
+  if (!record.expiresAt || record.expiresAt.getTime() <= Date.now()) return null
+
+  if (record.sessionId) {
+    const rows = await db
+      .select({ session: sessions, user: users })
+      .from(sessions)
+      .innerJoin(users, eq(sessions.userId, users.id))
+      .where(eq(sessions.id, record.sessionId))
+      .limit(1)
+    if (rows[0]) return rows[0]
+  }
+
+  // Session was deleted or null on the row — fall back to the user's latest
+  // session so `/mcp` still has a context to operate under.
+  const rows = await db
+    .select({ session: sessions, user: users })
+    .from(sessions)
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(eq(users.id, record.userId))
+    .orderBy(desc(sessions.updatedAt))
+    .limit(1)
+  return rows[0] ?? null
+}
+
 export const withCookieAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   const auth = getAuth()
   const authSession = await auth.api.getSession({
@@ -128,6 +179,26 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     ? authorization.replace("Bearer ", "").trim()
     : null
   if (!accessToken) return next()
+
+  // Better Auth's oauthProvider only issues JWT access tokens when the client
+  // sends the RFC 8707 `resource` parameter (`index.mjs:411`). MCP clients like
+  // CodeRabbit omit it, so we get an opaque random string instead. JWTs have
+  // three `.`-separated base64url segments; anything else we treat as opaque
+  // and validate via the `oauth_access_tokens` table.
+  if (accessToken.split(".").length !== 3) {
+    const resolved = await resolveOpaqueAccessToken(accessToken)
+    if (resolved) {
+      c.set("session", resolved.session)
+      c.set("user", resolved.user)
+      return next()
+    }
+    logBearerAuthFailure(new Error("Opaque access token not recognized"))
+    return c.json(
+      { error: "Unauthorized" },
+      401,
+      wwwAuthenticateInvalidToken("The access token could not be validated"),
+    )
+  }
 
   const auth = getAuth()
   const authBaseUrl = c.var.env.AUTH_BASE_URL


### PR DESCRIPTION
Better Auth's oauthProvider only mints JWT access tokens when the OAuth client sends the RFC 8707 `resource` parameter (index.mjs:411). MCP clients like CodeRabbit omit it, so the token is an opaque random string stored in `oauth_access_tokens`. Our bearer middleware was JWT-only, so jose threw JWSInvalid at compactVerify and the request 401'd.

withBearerAuth now detects non-JWT shape (token lacks three `.`-separated segments) and resolves it via `oauth_access_tokens`, hashing the bearer the same way Better Auth stores it (SHA-256 → unpadded base64url, matching @better-auth/utils defaultHasher). The existing JWT path is unchanged.

The prior sid-fallback fix is retained but inert for this code path — Better Auth always sets sid on its JWTs.