### PR TITLE
feat(ui/knowledge-graph): "Ask ctx|" CTA seeds a chat from selected node

### DIFF
--- a/apps/ui/src/features/chat/ChatWorkspace.tsx
+++ b/apps/ui/src/features/chat/ChatWorkspace.tsx
@@ -6,7 +6,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query"
 import { Link, Navigate, useRouter } from "@tanstack/react-router"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { ShimmerPlaceholder } from "@/components/ui/ShimmerPlaceholder"
 import { client } from "@/lib/api"
 import { useSession } from "@/lib/auth-client"
@@ -26,11 +26,14 @@ import type {
 export function ChatWorkspace(props: {
   orgSlug: string
   conversationId?: string
+  /** If set, auto-sent as the first user message on mount (index route only).
+   * Used by the KG "Ask ctx|" CTA to seed a new chat with node context. */
+  seed?: string
 }) {
   const { data: session, isPending: sessionPending } = useSession()
   const queryClient = useQueryClient()
   const router = useRouter()
-  const { orgSlug, conversationId: conversationIdFromParams } = props
+  const { orgSlug, conversationId: conversationIdFromParams, seed } = props
 
   const [conversationId] = useState(
     () => conversationIdFromParams ?? createObjectId("conv"),
@@ -151,6 +154,18 @@ export function ChatWorkspace(props: {
       })
     }
   }
+
+  // One-shot auto-send for `?seed=...` handoffs (e.g. KG "Ask ctx|" CTA).
+  // Ref guard prevents re-fire on rerender; navigation to /chat/:id on success
+  // drops the seed from the URL anyway.
+  const autoSentSeedRef = useRef(false)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional one-shot on mount
+  useEffect(() => {
+    if (autoSentSeedRef.current) return
+    if (!seed || !isOnIndexRoute || sessionPending || !session) return
+    autoSentSeedRef.current = true
+    void handleSendMessage({ text: seed })
+  }, [seed, isOnIndexRoute, sessionPending, session])
 
   if (sessionPending) return <ChatWorkspaceSkeleton orgSlug={orgSlug} />
   if (!session) return <Navigate to="/.auth/sign-in" replace />

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
@@ -5,6 +5,7 @@ import {
   IconX,
 } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
+import { useRouter } from "@tanstack/react-router"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { client } from "@/lib/api"
 import { cn } from "@/lib/utils"
@@ -62,6 +63,7 @@ function syncDeepLink(nodeId: string | null): void {
 }
 
 export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
+  const router = useRouter()
   const [search, setSearch] = useState("")
   const [hiddenKinds, setHiddenKinds] = useState<Set<string>>(new Set())
   const [selectedId, setSelectedId] = useState<string | null>(() =>
@@ -657,6 +659,13 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
             cgRef.current?.focusNode(displayedNode.id)
           }}
           onNeighbourSelect={(id) => setSelectedId(id)}
+          onAskAgent={(seed) => {
+            void router.navigate({
+              to: "/$orgSlug/chat",
+              params: { orgSlug },
+              search: { seed },
+            })
+          }}
         />
       ) : null}
     </div>

