### PR TITLE
fix(chat): agent-only UI stream + dedupe conversation list (CTX-83)

### DIFF
--- a/apps/backend/src/domain/conversations/internalNodeMessageFilter.test.ts
+++ b/apps/backend/src/domain/conversations/internalNodeMessageFilter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { filterInternalNodeMessageChunks } from "./internalNodeMessageFilter.js"
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = []
+  for await (const x of iter) out.push(x)
+  return out
+}
+
+describe("filterInternalNodeMessageChunks", () => {
+  it("drops messages chunks from planner, keeps agent", async () => {
+    const plannerChunk = [
+      "messages",
+      [{}, { langgraph_node: "planner", langgraph_step: 1 }],
+    ]
+    const agentChunk = [
+      "messages",
+      [{}, { langgraph_node: "agent", langgraph_step: 2 }],
+    ]
+    const customChunk = ["custom", { type: "rename", name: "x" }]
+
+    const out = await collect(
+      filterInternalNodeMessageChunks(
+        (async function* () {
+          yield plannerChunk
+          yield agentChunk
+          yield customChunk
+        })(),
+      ),
+    )
+
+    expect(out).toEqual([agentChunk, customChunk])
+  })
+
+  it("drops messages chunks when langgraph_node is missing", async () => {
+    const chunk = ["messages", [{}, {}]]
+    const out = await collect(
+      filterInternalNodeMessageChunks(
+        (async function* () {
+          yield chunk
+        })(),
+      ),
+    )
+    expect(out).toEqual([])
+  })
+})

--- a/apps/backend/src/domain/conversations/internalNodeMessageFilter.ts
+++ b/apps/backend/src/domain/conversations/internalNodeMessageFilter.ts
@@ -1,17 +1,19 @@
 /**
- * Node names whose LLM output should not appear in the streamed UI (internal only).
- * When adding new internal nodes to the conversation graph, add them here or their
- * LLM output will leak into the streamed response.
+ * LangGraph `streamMode: "messages"` forwards token streams from every node that
+ * invokes a chat model (planner, conversation naming, agent, etc.). The UI must
+ * only show the user-facing `agent` reply.
+ *
+ * We allowlist the visible node rather than maintaining a blocklist: a missing
+ * or renamed `langgraph_node` on an internal model call would otherwise leak
+ * planner JSON into the chat, or a too-aggressive blocklist could drop the agent
+ * stream entirely (stuck on "Thinking…" with no answer).
  */
-const INTERNAL_MESSAGE_NODES = ["conversationNaming", "planner"] as const
-
-type InternalNodeName = (typeof INTERNAL_MESSAGE_NODES)[number]
+const USER_VISIBLE_MESSAGE_STREAM_NODE = "agent"
 
 /**
- * Filters out "messages" stream events from internal nodes (e.g. conversationNaming, planner).
- * LangGraph emits text-start/text-delta/text-end for ALL model invocations (including
- * model.invoke()). The metadata includes langgraph_node to identify the source node.
- * We filter these so only the final agent reply is shown as streamed text.
+ * Drops `messages` stream events from every LangGraph node except the
+ * user-facing assistant (`agent`). Other nodes still run; their model I/O is
+ * omitted from the UI message stream.
  */
 export async function* filterInternalNodeMessageChunks(
   stream: AsyncIterable<unknown>,
@@ -26,14 +28,10 @@ export async function* filterInternalNodeMessageChunks(
     if (mode === "messages" && Array.isArray(data) && data.length >= 2) {
       const metadata = data[1] as Record<string, unknown> | undefined
       const node = metadata?.langgraph_node
-      if (
-        node &&
-        INTERNAL_MESSAGE_NODES.includes(node as InternalNodeName)
-      ) {
+      if (node !== USER_VISIBLE_MESSAGE_STREAM_NODE) {
         continue
       }
     }
     yield chunk
   }
 }
-

--- a/apps/ui/src/features/chat/ChatWorkspace.tsx
+++ b/apps/ui/src/features/chat/ChatWorkspace.tsx
@@ -137,11 +137,13 @@ export function ChatWorkspace(props: {
         }
         return {
           ...old,
-          pages: old.pages.map((page, i) =>
-            i === 0
-              ? { ...page, items: [optimisticItem, ...page.items] }
-              : page,
-          ),
+          pages: old.pages.map((page, i) => {
+            if (i !== 0) return page
+            const withoutDup = page.items.filter(
+              (c) => c.id !== optimisticItem.id,
+            )
+            return { ...page, items: [optimisticItem, ...withoutDup] }
+          }),
         }
       })
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses **CTX-83** (chat stuck after "Thinking…", duplicate rows in conversation list).

### Root cause (responses)

The conversation graph uses LangGraph `streamMode: "messages"`, which forwards **token streams from every node that calls a chat model** (planner, conversation naming, agent, etc.). `@ai-sdk/langchain` turns those into UI `text-delta` / `reasoning-delta` chunks. A **blocklist** of internal nodes is brittle: if LangGraph tags a chunk with a node name we do not recognise, the UI can show planner-style output as the "assistant" stream, or internal chunks can interfere with the stream state so the user-visible answer never lands cleanly.

### Fix

- **Allowlist** `messages` chunks to only those with `metadata.langgraph_node === "agent"`. Everything else is dropped from the stream before `toUIMessageStream`. Custom/rename events are unchanged.

### Duplicate chats in the sidebar

On the index route we optimistically prepend `"New Chat"` to the React Query cache, then `invalidateQueries` refetches and can append the same conversation id again. We now **remove any existing row with that id** before prepending the optimistic item.

### Tests

- Added `internalNodeMessageFilter.test.ts` (Vitest) for allowlist behaviour.

## Verification

- `pnpm exec vitest run src/domain/conversations/internalNodeMessageFilter.test.ts` (from `apps/backend`)

Full backend `vitest run` in this environment still hits unrelated failures without Postgres (`DATABASE_URL` / integration suites).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-83](https://linear.app/ctxpipe/issue/CTX-83/chat-ui-responses-not-coming-through-duplicate-chats-recorded-in-list)

<div><a href="https://cursor.com/agents/bc-82282d36-e265-4332-997c-5b481edfdcad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82282d36-e265-4332-997c-5b481edfdcad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

