### PR TITLE
fix(backend,ci): scope compress() to KG route and fix forge lint env

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -174,6 +174,7 @@ jobs:
           FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
           FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
           FORGE_DISABLE_ANALYTICS: "1"
+          REMOTE_BASE_URL: https://app.ctxpipe.ai/
         run: pnpm --filter @ctxpipe/forge-ctxpipe-agent exec forge lint
 
       - name: Deploy to Forge production

--- a/apps/backend/src/app/app.ts
+++ b/apps/backend/src/app/app.ts
@@ -1,7 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi"
 import { parseError } from "evlog"
 import { evlog } from "evlog/hono"
-import { compress } from "hono/compress"
 import { contextStorage } from "hono/context-storage"
 import { cors } from "hono/cors"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
@@ -41,9 +40,6 @@ export function createApp() {
       credentials: true,
     }),
   )
-  // Large JSON payloads (knowledge-graph snapshot) are the motivating case;
-  // `compress()` uses the browser-native CompressionStream API (gzip/deflate).
-  app.use("*", compress())
   app.use(contextStorage())
   app.use(evlog({ drain: createEvlogDrain() }))
   app.use("*", async (c, next) => {

--- a/apps/backend/src/routes/v1/knowledge-graph.ts
+++ b/apps/backend/src/routes/v1/knowledge-graph.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { compress } from "hono/compress"
 import type { AppEnv } from "../../app/env.js"
 import {
   requireCurrentOrgId,
@@ -90,9 +91,9 @@ export const getKnowledgeGraphRoute = createRoute({
   },
 })
 
-export const knowledgeGraphRoutes = new OpenAPIHono<AppEnv>().openapi(
-  getKnowledgeGraphRoute,
-  async (c) => {
+export const knowledgeGraphRoutes = new OpenAPIHono<AppEnv>()
+  .use("*", compress())
+  .openapi(getKnowledgeGraphRoute, async (c) => {
     const user = c.get("user")
     const session = c.get("session")
     if (!user || !session) {
@@ -117,5 +118,4 @@ export const knowledgeGraphRoutes = new OpenAPIHono<AppEnv>().openapi(
       })
       return c.json({ error: "Graph database unavailable" }, 503)
     }
-  },
-)
+  })


### PR DESCRIPTION
## Summary

Two deploy-blocking issues both surfaced by the kg-graph-ui merge (#112):

### 1. Backend healthcheck failure (blocks KG UI in prod)

`app.use("*", compress())` applied Hono's compression middleware to every response — including `/.status`. Railway's healthcheck probe then received "service unavailable" for 14 consecutive attempts (5 min window), so every backend deploy for SHAs `>= c1739f8` failed and was rolled back to `6aa2be7`, which doesn't have the `/knowledge-graph` route — hence the 404 in production.

Fix: move `compress()` to the knowledge-graph sub-app only, where it was actually needed for the large snapshot payload.

### 2. Forge lint step now fails on missing `REMOTE_BASE_URL`

After #119 fixed the Forge analytics TTY prompt, `forge lint` now reaches manifest validation and fails:
```
manifest.yml failed to parse content - could not find environment variable 'REMOTE_BASE_URL'
```
The `deploy:prod` package script sets this at runtime (`REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge deploy ...`), but the bare `forge lint` step doesn't. Mirror it in the workflow step env.

## Expected outcome after merge

- Backend image rebuilds from new main SHA.
- Railway healthcheck passes (compress no longer in the `/.status` path).
- Terraform promotes the new backend SHA → UI's `/knowledge-graph` fetch succeeds.
- Forge lint + deploy both pass, workflow goes fully green.

## Test plan

- [ ] Deploy workflow on `main` after merge goes green end-to-end.
- [ ] Railway `backend` service shows a `SUCCESS` deploy with the new main SHA, not rolled back.
- [ ] Knowledge Graph page in production loads without the `GET /:orgSlug/api/v1/knowledge-graph 404` error.
- [ ] Forge Confluence app shows the new production version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)