### PR TITLE
docs: Knowledge graph UI guide (CTX-84)

### DIFF
--- a/apps/docs/content/docs/(guide)/index.mdx
+++ b/apps/docs/content/docs/(guide)/index.mdx
@@ -21,6 +21,11 @@ organisation-scoped context layer. Use these docs alongside
     description="What gets connected, how ingestion works, tools and docs."
   />
   <Card
+    title="Using the app"
+    href="/docs/using-the-app"
+    description="In-product guides, including the knowledge graph explorer."
+  />
+  <Card
     title="Managing your organisation"
     href="/docs/managing-organisation"
     description="Workspaces, repositories, members, and access."

--- a/apps/docs/content/docs/(guide)/meta.json
+++ b/apps/docs/content/docs/(guide)/meta.json
@@ -5,6 +5,7 @@
     "index",
     "getting-started",
     "connections",
+    "using-the-app",
     "managing-organisation",
     "mcp",
     "resources"

--- a/apps/docs/content/docs/(guide)/using-the-app/index.mdx
+++ b/apps/docs/content/docs/(guide)/using-the-app/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Using the app
+description: How to use ctx| in the browser — dashboards, graph explorer, and related UI.
+---
+
+These guides describe **product UI** in the web app (paths under your organisation slug, for example `/:orgSlug/...`).
+
+## In this section
+
+- [Knowledge graph](/docs/using-the-app/knowledge-graph) — explore entities and relationships extracted from your connected sources.

