### PR TITLE
fix(ci): pass Amplitude credentials from GitHub secrets to Terraform

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -116,6 +116,8 @@ jobs:
       TF_VAR_better_stack_token: ${{ secrets.BETTER_STACK_TOKEN }}
       TF_VAR_langfuse_auth_string: ${{ secrets.LANGFUSE_AUTH_STRING }}
       TF_VAR_langfuse_otlp_endpoint: ${{ secrets.LANGFUSE_OTLP_ENDPOINT }}
+      TF_VAR_amplitude_api_key: ${{ secrets.AMPLITUDE_API_KEY }}
+      TF_VAR_amplitude_region: ${{ secrets.AMPLITUDE_REGION || 'us' }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/.github/workflows/terraform-plan-pr.yaml
+++ b/.github/workflows/terraform-plan-pr.yaml
@@ -39,6 +39,8 @@ jobs:
       TF_VAR_better_stack_token: ${{ secrets.BETTER_STACK_TOKEN }}
       TF_VAR_langfuse_auth_string: ${{ secrets.LANGFUSE_AUTH_STRING }}
       TF_VAR_langfuse_otlp_endpoint: ${{ secrets.LANGFUSE_OTLP_ENDPOINT }}
+      TF_VAR_amplitude_api_key: ${{ secrets.AMPLITUDE_API_KEY }}
+      TF_VAR_amplitude_region: ${{ secrets.AMPLITUDE_REGION || 'us' }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Terraform already maps `var.amplitude_api_key` to Railway `AMPLITUDE_API_KEY` / `AMPLITUDE_REGION` on backend and UI when the API key is non-empty (`infra/module/ctxpipe/railway.tf`). The deploy and PR terraform-plan workflows never set `TF_VAR_amplitude_api_key`, so CI always applied with the default empty string and **omitted** Amplitude from Railway entirely.

## Changes

- `.github/workflows/deploy.yaml`: set `TF_VAR_amplitude_api_key` from `secrets.AMPLITUDE_API_KEY` and `TF_VAR_amplitude_region` from `secrets.AMPLITUDE_REGION` (fallback `us`).
- `.github/workflows/terraform-plan-pr.yaml`: same so PR plans match deploy behavior.

## Operator notes

- Ensure the GitHub secret is named **`AMPLITUDE_API_KEY`** (matches workflow). If the secret used a different name, either rename it or adjust the workflow.
- Optional: add **`AMPLITUDE_REGION`** (`us` or `eu`); if omitted, workflows pass `us`.
- After merge, run a deploy (or manual `terraform apply` with the same TF_VARs) so Railway variables are created/updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cf57afd-e6cb-4272-8a1d-88d54f29a458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cf57afd-e6cb-4272-8a1d-88d54f29a458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

