### PR TITLE
ci(forge): disable CLI analytics prompt in non-TTY env

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -173,10 +173,12 @@ jobs:
         env:
           FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
           FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
+          FORGE_DISABLE_ANALYTICS: "1"
         run: pnpm --filter @ctxpipe/forge-ctxpipe-agent exec forge lint
 
       - name: Deploy to Forge production
         env:
           FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
           FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
+          FORGE_DISABLE_ANALYTICS: "1"
         run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run deploy:prod


### PR DESCRIPTION
## Summary

- Adds `FORGE_DISABLE_ANALYTICS=1` to both `Forge lint` and `Deploy to Forge production` steps in the `Deploy` workflow.
- Every post-merge Deploy run since 2026-04-16 has failed at `Forge lint` with: `Prompts can not be meaningfully rendered in non-TTY environments` — the Atlassian Forge CLI prompts for first-run analytics consent on each fresh GitHub Actions runner, and the prompt errors out under non-TTY.
- Setting `FORGE_DISABLE_ANALYTICS=1` short-circuits `CachedConfigService.getAnalyticsPreferences()` to return `false` (see `@forge/cli`'s `cached-config-service.js:24`), which skips the consent prompt in `PreCommandController.verifyAnalyticsPreferences`.

## Impact

- Backend/UI images have still been pushed and Terraform has been applying to Railway on every merge (Forge is the last job in the chain), so this fix unblocks only the Forge Confluence app deploys — recent merges did *not* bring Forge-side changes to prod.
- No change to other deploy stages.

## Test plan

- [ ] Merge and observe the next `Deploy` workflow run on `main`: `forge_deploy` job should pass without the TTY error.
- [ ] Confirm Forge production deploy succeeds end-to-end (look for the `forge deploy --environment production --non-interactive` step output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)