### PR TITLE
feat(ui): knowledge graph first-visit tips and docs link (CTX-85)

### DIFF
--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
@@ -458,7 +458,7 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
         </h1>
         <div
           className={cn(
-            "pointer-events-auto flex flex-col gap-3",
+            "pointer-events-auto flex flex-col gap-2",
             /* Centred search sits high on small screens; nudge tips below that row. */
             showGraph && "max-sm:mt-10",
           )}

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
@@ -451,17 +451,23 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
         </div>
       ) : null}
 
-      <div className="pointer-events-none absolute left-4 top-4 z-10 flex max-w-[min(22rem,calc(100vw-2rem))] flex-col gap-3">
+      <div className="pointer-events-none absolute left-4 top-4 z-30 flex w-[min(24rem,calc(100vw-2rem))] flex-col gap-3">
         <h1 className="font-mono text-[12px] uppercase tracking-[0.24em] text-teal-400 drop-shadow-[0_1px_8px_rgba(0,0,0,0.85)]">
           Knowledge graph
         </h1>
         {showGraph && data?.metrics ? (
-          <div className="pointer-events-auto flex gap-2">
+          <div className="pointer-events-auto flex flex-wrap gap-2">
             <MetricChip label="Nodes" value={data.metrics.totalNodes} />
             <MetricChip label="Edges" value={data.metrics.totalEdges} />
           </div>
         ) : null}
-        <div className="pointer-events-auto flex flex-col gap-2">
+        <div
+          className={cn(
+            "pointer-events-auto flex flex-col gap-2",
+            /* Centred search sits high on small screens; nudge tips below that row. */
+            showGraph && "max-sm:mt-10",
+          )}
+        >
           <KnowledgeGraphIntroCallout
             open={kgIntroOpen}
             onDismiss={() => {

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
@@ -22,7 +22,7 @@ import {
 } from "./KnowledgeGraphIntroCallout"
 import {
   dismissKnowledgeGraphIntro,
-  isKnowledgeGraphIntroDismissed,
+  shouldShowKnowledgeGraphIntro,
 } from "./knowledgeGraphIntroStorage"
 import { MapControlButton } from "./MapControlButton"
 import { MetricChip } from "./MetricChip"
@@ -77,14 +77,15 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
   const [selectedId, setSelectedId] = useState<string | null>(() =>
     readDeepLinkNodeId(),
   )
-  const [kgIntroOpen, setKgIntroOpen] = useState(false)
+  const [kgIntroOpen, setKgIntroOpen] = useState(() =>
+    shouldShowKnowledgeGraphIntro(orgSlug),
+  )
   const cgRef = useRef<KnowledgeGraphCosmographCanvasHandle>(null)
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  /** First visit per org: show tips + docs link; dismiss persists in localStorage. */
+  /** Keep intro visibility in sync with the active org's persisted dismissal state. */
   useEffect(() => {
-    if (isKnowledgeGraphIntroDismissed(orgSlug)) return
-    setKgIntroOpen(true)
+    setKgIntroOpen(shouldShowKnowledgeGraphIntro(orgSlug))
   }, [orgSlug])
 
   /** Keep URL in sync with the selected node so the drawer state is shareable. */
@@ -451,23 +452,29 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
         </div>
       ) : null}
 
-      <div className="pointer-events-none absolute left-4 top-4 z-30 flex w-[min(24rem,calc(100vw-2rem))] flex-col gap-3">
+      <div className="pointer-events-none absolute left-4 top-4 z-30 flex max-w-[calc(100vw-2rem)] flex-col items-start gap-3">
         <h1 className="font-mono text-[12px] uppercase tracking-[0.24em] text-teal-400 drop-shadow-[0_1px_8px_rgba(0,0,0,0.85)]">
           Knowledge graph
         </h1>