--- a/apps/docs/content/docs/(guide)/using-the-app/knowledge-graph.mdx
+++ b/apps/docs/content/docs/(guide)/using-the-app/knowledge-graph.mdx
@@ -1,0 +1,102 @@
+---
+title: Knowledge graph
+description: Purpose of the knowledge graph view, metrics, search, legend filters, and the node inspector.
+---
+
+The **knowledge graph** page (`/:orgSlug/knowledge-graph`) visualises entities and relationships that ctx| has inferred from your connected repositories and related ingestion pipelines. It is an **exploration and sense-making** surface: you see structure, density of connections, and how recently evidence appeared — not a full graph query console.
+
+<Callout type="info">
+  The in-app route is **`/knowledge-graph`** (spelled with two **e**s), under your org slug. If you bookmark or share links, use that path.
+</Callout>
+
+## Why this page exists
+
+Software systems are easier to reason about when you can **see** services, APIs, data stores, patterns, and how they relate. The graph view turns extracted **claims** (typed relationships with optional confidence and observation time) into:
+
+- **Nodes** — discrete things the system knows about (for example a service, API, library, or pattern). Each node has a stable **id**, a **kind** (type), and usually a **name** and **summary** derived from your sources.
+- **Edges** — directed links between two nodes, labelled with a **predicate** (the relationship name). Edges may carry **confidence** (how strongly the model backs the claim) and **last observed** timestamps from ingestion.
+
+Visualising the graph helps you spot hubs, orphaned entities, recent activity clusters, and kinds of entities that dominate a workspace — before you ask an agent or open individual repos.
+
+## Activity and “last updated”
+
+When the graph has dated edges, the **activity sparkline** (top-right when no node drawer is open) buckets **edge observation times** into a compact histogram. That is the same signal used for **“Updated”** at the bottom-left: it reflects **when relationship evidence last changed**, not necessarily when you opened the page.
+
+If the backend returns only a **subset** of the full org graph for performance, a notice explains that **counts on the chips are org-wide totals** while the canvas shows a capped sample.
+
+## Exploring the canvas
+
+The layout is a **force-directed** view: you can **pan** by dragging the background and **zoom** with scroll (or pinch on a trackpad or touchscreen). Node **size** scales with overall connectivity so highly linked entities stand out; on very large graphs, zooming in progressively reveals smaller nodes.
+
+**Fit view** (bottom-right) reframes the entire graph. **Refresh** reloads data from the server.
+
+## Nodes and edges (metrics)
+
+Under the page title, **Nodes** and **Edges** show **organisation-level totals** (or totals as returned by the API). In documentation terms:
+
+| Term | Meaning |
+|------|---------|
+| **Node** | One entity in the graph; identified by **id** and coloured by **kind**. |
+| **Edge** | A relationship instance from one node to another, with a **predicate** and metadata such as confidence and last observed time. |
+| **Kind** | The node’s category (for example Service, API, Database). Kinds drive colour in the legend and labels on the canvas. |
+
+## Search
+
+The **search** field (centre top) filters the canvas by **substring match** over each node’s **id**, **kind**, **name**, and **summary** (case-insensitive). It is meant for **quick navigation** (“find the payments service”) rather than graph query languages.
+
+- Matches are counted next to the field; **Escape** clears the query.
+- With a moderate number of matches, the view **zooms to fit** those nodes.
+- When nothing matches, the canvas is de-emphasised until you clear or change the query.
+
+Search respects **hidden kinds** from the legend (see below): only nodes that remain visible participate in matching.
+
+## Node kinds (legend and filter)
+
+The **Node kinds** panel lists every kind present in the current payload, with a **colour swatch** per kind. Click a row to **toggle visibility** of that kind: hidden kinds are shown struck-through and dimmed, and their nodes drop out of search and layout emphasis. **Show all** restores every kind.
+
+While this looks like a legend, it is also a **filter**: it controls what is treated as “in scope” for search and highlighting, and gives immediate feedback about what you are looking at.
+
+## Selecting a node
+
+**Click a node** (or its label) to open the **node inspector** drawer and to **focus the one-hop neighbourhood** on the canvas: the selected node, its directly connected neighbours, and their connecting edges stay emphasised; everything else is subdued. **Click empty space** or **Close** / **Escape** clears the selection.
+
+Opening a node also syncs the URL with **`?node=<id>`** so you can refresh or share the view. Inside the drawer, **Copy link** copies the full URL including that parameter.
+
+## Node inspector
+
+The right-hand drawer is the detailed view for the selected node.
+
+### Summary metadata
+
+- **Kind** and display **name** (or id if no name).
+- **Rank** (when meaningful): where this node sits by **total degree** compared to other nodes of the **same kind** — useful for spotting unusually central services.
+- **Loosely connected**: a hint when the node has very few relationships (possible stub or stale entity).
+- **Summary** text when ingestion provided one.
+
+Some kinds can show extra **detail chips** when the API includes structured payload fields; otherwise those rows stay hidden.
+
+### Identifiers and sharing
+
+- **Id** — the canonical graph identifier. Use **Copy id** for tickets, scripts, or support.
+- **Copy link** — a shareable URL that opens the graph with this node already selected.
+
+### Connections and “why”
+
+- **Connections** — **In**, **Out**, and **Total** degree (counts of edges by direction).
+- **Strongest connections** — neighbouring nodes ranked by how many distinct claims involve them; **click a row** to jump the inspector to that neighbour.
+- **Predicates** — relationship names aggregated with counts; **click a predicate** to filter the **claims** list below.
+- **Claims** — individual edges involving this node, with direction, predicate, neighbour, **confidence** colouring, and **observed** date. **Click a claim** to open the neighbour.
+- **Neighbour kinds** — distribution of connected node types.
+
+### Activity (per node)
+
+**First seen** and **Last seen** come from claim timestamps. A **per-node sparkline** mirrors the global activity idea for that node’s claims only.
+
+### Focus and Ask ctx|
+
+- **Focus** — zooms the canvas to this node (tight framing).
+- **Ask ctx|** — opens **chat** with a **pre-filled prompt** that includes the node’s label, id, connection counts, strongest links, common predicates, and summary when available. Use it when you want a **narrative explanation** or risk discussion grounded in that node’s graph context; you can edit the message before sending.
+
+---
+
+For how entities get into the graph from repos and workflows, see [How ctx| works](/docs/getting-started/how-it-works) and [Ingestion](/docs/connections/ingestion).

--- a/apps/docs/content/docs/(guide)/using-the-app/meta.json
+++ b/apps/docs/content/docs/(guide)/using-the-app/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Using the app",
+  "pages": ["index", "knowledge-graph"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Using the app** section to the Fumadocs guide with a dedicated **Knowledge graph** page for CTX-84.

The page explains what the graph is for (nodes, edges, predicates, claims), how to read **activity** and **last updated**, **pan/zoom** and **fit view**, **Nodes/Edges** metrics, **search** scope, the **Node kinds** panel as legend plus filter, **node selection** and neighbourhood emphasis, **`?node=`** deep links, and **node inspector** behaviour including **Copy id**, **Copy link**, **Ask ctx|**, claims/predicates, and **Focus**.

Includes a callout that the in-app path is spelled **`/knowledge-graph`** (not the typo from the ticket).

## Test plan

- [x] `pnpm --filter @ctxpipe/docs build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-84](https://linear.app/ctxpipe/issue/CTX-84/update-docs-with-knowledge-graph-page)

<div><a href="https://cursor.com/agents/bc-030f0fad-cd47-406a-a963-03805487945c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-030f0fad-cd47-406a-a963-03805487945c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

