### PR TITLE
fix(backend): CORS for MCP Inspector on localhost

### DIFF
--- a/apps/backend/src/app/app.ts
+++ b/apps/backend/src/app/app.ts
@@ -16,6 +16,7 @@ import { registerStatusRoutes } from "../routes/status"
 import { registerUiRoutes } from "../routes/ui.js"
 import { registerV1Routes } from "../routes/v1/index.js"
 import { registerWebhookRoutes } from "../routes/webhooks.js"
+import { corsOriginOption } from "./corsOrigin.js"
 import type { AppEnv } from "./env.js"
 
 export type { AppEnv } from "./env.js"
@@ -36,7 +37,7 @@ export function createApp() {
   app.use(
     "*",
     cors({
-      origin: corsOrigins.length > 0 ? corsOrigins : "*",
+      origin: corsOriginOption(corsOrigins),
       credentials: true,
     }),
   )

--- a/apps/backend/src/app/corsOrigin.test.ts
+++ b/apps/backend/src/app/corsOrigin.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { corsOriginOption, isLoopbackBrowserOrigin } from "./corsOrigin.js"
+
+describe("isLoopbackBrowserOrigin", () => {
+  it("accepts localhost and 127.0.0.1 with any port", () => {
+    expect(isLoopbackBrowserOrigin("http://localhost:6274")).toBe(true)
+    expect(isLoopbackBrowserOrigin("http://127.0.0.1:3000")).toBe(true)
+    expect(isLoopbackBrowserOrigin("https://localhost")).toBe(true)
+  })
+
+  it("accepts IPv6 loopback", () => {
+    expect(isLoopbackBrowserOrigin("http://[::1]:8080")).toBe(true)
+  })
+
+  it("rejects non-loopback hosts", () => {
+    expect(isLoopbackBrowserOrigin("https://evil.example")).toBe(false)
+    expect(isLoopbackBrowserOrigin("http://192.168.1.1:3000")).toBe(false)
+  })
+})
+
+describe("corsOriginOption", () => {
+  it("returns * when the allowlist is empty", () => {
+    expect(corsOriginOption([])).toBe("*")
+  })
+
+  it("allows listed origins and loopback dev origins", () => {
+    const allow = corsOriginOption([
+      "https://app.example.com",
+      "https://ui.example.com",
+    ])
+    expect(typeof allow).toBe("function")
+    const fn = allow as (origin: string) => string | null | undefined
+    expect(fn("https://app.example.com")).toBe("https://app.example.com")
+    expect(fn("http://localhost:6274")).toBe("http://localhost:6274")
+    expect(fn("https://attacker.com")).toBeNull()
+  })
+})

--- a/apps/backend/src/app/corsOrigin.ts
+++ b/apps/backend/src/app/corsOrigin.ts
@@ -1,0 +1,38 @@
+import type { Context } from "hono"
+
+/**
+ * True for typical local dev origins (any port), so tools like MCP Inspector
+ * (browser on e.g. http://localhost:6274) work when AUTH_ALLOWED_ORIGINS lists
+ * only the app and UI (portless) origins.
+ */
+export function isLoopbackBrowserOrigin(origin: string): boolean {
+  try {
+    const u = new URL(origin)
+    if (u.protocol !== "http:" && u.protocol !== "https:") return false
+    const host = u.hostname.toLowerCase()
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host === "[::1]"
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Hono `cors({ origin })` value: explicit list, or "*" when unset, or a
+ * resolver that also allows loopback origins for dev tooling.
+ */
+export function corsOriginOption(
+  allowedOrigins: string[],
+): string | ((origin: string, c: Context) => string | null | undefined) {
+  if (allowedOrigins.length === 0) return "*"
+  return (origin: string, _c: Context) => {
+    if (!origin) return null
+    if (allowedOrigins.includes(origin)) return origin
+    if (isLoopbackBrowserOrigin(origin)) return origin
+    return null
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Browsers block cross-origin requests when `AUTH_ALLOWED_ORIGINS` lists only the app and UI origins (e.g. from `scripts/dev-apps.sh`). MCP Inspector runs on a different origin such as `http://localhost:6274`, so preflight failed with no `Access-Control-Allow-Origin`.

## Change

- Add a CORS origin resolver that allows configured origins **and** loopback browser origins (`localhost`, `127.0.0.1`, `::1`, any port) when an allowlist is set.
- When `AUTH_ALLOWED_ORIGINS` is unset, behavior stays `origin: *` (unchanged).

## Notes

Production deployments should still list real web app origins in `AUTH_ALLOWED_ORIGINS`; this only relaxes **local** tooling origins without opening arbitrary public domains.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a6e9f5d-4b12-4edd-8cb9-fc25f5c0bc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a6e9f5d-4b12-4edd-8cb9-fc25f5c0bc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