-        {showGraph && data?.metrics ? (
-          <div className="pointer-events-auto flex flex-wrap gap-2">
-            <MetricChip label="Nodes" value={data.metrics.totalNodes} />
-            <MetricChip label="Edges" value={data.metrics.totalEdges} />
-          </div>
-        ) : null}
         <div
           className={cn(
-            "pointer-events-auto flex flex-col gap-2",
+            "pointer-events-auto flex flex-col gap-3",
             /* Centred search sits high on small screens; nudge tips below that row. */
             showGraph && "max-sm:mt-10",
           )}
         >
+          {showGraph && data?.metrics ? (
+            <div className="grid grid-cols-[max-content_max-content] gap-2">
+              <MetricChip label="Nodes" value={data.metrics.totalNodes} />
+              <MetricChip label="Edges" value={data.metrics.totalEdges} />
+              {!kgIntroOpen ? (
+                <KnowledgeGraphHelpButton
+                  className="col-span-2 w-full"
+                  onClick={() => setKgIntroOpen(true)}
+                />
+              ) : null}
+            </div>
+          ) : null}
           <KnowledgeGraphIntroCallout
             open={kgIntroOpen}
             onDismiss={() => {
@@ -475,7 +482,7 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
               setKgIntroOpen(false)
             }}
           />
-          {!kgIntroOpen ? (
+          {!showGraph && !kgIntroOpen ? (
             <KnowledgeGraphHelpButton onClick={() => setKgIntroOpen(true)} />
           ) : null}
         </div>

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
@@ -16,6 +16,14 @@ import {
   type KnowledgeGraphCosmographCanvasHandle,
 } from "./KnowledgeGraphCosmographCanvas"
 import { type EmptyReason, KnowledgeGraphEmpty } from "./KnowledgeGraphEmpty"
+import {
+  KnowledgeGraphHelpButton,
+  KnowledgeGraphIntroCallout,
+} from "./KnowledgeGraphIntroCallout"
+import {
+  dismissKnowledgeGraphIntro,
+  isKnowledgeGraphIntroDismissed,
+} from "./knowledgeGraphIntroStorage"
 import { MapControlButton } from "./MapControlButton"
 import { MetricChip } from "./MetricChip"
 import { NodeDetailDrawer } from "./NodeDetailDrawer"
@@ -69,8 +77,15 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
   const [selectedId, setSelectedId] = useState<string | null>(() =>
     readDeepLinkNodeId(),
   )
+  const [kgIntroOpen, setKgIntroOpen] = useState(false)
   const cgRef = useRef<KnowledgeGraphCosmographCanvasHandle>(null)
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  /** First visit per org: show tips + docs link; dismiss persists in localStorage. */
+  useEffect(() => {
+    if (isKnowledgeGraphIntroDismissed(orgSlug)) return
+    setKgIntroOpen(true)
+  }, [orgSlug])
 
   /** Keep URL in sync with the selected node so the drawer state is shareable. */
   useEffect(() => {
@@ -436,7 +451,7 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
         </div>
       ) : null}
 
-      <div className="pointer-events-none absolute left-4 top-4 z-10 flex flex-col gap-3">
+      <div className="pointer-events-none absolute left-4 top-4 z-10 flex max-w-[min(22rem,calc(100vw-2rem))] flex-col gap-3">
         <h1 className="font-mono text-[12px] uppercase tracking-[0.24em] text-teal-400 drop-shadow-[0_1px_8px_rgba(0,0,0,0.85)]">
           Knowledge graph
         </h1>
@@ -446,6 +461,18 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
             <MetricChip label="Edges" value={data.metrics.totalEdges} />
           </div>
         ) : null}