--- a/apps/ui/src/features/knowledge-graph/NodeDetailDrawer.tsx
+++ b/apps/ui/src/features/knowledge-graph/NodeDetailDrawer.tsx
@@ -130,6 +130,7 @@ export function NodeDetailDrawer({
   onClose,
   onFocus,
   onNeighbourSelect,
+  onAskAgent,
 }: {
   node: KnowledgeGraphNode
   facts: NodeFacts
@@ -141,6 +142,7 @@ export function NodeDetailDrawer({
   onClose: () => void
   onFocus: () => void
   onNeighbourSelect: (id: string) => void
+  onAskAgent: (seed: string) => void
 }) {
   const kind = node.kind || "Unknown"
   const predicates = Array.from(facts.predicateCounts.entries())
@@ -228,6 +230,43 @@ export function NodeDetailDrawer({
       .catch(() => {})
   }
 
+  /** Compact, user-visible prompt the Chat UI autosends. Kept plain-text so
+   * the user can read/edit it if they land on the chat before it fires. */
+  const buildAskSeed = (): string => {
+    const lines: string[] = []
+    const label = node.name?.trim() || node.id
+    lines.push(`I want to understand this ${kind}: ${label} (${node.id}).`)
+    lines.push("")
+    lines.push(
+      `Connections: ${facts.inDegree} in · ${facts.outDegree} out · ${totalDegree} total.`,
+    )
+    if (strongestConnections.length > 0) {
+      const links = strongestConnections
+        .slice(0, 5)
+        .map(([nid]) => {
+          const nb = nodeById.get(nid)
+          return `${nb?.name?.trim() || nid} (${nb?.kind || "Unknown"})`
+        })
+        .join(", ")
+      lines.push(`Strongest links: ${links}.`)
+    }
+    if (predicates.length > 0) {
+      const preds = predicates
+        .slice(0, 5)
+        .map(([p, c]) => `${p} (${c})`)
+        .join(", ")
+      lines.push(`Common predicates: ${preds}.`)
+    }
+    if (node.summary?.trim()) {
+      lines.push(`Summary: ${node.summary.trim()}`)
+    }
+    lines.push("")
+    lines.push(
+      "Please explain what this node does, how it fits in the broader system based on its connections, and any risk areas worth paying attention to.",
+    )
+    return lines.join("\n")
+  }
+
   return (
     <aside
       className={cn(
@@ -264,34 +303,40 @@ export function NodeDetailDrawer({
       </div>
 
       <div className="flex-1 space-y-4 overflow-y-auto p-4">
-        {(peerRank || isIsolated) && (
-          <div className="flex flex-wrap items-center gap-1.5">
-            {peerRank ? (
-              <span
-                className="inline-flex items-center gap-1.5 border border-teal-500/30 bg-teal-500/5 px-2 py-0.5 text-[12px] text-teal-200"
-                title={`Rank ${peerRank.rankFromTop.toLocaleString()} of ${peerRank.totalPeers.toLocaleString()} ${kind} nodes by total connections`}
-              >
-                <span className="font-mono uppercase tracking-[0.12em] text-teal-400/80">
-                  Rank
-                </span>
-                <span className="tabular-nums">
-                  Top {formatPercentile(peerRank.percentile)} of {kind}
-                </span>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {peerRank ? (
+            <span
+              className="inline-flex items-center gap-1.5 border border-teal-500/30 bg-teal-500/5 px-2 py-0.5 text-[12px] text-teal-200"
+              title={`Rank ${peerRank.rankFromTop.toLocaleString()} of ${peerRank.totalPeers.toLocaleString()} ${kind} nodes by total connections`}
+            >
+              <span className="font-mono uppercase tracking-[0.12em] text-teal-400/80">
+                Rank
               </span>
-            ) : null}
-            {isIsolated ? (
-              <span
-                className="inline-flex items-center gap-1.5 border border-amber-500/30 bg-amber-500/5 px-2 py-0.5 text-[12px] text-amber-200"
-                title="Few or no connections — may indicate a stub or stale entity"
-              >
-                <span className="font-mono uppercase tracking-[0.12em] text-amber-400/80">
-                  ⚠
-                </span>
-                <span>Loosely connected</span>
+              <span className="tabular-nums">
+                Top {formatPercentile(peerRank.percentile)} of {kind}
               </span>
-            ) : null}
-          </div>
-        )}
+            </span>
+          ) : null}
+          {isIsolated ? (
+            <span
+              className="inline-flex items-center gap-1.5 border border-amber-500/30 bg-amber-500/5 px-2 py-0.5 text-[12px] text-amber-200"
+              title="Few or no connections — may indicate a stub or stale entity"
+            >
+              <span className="font-mono uppercase tracking-[0.12em] text-amber-400/80">
+                ⚠
+              </span>
+              <span>Loosely connected</span>
+            </span>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => onAskAgent(buildAskSeed())}
+            className="ml-auto inline-flex items-center gap-1.5 border border-teal-500/55 bg-teal-500/10 px-2 py-0.5 text-[12px] text-teal-200 transition-colors hover:border-teal-500/70 hover:bg-teal-500/15"
+            title="Open a new chat seeded with this node's context"
+          >
+            Ask ctx|
+          </button>
+        </div>
 
         <DetailRow label="Id">
           <div className="flex items-center gap-1.5">

--- a/apps/ui/src/routes/$orgSlug.chat.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.chat.index.tsx
@@ -1,11 +1,15 @@
-import { ChatWorkspace } from "@/features/chat/ChatWorkspace"
 import { createFileRoute } from "@tanstack/react-router"
+import { ChatWorkspace } from "@/features/chat/ChatWorkspace"
 
 export const Route = createFileRoute("/$orgSlug/chat/")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    seed: typeof search.seed === "string" ? search.seed : undefined,
+  }),
   component: ChatIndexRoute,
 })
 
 function ChatIndexRoute() {
   const { orgSlug } = Route.useParams()
-  return <ChatWorkspace orgSlug={orgSlug} />
+  const { seed } = Route.useSearch()
+  return <ChatWorkspace orgSlug={orgSlug} seed={seed} />
 }


### PR DESCRIPTION
## Summary

Adds a right-aligned **Ask ctx|** button inline with the rank chip at the top of the KG node drawer. Clicking builds a compact, user-visible text seed from the selected node's context (kind, name, id, connection counts, strongest links, top predicates, summary) and navigates to `/:orgSlug/chat?seed=…`. `ChatWorkspace` auto-sends the seed once on mount — no extra click needed — and the normal chat flow takes over from there (optimistic conversation entry + navigate to `/chat/:conversationId`).

## Why

The KG surfaces a lot of structure but answers "what is this?" only sparsely. The CTA is a one-click bridge from graph exploration → agent-backed explanation, using the conversation retrieval pipeline that already exists.

## Changes

- `NodeDetailDrawer.tsx` — new `onAskAgent(seed)` prop, inline `Ask ctx|` button in the rank row (row now always renders even without rank/isolated chips), `buildAskSeed()` helper that assembles the prompt from already-loaded drawer state.
- `KnowledgeGraphExplorer.tsx` — wires the handler to `router.navigate({ to: "/$orgSlug/chat", search: { seed } })`.
- `$orgSlug.chat.index.tsx` — `validateSearch` for the `seed` param, passes it through.
- `ChatWorkspace.tsx` — accepts optional `seed` prop; one-shot `useEffect` (ref-guarded) calls the existing `handleSendMessage` once when on the index route with a seed.

No backend changes. Seed is plain text and visible in the resulting conversation, so a user who lands on chat before auto-send fires can still edit it.

## Tradeoffs / notes

- Grounding quality depends on whether the conversation agent's retrieval finds source material keyed on node id/name. If answers feel thin for some node kinds, we'd follow up with kind-specific seed templates rather than reworking the button.
- Seed is passed via URL search param. Typical size ~500 chars; well under any URL length limits. If we ever want richer (binary) context, move to `sessionStorage` handoff.
- Auto-send is single-shot per mount. Navigating away and back with a new seed remounts the index route, so the next seed fires correctly.

## Test plan

- [ ] KG drawer: CTA visible right-aligned on the rank row for any node (including isolated / low-rank ones where the rank chip is absent).
- [ ] Click → arrives on `/:orgSlug/chat?seed=…`, seed auto-sends, URL transitions to `/:orgSlug/chat/:conversationId`.
- [ ] The seeded message appears as the user's first message in the thread; agent responds with an explanation that references the node.
- [ ] No double-send, no repeat on re-render/resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)