### PR TITLE
fix(chat): stop double-registering Langfuse handler on child CallbackManagers

### DIFF
--- a/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
@@ -141,10 +141,47 @@ export async function agentNode(
   )
 
   let finalMessages: BaseMessageLike[] | undefined
-  for await (const chunk of stream) {
-    const fromChunk = extractAgentStateMessages(chunk)
-    if (fromChunk) finalMessages = fromChunk
+  let messagesChunks = 0
+  let valuesChunks = 0
+  let otherChunks = 0
+  try {
+    for await (const chunk of stream) {
+      if (Array.isArray(chunk)) {
+        const mode = chunk.length === 3 ? chunk[1] : chunk[0]
+        if (mode === "messages") messagesChunks++
+        else if (mode === "values") valuesChunks++
+        else otherChunks++
+      } else {
+        otherChunks++
+      }
+      const fromChunk = extractAgentStateMessages(chunk)
+      if (fromChunk) finalMessages = fromChunk
+    }
+  } catch (err) {
+    // DIAGNOSTIC: surface LLM/stream errors that were previously silent.
+    // Chat was returning 200 with an empty SSE body; remove after root cause found.
+    console.error("[agentNode] stream error", {
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+      messagesChunks,
+      valuesChunks,
+      otherChunks,
+    })
+    throw err
   }
+
+  // DIAGNOSTIC: if messagesChunks === 0 the LLM emitted no token deltas →
+  // toUIMessageStream has no text-delta to send, UI renders nothing.
+  console.log("[agentNode] stream complete", {
+    messagesChunks,
+    valuesChunks,
+    otherChunks,
+    hasFinalMessages: !!finalMessages,
+    finalMessageCount: finalMessages?.length ?? 0,
+    generatedCount: finalMessages
+      ? finalMessages.slice(inputMessages.length).length
+      : 0,
+  })
 
   if (!finalMessages) {
     return {

--- a/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
@@ -2,7 +2,7 @@ import type { BaseMessageLike } from "@langchain/core/messages"
 import { AIMessage, SystemMessage } from "@langchain/core/messages"
 import { mergeConfigs } from "@langchain/core/runnables"
 import { getConfig } from "@langchain/langgraph"
-import { langfusePipelineCallbacks } from "../../../observability/langfusePipelineMetrics.js"
+import { createPipelineMetricsHandler } from "../../../observability/langfusePipelineMetrics.js"
 import { getModel } from "../../../retrieval/services/modelProvider.js"
 import { listRepositoriesTool } from "../../../tools/listRepositories.js"
 import { standardRepoExplorerTools } from "../../../tools/repoExplorerTools.js"
@@ -120,15 +120,23 @@ export async function agentNode(
   // Merge parent graph config so LangGraph's StreamMessagesHandler stays on callbacks.
   // Passing only langfuse callbacks replaces the parent CallbackManager and drops token
   // streaming (handleLLMNewToken), so the UI saw one blob per model call.
+  //
+  // Intentionally NOT re-attaching the shared Langfuse CallbackHandler here: it is
+  // already bound at the outer conversationGraph.stream via the transport. Adding it
+  // again registers the same handler on the child CallbackManager, so LLM events get
+  // routed to its runMap twice and corrupt it ("Span not found in runMap" → dropped
+  // tokens). Keep only the per-node metrics handler locally.
   const stream = await agent.stream(
     { messages: inputMessages },
     mergeConfigs(config, {
       streamMode: ["messages", "values"],
       recursionLimit: AGENT_RECURSION_LIMIT,
-      callbacks: langfusePipelineCallbacks({
-        step: "conversation.agent",
-        dimensions: { source: source ?? "ui" },
-      }),
+      callbacks: [
+        createPipelineMetricsHandler({
+          step: "conversation.agent",
+          dimensions: { source: source ?? "ui" },
+        }),
+      ],
     }),
   )
 

--- a/apps/backend/src/graphs/conversationGraph/nodes/conversationNaming.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/conversationNaming.ts
@@ -4,7 +4,7 @@ import {
   getConversation,
   updateConversation,
 } from "../../../models/conversations.js"
-import { langfusePipelineCallbacks } from "../../../observability/langfusePipelineMetrics.js"
+import { createPipelineMetricsHandler } from "../../../observability/langfusePipelineMetrics.js"
 import { getModel } from "../../../retrieval/services/modelProvider.js"
 
 const titlePrompt =
@@ -55,10 +55,14 @@ export async function conversationNaming(
   const response = await model.invoke(
     [{ role: "user", content: titlePrompt + context }],
     {
-      callbacks: langfusePipelineCallbacks({
-        step: "conversation.naming",
-        dimensions: conversationId ? { conversationId } : undefined,
-      }),
+      // Langfuse CallbackHandler is bound at the outer conversationGraph stream;
+      // don't re-attach here (see agent.ts for the runMap double-registration detail).
+      callbacks: [
+        createPipelineMetricsHandler({
+          step: "conversation.naming",
+          dimensions: conversationId ? { conversationId } : undefined,
+        }),
+      ],
     },
   )
   const raw =

--- a/apps/backend/src/graphs/conversationGraph/nodes/planner.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/planner.ts
@@ -1,4 +1,4 @@
-import { langfusePipelineCallbacks } from "../../../observability/langfusePipelineMetrics.js"
+import { createPipelineMetricsHandler } from "../../../observability/langfusePipelineMetrics.js"
 import { getYamlSchemaForLlm } from "../../../retrieval/index.js"
 import type { RetrievalPlan } from "../../../retrieval/schema/plan.js"
 import { RetrievalPlanSchema } from "../../../retrieval/schema/plan.js"
@@ -97,7 +97,12 @@ Embedding available: ${embedding ? "yes" : "no"}
 Respond with ONLY valid JSON, no markdown.`
 
     const response = await model.invoke(prompt, {
-      callbacks: langfusePipelineCallbacks({ step: "conversation.planner" }),
+      // Langfuse CallbackHandler is bound once at the outer conversationGraph
+      // stream; re-attaching it here double-registers on a child CallbackManager
+      // and corrupts its runMap. Keep only the per-node metrics handler.
+      callbacks: [
+        createPipelineMetricsHandler({ step: "conversation.planner" }),
+      ],
     })
     const content =
       typeof response.content === "string"


### PR DESCRIPTION
## Problem

Every chat POST returns 200 in ~2.5–4s but the SSE stream is empty — UI shows "ctx| thinking" then nothing. Happens on all conversations (seeded from KG or typed normally).

## Observations from prod logs

- `POST /:orgSlug/api/v1/conversations/:id` consistently 200, duration 2.47–3.89s.
- No 5xx, no exceptions logged in the chat path.
- Repeated warnings clustered around chat requests:
  \`\`\`
  [Langfuse SDK] [WARN] Span not found in runMap. Skipping operation
  \`\`\`

## Root cause hypothesis

The `@langfuse/langchain` `CallbackHandler` is created once per request by `runWithLangfuseContext` and stored in AsyncLocalStorage. Three different graph nodes (`agent`, `planner`, `conversationNaming`) then call `langfusePipelineCallbacks()` and include that same handler as a **child-level** callback on their own `model.invoke` / `agent.stream`.

LangChain propagates callback events up the manager chain, so the Langfuse handler receives start/end for each LLM run from **both** the outer `conversationGraph.stream` manager *and* the inner child manager. Its `runMap` (keyed by runId) gets clobbered — duplicate starts, early deletes — and the handler drops subsequent lookups with "Span not found in runMap".

The same double-registration sits on the callback chain that LangGraph's `StreamMessagesHandler` uses to emit token deltas. When that chain is disturbed, token-delta events don't reach `toUIMessageStream`, so the SSE stream closes without any assistant text chunks. That matches the observed "200 + empty stream" UI symptom exactly.

## Fix

Register only the per-node `PipelineMetricsHandler` locally in `agent.ts`, `planner.ts`, `conversationNaming.ts`. The Langfuse handler is still attached once at the outer `conversationGraph.stream` level (via the transport); child runs propagate events up to it naturally, so Langfuse tracing is preserved.

## Tradeoffs

- No change to Langfuse trace coverage — outer handler still receives every event.
- One fewer callback listener per node = very small perf win.
- If the fix resolves the stream, the "Span not found" warnings will disappear as a secondary signal. If it doesn't, the hypothesis is wrong and we dig into either the OpenRouter model defaults (\`google/gemini-3-flash-preview\`, \`z-ai/glm-5.1\`, \`xiaomi/mimo-v2-flash\` — worth checking these actually exist) or the `toUIMessageStream` conversion.

## Test plan

- [ ] Merge → Deploy workflow green.
- [ ] Open regular chat, send a message → see streaming tokens in the UI.
- [ ] Open KG, click "Ask ctx|" → streaming tokens in the UI.
- [ ] Langfuse "Span not found in runMap" warnings disappear from backend logs for chat activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)