+        <div className="pointer-events-auto flex flex-col gap-2">
+          <KnowledgeGraphIntroCallout
+            open={kgIntroOpen}
+            onDismiss={() => {
+              dismissKnowledgeGraphIntro(orgSlug)
+              setKgIntroOpen(false)
+            }}
+          />
+          {!kgIntroOpen ? (
+            <KnowledgeGraphHelpButton onClick={() => setKgIntroOpen(true)} />
+          ) : null}
+        </div>
       </div>
 
       {showGraph ? (

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphIntroCallout.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphIntroCallout.tsx
@@ -1,4 +1,5 @@
 import { IconExternalLink, IconHelp, IconX } from "@tabler/icons-react"
+import { cn } from "@/lib/utils"
 import { FloatingPanel, PanelLabel } from "./FloatingPanel"
 
 /** Product guide: Using the app → Knowledge graph */
@@ -20,7 +21,7 @@ export function KnowledgeGraphIntroCallout({
     <FloatingPanel
       role="dialog"
       ariaLabel="Knowledge graph tips"
-      className="pointer-events-auto w-full max-w-sm px-3 py-3"
+      className="pointer-events-auto w-[min(24rem,calc(100vw-2rem))] px-3 py-3"
     >
       <div className="flex items-start justify-between gap-2">
         <PanelLabel className="mb-0 pr-1">Using this view</PanelLabel>
@@ -33,63 +34,53 @@ export function KnowledgeGraphIntroCallout({
           <IconX className="h-3.5 w-3.5" aria-hidden />
         </button>
       </div>
-      <p className="mt-2 text-[12px] leading-snug text-zinc-400">
-        Drag the background to <span className="text-zinc-300">pan</span>,
-        scroll or pinch to <span className="text-zinc-300">zoom</span>. Click a
-        node for the drawer — claims, neighbours, and confidence.
-      </p>
-      <ul className="mt-2 list-outside list-disc space-y-1 pl-3.5 text-[12px] leading-snug text-zinc-500 marker:text-zinc-600">
+      <ul className="mt-2 list-outside list-disc space-y-1.5 pl-3.5 text-[12px] leading-snug text-zinc-400 marker:text-zinc-600">
         <li>
-          <span className="text-zinc-400">
-            <span className="text-zinc-300">Narrow</span> — search (top centre)
-            and node kinds (top right) filter what stays on the canvas.
-          </span>
+          <span className="font-medium text-teal-400">Explore</span> by
+          click-dragging the background to pan and using the mouse wheel or
+          trackpad to zoom.
         </li>
         <li>
-          <span className="text-zinc-400">
-            <span className="text-zinc-300">Share</span> — the URL gains{" "}
-            <span className="font-mono text-zinc-500">?node=…</span> for the
-            selected node.
-          </span>
+          <span className="font-medium text-teal-400">Interact</span> with
+          nodes to inspect relationships, then ask ctx| to dig further from that
+          graph context.
+        </li>
+        <li>
+          <span className="font-medium text-teal-400">Monitor</span> activity
+          to see when relationship evidence has changed recently.
         </li>
       </ul>
-      <div className="mt-3 flex flex-col gap-2 border-t border-zinc-800/80 pt-3 sm:flex-row sm:items-stretch">
+      <div className="mt-3 border-t border-zinc-800/80 pt-3">
         <a
           href={KNOWLEDGE_GRAPH_DOCS_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex flex-1 items-center gap-2 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-3 py-2 text-[12px] font-medium text-zinc-200 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:text-zinc-50"
+          className="inline-flex items-center gap-1.5 text-[12px] font-medium text-teal-400 transition-colors hover:text-teal-300"
         >
-          <IconExternalLink
-            className="h-3.5 w-3.5 shrink-0 text-zinc-500"
-            aria-hidden
-          />
-          <span className="min-w-0 leading-snug">
-            Full guide
-            <span className="mt-0.5 block font-normal text-[11px] text-zinc-500">
-              docs.ctxpipe.ai
-            </span>
-          </span>
+          Docs
+          <IconExternalLink className="h-3 w-3" aria-hidden />
         </a>
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="inline-flex h-auto min-h-8 shrink-0 items-center justify-center rounded-none border border-zinc-800/95 bg-zinc-950/90 px-3 py-2 text-[12px] font-medium uppercase tracking-[0.12em] text-zinc-400 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-100 sm:w-[5.5rem]"
-        >
-          Close
-        </button>
       </div>
     </FloatingPanel>
   )
 }
 
-export function KnowledgeGraphHelpButton({ onClick }: { onClick: () => void }) {
+export function KnowledgeGraphHelpButton({
+  className,
+  onClick,
+}: {
+  className?: string
+  onClick: () => void
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
       aria-label="Show knowledge graph tips"
-      className="pointer-events-auto inline-flex h-8 items-center gap-1.5 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-2.5 text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-300"
+      className={cn(
+        "pointer-events-auto inline-flex h-8 w-40 items-center gap-1.5 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-2.5 text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-300",
+        className,
+      )}
     >
       <IconHelp className="h-3.5 w-3.5" aria-hidden />
       Tips

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphIntroCallout.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphIntroCallout.tsx
@@ -1,0 +1,87 @@
+import { IconBook, IconHelp, IconX } from "@tabler/icons-react"
+import { FloatingPanel, PanelLabel } from "./FloatingPanel"
+
+const DOCS_KG_URL = "https://docs.ctxpipe.ai/docs"
+
+type KnowledgeGraphIntroCalloutProps = {
+  open: boolean
+  onDismiss: () => void
+}
+
+export function KnowledgeGraphIntroCallout({
+  open,
+  onDismiss,
+}: KnowledgeGraphIntroCalloutProps) {
+  if (!open) return null
+
+  return (
+    <FloatingPanel
+      role="dialog"
+      ariaLabel="Knowledge graph tips"
+      className="pointer-events-auto max-w-sm px-3 py-3"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <PanelLabel className="mb-1.5">Getting started</PanelLabel>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss tips"
+          className="-m-1 shrink-0 p-1 text-zinc-500 transition-colors hover:text-zinc-200"
+        >
+          <IconX className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+      <ul className="list-inside list-disc space-y-1.5 text-[13px] leading-snug text-zinc-400">
+        <li>
+          <span className="text-zinc-300">Explore</span> — pan and zoom the
+          canvas; select a node to inspect claims and neighbours in the drawer.
+        </li>
+        <li>
+          <span className="text-zinc-300">Narrow down</span> — search matches
+          labels and kinds; use node kinds to hide categories you do not need
+          right now.
+        </li>
+        <li>
+          <span className="text-zinc-300">Share</span> — the URL updates with
+          your selected node so you can send a link back to the same view.
+        </li>
+      </ul>
+      <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-zinc-800/80 pt-3">
+        <a
+          href={DOCS_KG_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-none border border-zinc-700/90 bg-zinc-900/80 px-2.5 py-1.5 text-[12px] font-medium text-zinc-200 transition-colors hover:border-teal-500/45 hover:text-teal-200"
+        >
+          <IconBook className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          Documentation
+        </a>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="text-[12px] text-teal-400/95 hover:text-teal-300"
+        >
+          Got it
+        </button>
+      </div>
+    </FloatingPanel>
+  )
+}
+
+export function KnowledgeGraphHelpButton({
+  onClick,
+}: {
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Show knowledge graph tips"
+      className="pointer-events-auto inline-flex items-center gap-1 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-2 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:text-zinc-300"
+    >
+      <IconHelp className="h-3 w-3" aria-hidden />
+      Tips
+    </button>
+  )
+}

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphIntroCallout.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphIntroCallout.tsx
@@ -1,4 +1,4 @@
-import { IconBook, IconHelp, IconX } from "@tabler/icons-react"
+import { IconExternalLink, IconHelp, IconX } from "@tabler/icons-react"
 import { FloatingPanel, PanelLabel } from "./FloatingPanel"
 
 /** Product guide: Using the app → Knowledge graph */
@@ -20,57 +20,61 @@ export function KnowledgeGraphIntroCallout({
     <FloatingPanel
       role="dialog"
       ariaLabel="Knowledge graph tips"
-      className="pointer-events-auto w-full max-w-sm px-3 py-3 shadow-2xl shadow-black/50"
+      className="pointer-events-auto w-full max-w-sm px-3 py-3"
     >
-      <div className="flex items-start justify-between gap-3">
-        <PanelLabel className="mb-0 pr-1">Quick tips</PanelLabel>
+      <div className="flex items-start justify-between gap-2">
+        <PanelLabel className="mb-0 pr-1">Using this view</PanelLabel>
         <button
           type="button"
           onClick={onDismiss}
           aria-label="Close tips"
-          className="min-h-9 min-w-9 shrink-0 rounded-none border border-transparent text-zinc-500 transition-colors hover:border-zinc-700 hover:bg-zinc-900/80 hover:text-zinc-100"
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-none border border-zinc-800/95 bg-zinc-950/90 text-zinc-500 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-100"
         >
-          <IconX className="mx-auto h-4 w-4" aria-hidden />
+          <IconX className="h-3.5 w-3.5" aria-hidden />
         </button>
       </div>
-      <p className="mt-2 text-[12px] leading-snug text-zinc-500">
-        Pan and zoom the canvas, then select a node to open the inspector
-        (claims, neighbours, confidence).
+      <p className="mt-2 text-[12px] leading-snug text-zinc-400">
+        Drag the background to <span className="text-zinc-300">pan</span>,
+        scroll or pinch to <span className="text-zinc-300">zoom</span>. Click a
+        node for the drawer — claims, neighbours, and confidence.
       </p>
-      <ul className="mt-2.5 list-outside list-disc space-y-1.5 pl-4 text-[13px] leading-snug text-zinc-400 marker:text-zinc-600">
+      <ul className="mt-2 list-outside list-disc space-y-1 pl-3.5 text-[12px] leading-snug text-zinc-500 marker:text-zinc-600">
         <li>
-          <span className="text-zinc-300">Search</span> — top centre; matches
-          names, kinds, and summaries.
+          <span className="text-zinc-400">
+            <span className="text-zinc-300">Narrow</span> — search (top centre)
+            and node kinds (top right) filter what stays on the canvas.
+          </span>
         </li>
         <li>
-          <span className="text-zinc-300">Node kinds</span> — top right; click
-          a kind to hide or show that category.
-        </li>
-        <li>
-          <span className="text-zinc-300">Share a node</span> — the address bar
-          adds <span className="font-mono text-zinc-500">?node=…</span> when
-          something is selected.
+          <span className="text-zinc-400">
+            <span className="text-zinc-300">Share</span> — the URL gains{" "}
+            <span className="font-mono text-zinc-500">?node=…</span> for the
+            selected node.
+          </span>
         </li>
       </ul>
-      <div className="mt-3 flex flex-col gap-2 border-t border-zinc-800/80 pt-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+      <div className="mt-3 flex flex-col gap-2 border-t border-zinc-800/80 pt-3 sm:flex-row sm:items-stretch">
         <a
           href={KNOWLEDGE_GRAPH_DOCS_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-none border border-zinc-700/90 bg-zinc-900/80 px-3 py-2 text-left text-[12px] font-medium text-zinc-200 transition-colors hover:border-teal-500/45 hover:text-teal-200"
+          className="inline-flex flex-1 items-center gap-2 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-3 py-2 text-[12px] font-medium text-zinc-200 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:text-zinc-50"
         >
-          <IconBook className="h-3.5 w-3.5 shrink-0" aria-hidden />
-          <span>
-            Knowledge graph guide
-            <span className="mt-0.5 block text-[11px] font-normal text-zinc-500">
-              Opens in a new tab
+          <IconExternalLink
+            className="h-3.5 w-3.5 shrink-0 text-zinc-500"
+            aria-hidden
+          />
+          <span className="min-w-0 leading-snug">
+            Full guide
+            <span className="mt-0.5 block font-normal text-[11px] text-zinc-500">
+              docs.ctxpipe.ai
             </span>
           </span>
         </a>
         <button
           type="button"
           onClick={onDismiss}
-          className="min-h-9 shrink-0 rounded-none border border-zinc-700/80 px-3 py-2 text-[12px] font-medium text-zinc-200 transition-colors hover:border-teal-500/40 hover:bg-teal-950/30 hover:text-teal-100"
+          className="inline-flex h-auto min-h-8 shrink-0 items-center justify-center rounded-none border border-zinc-800/95 bg-zinc-950/90 px-3 py-2 text-[12px] font-medium uppercase tracking-[0.12em] text-zinc-400 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-100 sm:w-[5.5rem]"
         >
           Close
         </button>
@@ -79,17 +83,13 @@ export function KnowledgeGraphIntroCallout({
   )
 }
 
-export function KnowledgeGraphHelpButton({
-  onClick,
-}: {
-  onClick: () => void
-}) {
+export function KnowledgeGraphHelpButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       type="button"
       onClick={onClick}
       aria-label="Show knowledge graph tips"
-      className="pointer-events-auto inline-flex min-h-9 items-center gap-1.5 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:text-zinc-300"
+      className="pointer-events-auto inline-flex h-8 items-center gap-1.5 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-2.5 text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-300"
     >
       <IconHelp className="h-3.5 w-3.5" aria-hidden />
       Tips

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphIntroCallout.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphIntroCallout.tsx
@@ -1,7 +1,9 @@
 import { IconBook, IconHelp, IconX } from "@tabler/icons-react"
 import { FloatingPanel, PanelLabel } from "./FloatingPanel"
 
-const DOCS_KG_URL = "https://docs.ctxpipe.ai/docs"
+/** Product guide: Using the app → Knowledge graph */
+export const KNOWLEDGE_GRAPH_DOCS_URL =
+  "https://docs.ctxpipe.ai/docs/using-the-app/knowledge-graph"
 
 type KnowledgeGraphIntroCalloutProps = {
   open: boolean
@@ -18,50 +20,59 @@ export function KnowledgeGraphIntroCallout({
     <FloatingPanel
       role="dialog"
       ariaLabel="Knowledge graph tips"
-      className="pointer-events-auto max-w-sm px-3 py-3"
+      className="pointer-events-auto w-full max-w-sm px-3 py-3 shadow-2xl shadow-black/50"
     >
-      <div className="flex items-start justify-between gap-2">
-        <PanelLabel className="mb-1.5">Getting started</PanelLabel>
+      <div className="flex items-start justify-between gap-3">
+        <PanelLabel className="mb-0 pr-1">Quick tips</PanelLabel>
         <button
           type="button"
           onClick={onDismiss}
-          aria-label="Dismiss tips"
-          className="-m-1 shrink-0 p-1 text-zinc-500 transition-colors hover:text-zinc-200"
+          aria-label="Close tips"
+          className="min-h-9 min-w-9 shrink-0 rounded-none border border-transparent text-zinc-500 transition-colors hover:border-zinc-700 hover:bg-zinc-900/80 hover:text-zinc-100"
         >
-          <IconX className="h-4 w-4" aria-hidden />
+          <IconX className="mx-auto h-4 w-4" aria-hidden />
         </button>
       </div>
-      <ul className="list-inside list-disc space-y-1.5 text-[13px] leading-snug text-zinc-400">
+      <p className="mt-2 text-[12px] leading-snug text-zinc-500">
+        Pan and zoom the canvas, then select a node to open the inspector
+        (claims, neighbours, confidence).
+      </p>
+      <ul className="mt-2.5 list-outside list-disc space-y-1.5 pl-4 text-[13px] leading-snug text-zinc-400 marker:text-zinc-600">
         <li>
-          <span className="text-zinc-300">Explore</span> — pan and zoom the
-          canvas; select a node to inspect claims and neighbours in the drawer.
+          <span className="text-zinc-300">Search</span> — top centre; matches
+          names, kinds, and summaries.
         </li>
         <li>
-          <span className="text-zinc-300">Narrow down</span> — search matches
-          labels and kinds; use node kinds to hide categories you do not need
-          right now.
+          <span className="text-zinc-300">Node kinds</span> — top right; click
+          a kind to hide or show that category.
         </li>
         <li>
-          <span className="text-zinc-300">Share</span> — the URL updates with
-          your selected node so you can send a link back to the same view.
+          <span className="text-zinc-300">Share a node</span> — the address bar
+          adds <span className="font-mono text-zinc-500">?node=…</span> when
+          something is selected.
         </li>
       </ul>
-      <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-zinc-800/80 pt-3">
+      <div className="mt-3 flex flex-col gap-2 border-t border-zinc-800/80 pt-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
         <a
-          href={DOCS_KG_URL}
+          href={KNOWLEDGE_GRAPH_DOCS_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 rounded-none border border-zinc-700/90 bg-zinc-900/80 px-2.5 py-1.5 text-[12px] font-medium text-zinc-200 transition-colors hover:border-teal-500/45 hover:text-teal-200"
+          className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-none border border-zinc-700/90 bg-zinc-900/80 px-3 py-2 text-left text-[12px] font-medium text-zinc-200 transition-colors hover:border-teal-500/45 hover:text-teal-200"
         >
           <IconBook className="h-3.5 w-3.5 shrink-0" aria-hidden />
-          Documentation
+          <span>
+            Knowledge graph guide
+            <span className="mt-0.5 block text-[11px] font-normal text-zinc-500">
+              Opens in a new tab
+            </span>
+          </span>
         </a>
         <button
           type="button"
           onClick={onDismiss}
-          className="text-[12px] text-teal-400/95 hover:text-teal-300"
+          className="min-h-9 shrink-0 rounded-none border border-zinc-700/80 px-3 py-2 text-[12px] font-medium text-zinc-200 transition-colors hover:border-teal-500/40 hover:bg-teal-950/30 hover:text-teal-100"
         >
-          Got it
+          Close
         </button>
       </div>
     </FloatingPanel>
@@ -78,9 +89,9 @@ export function KnowledgeGraphHelpButton({
       type="button"
       onClick={onClick}
       aria-label="Show knowledge graph tips"
-      className="pointer-events-auto inline-flex items-center gap-1 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-2 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:text-zinc-300"
+      className="pointer-events-auto inline-flex min-h-9 items-center gap-1.5 rounded-none border border-zinc-800/95 bg-zinc-950/90 px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 shadow-xl shadow-black/40 backdrop-blur-md transition-colors hover:border-zinc-700 hover:text-zinc-300"
     >
-      <IconHelp className="h-3 w-3" aria-hidden />
+      <IconHelp className="h-3.5 w-3.5" aria-hidden />
       Tips
     </button>
   )

--- a/apps/ui/src/features/knowledge-graph/knowledgeGraphIntroStorage.test.ts
+++ b/apps/ui/src/features/knowledge-graph/knowledgeGraphIntroStorage.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  dismissKnowledgeGraphIntro,
+  isKnowledgeGraphIntroDismissed,
+  knowledgeGraphIntroStorageKey,
+  shouldShowKnowledgeGraphIntro,
+} from "./knowledgeGraphIntroStorage"
+
+function createStorage() {
+  const store = new Map<string, string>()
+
+  return {
+    getItem(key: string) {
+      return store.get(key) ?? null
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value)
+    },
+  }
+}
+
+describe("knowledgeGraphIntroStorage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("namespaces the dismissal key per org", () => {
+    expect(knowledgeGraphIntroStorageKey("acme")).toBe(
+      "ctxpipe:kgIntroDismissed:v1:acme",
+    )
+    expect(knowledgeGraphIntroStorageKey("globex")).toBe(
+      "ctxpipe:kgIntroDismissed:v1:globex",
+    )
+  })
+
+  it("treats the intro as visible until that org is dismissed", () => {
+    const localStorage = createStorage()
+    vi.stubGlobal("window", {
+      localStorage,
+    })
+
+    expect(shouldShowKnowledgeGraphIntro("acme")).toBe(true)
+    expect(isKnowledgeGraphIntroDismissed("acme")).toBe(false)
+
+    dismissKnowledgeGraphIntro("acme")
+
+    expect(isKnowledgeGraphIntroDismissed("acme")).toBe(true)
+    expect(shouldShowKnowledgeGraphIntro("acme")).toBe(false)
+    expect(shouldShowKnowledgeGraphIntro("globex")).toBe(true)
+  })
+
+  it("is safe when window is unavailable", () => {
+    expect(isKnowledgeGraphIntroDismissed("acme")).toBe(false)
+    expect(shouldShowKnowledgeGraphIntro("acme")).toBe(true)
+    expect(() => dismissKnowledgeGraphIntro("acme")).not.toThrow()
+  })
+})

--- a/apps/ui/src/features/knowledge-graph/knowledgeGraphIntroStorage.ts
+++ b/apps/ui/src/features/knowledge-graph/knowledgeGraphIntroStorage.ts
@@ -3,6 +3,10 @@ export function knowledgeGraphIntroStorageKey(orgSlug: string): string {
   return `ctxpipe:kgIntroDismissed:v1:${orgSlug}`
 }
 
+export function shouldShowKnowledgeGraphIntro(orgSlug: string): boolean {
+  return !isKnowledgeGraphIntroDismissed(orgSlug)
+}
+
 export function isKnowledgeGraphIntroDismissed(orgSlug: string): boolean {
   if (typeof window === "undefined") return false
   return window.localStorage.getItem(knowledgeGraphIntroStorageKey(orgSlug)) === "1"

--- a/apps/ui/src/features/knowledge-graph/knowledgeGraphIntroStorage.ts
+++ b/apps/ui/src/features/knowledge-graph/knowledgeGraphIntroStorage.ts
@@ -1,0 +1,14 @@
+/** Per-org, per-browser flag so returning users are not interrupted. */
+export function knowledgeGraphIntroStorageKey(orgSlug: string): string {
+  return `ctxpipe:kgIntroDismissed:v1:${orgSlug}`
+}
+
+export function isKnowledgeGraphIntroDismissed(orgSlug: string): boolean {
+  if (typeof window === "undefined") return false
+  return window.localStorage.getItem(knowledgeGraphIntroStorageKey(orgSlug)) === "1"
+}
+
+export function dismissKnowledgeGraphIntro(orgSlug: string): void {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(knowledgeGraphIntroStorageKey(orgSlug), "1")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses **CTX-85** (knowledge graph onboarding).

## Updates (latest)

- Merged **`origin/main`** so this branch includes the new docs page at `apps/docs/content/docs/(guide)/using-the-app/knowledge-graph.mdx`.
- **Docs link** now targets the dedicated guide: `https://docs.ctxpipe.ai/docs/using-the-app/knowledge-graph` (exported as `KNOWLEDGE_GRAPH_DOCS_URL` in `KnowledgeGraphIntroCallout.tsx`).
- **Panel UX review**
  - Copy aligned with the shipped UI: search **top centre**, node kinds **top right**, `?node=` sharing explained plainly.
  - **Dismiss**: large **X** hit target (`min-h-9 min-w-9`) plus a bordered **Close** button next to the docs link (no reliance on a tiny text-only control).
  - **Position**: left column remains `left-4 top-4` with **`z-30`** so it stays above the canvas; when the graph is visible, **`max-sm:mt-10`** on the tips block reduces overlap with the centred search on narrow viewports.
  - **Escape**: intentionally **not** wired globally — the search field already uses **Esc** to clear; closing the tips with Esc would fight that behaviour.

## Testing

- `pnpm exec biome lint` on the touched files.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-85](https://linear.app/ctxpipe/issue/CTX-85/onboarding-for-knowledge-graph-page)

<div><a href="https://cursor.com/agents/bc-76402507-b4fb-4218-ab9a-8106e4dac736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76402507-b4fb-4218-ab9a-8106e4dac736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

