### PR TITLE
fix(backend): remove compress() middleware from KG route

### DIFF
--- a/apps/backend/src/routes/v1/knowledge-graph.ts
+++ b/apps/backend/src/routes/v1/knowledge-graph.ts
@@ -1,5 +1,4 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
-import { compress } from "hono/compress"
 import type { AppEnv } from "../../app/env.js"
 import {
   requireCurrentOrgId,
@@ -91,9 +90,9 @@ export const getKnowledgeGraphRoute = createRoute({
   },
 })
 
-export const knowledgeGraphRoutes = new OpenAPIHono<AppEnv>()
-  .use("*", compress())
-  .openapi(getKnowledgeGraphRoute, async (c) => {
+export const knowledgeGraphRoutes = new OpenAPIHono<AppEnv>().openapi(
+  getKnowledgeGraphRoute,
+  async (c) => {
     const user = c.get("user")
     const session = c.get("session")
     if (!user || !session) {


### PR DESCRIPTION
## Summary

`hono/compress` relies on `globalThis.CompressionStream`, which is not available in this Bun runtime (`oven/bun:1.2-alpine`). Every `GET /:orgSlug/api/v1/knowledge-graph` in production is returning 500:

```
ReferenceError: CompressionStream is not defined
  at compress2 (hono/dist/middleware/compress/index.js:23:24)
```

The previous PR (#120) scoped compress to the KG sub-app only (fixing the Railway healthcheck), but the underlying Bun incompatibility still breaks every KG request. Removing it ships uncompressed JSON, which is fine for current snapshot sizes.

## Tradeoffs

- Raw JSON over the wire. Tested: Railway's edge proxy does **not** auto-gzip dynamic responses for this service (no `content-encoding` returned on `Accept-Encoding: gzip`), so removal means no compression.
- For current graph sizes (a few hundred KB to ~1 MB), unnoticeable on desktop/good networks.
- Scales linearly with graph size — revisit if payloads cross ~1–2 MB via: manual `Bun.gzipSync` in the handler, Bun version bump (may have `CompressionStream` in later releases), or pagination.

## Test plan

- [ ] Deploy workflow on `main` after merge goes green.
- [ ] KG page in production loads without `GET /:orgSlug/api/v1/knowledge-graph 500`.
- [ ] Response `content-type: application/json`, no `content-encoding`.
- [ ] Graph renders in the UI for at least one org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)