### PR TITLE
docs: Add to Cursor button for MCP (CTX-78)

### DIFF
--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -11,6 +11,7 @@ import {
 import defaultMdxComponents from "fumadocs-ui/mdx"
 import { Card, Cards } from "fumadocs-ui/components/card"
 import { Callout } from "fumadocs-ui/components/callout"
+import { AddToCursorMcp } from "@/app/docs/components/add-to-cursor-mcp"
 import { source } from "@/lib/source"
 
 /** MDX pages from fumadocs-mdx; loader output is typed as base `PageData` without `body`/`toc`. */
@@ -48,7 +49,13 @@ export default async function Page({ params }: Props) {
       <DocsBody>
         <MDX
           components={
-            { ...defaultMdxComponents, Card, Cards, Callout } as Record<
+            {
+              ...defaultMdxComponents,
+              Card,
+              Cards,
+              Callout,
+              AddToCursorMcp,
+            } as Record<
               string,
               ComponentType<unknown>
             >

--- a/apps/docs/app/docs/components/add-to-cursor-mcp.tsx
+++ b/apps/docs/app/docs/components/add-to-cursor-mcp.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+/**
+ * One-click MCP install for Cursor (same deep link pattern as cursor.directory / Railway docs).
+ * @see https://cursor.com/en/install-mcp
+ */
+const CURSOR_INSTALL_MCP_BASE = "https://cursor.com/en/install-mcp"
+
+/** Default hosted app origin for the MCP endpoint in the install link. */
+const DEFAULT_MCP_ORIGIN = "https://app.ctxpipe.ai"
+
+function buildInstallHref(mcpUrl: string): string {
+  const configJson = JSON.stringify({
+    type: "streamable-http",
+    url: mcpUrl,
+  })
+  const config = btoa(configJson)
+  const params = new URLSearchParams({ name: "ctxpipe", config })
+  return `${CURSOR_INSTALL_MCP_BASE}?${params.toString()}`
+}
+
+export function AddToCursorMcp({
+  orgSlugPlaceholder = "your-org",
+  mcpOrigin = DEFAULT_MCP_ORIGIN,
+}: {
+  /** Shown in the helper text so users know what to substitute after install. */
+  orgSlugPlaceholder?: string
+  /** Use your self-hosted origin instead of the hosted app when documenting forks. */
+  mcpOrigin?: string
+}) {
+  const mcpUrl = `${mcpOrigin.replace(/\/$/, "")}/mcp?orgSlug=${orgSlugPlaceholder}`
+  const href = buildInstallHref(mcpUrl)
+
+  return (
+    <div className="not-prose my-6 space-y-3 rounded-lg border border-fd-border bg-fd-card p-4">
+      <p className="text-sm text-fd-muted-foreground">
+        One-click add in Cursor opens an install prompt with this server pre-filled. Replace{" "}
+        <code className="rounded bg-fd-muted px-1 py-0.5 font-mono text-xs">
+          {orgSlugPlaceholder}
+        </code>{" "}
+        in the URL with your organisation slug if needed (you can edit the entry in Cursor
+        settings afterward).
+      </p>
+      <a
+        href={href}
+        className="inline-flex items-center gap-2 rounded-md bg-[#0a0a0a] px-3 py-2 text-sm font-medium text-white no-underline ring-1 ring-white/10 transition hover:bg-[#171717]"
+      >
+        <svg
+          aria-hidden
+          className="size-4 shrink-0"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+        </svg>
+        Add to Cursor
+      </a>
+      <p className="text-xs text-fd-muted-foreground">
+        If nothing happens, ensure Cursor is installed — the link is handled by the Cursor app
+        on your machine. With several Cursor windows open, whichever instance registers the
+        protocol handler typically receives the install flow; after confirming, reload MCP or
+        restart Cursor if tools do not appear. This only updates your local{" "}
+        <code className="rounded bg-fd-muted px-1 py-0.5 font-mono">.cursor/mcp.json</code> (or
+        global Cursor MCP config); it does not change Git or replace{" "}
+        <strong className="font-medium text-fd-foreground">Install MCP via PR</strong> in the
+        product UI, which opens pull requests that add the same MCP entry to a repo for the
+        whole team.
+      </p>
+    </div>
+  )
+}

--- a/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
+++ b/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
@@ -39,7 +39,11 @@ Different clients read the same fields but not every UI exposes them the same wa
 
 ### Cursor
 
-Config file: **`.cursor/mcp.json`** at the root of your project (or the path your workspace uses for MCP).
+You can one-click install the MCP server in Cursor using the button below (opens Cursor’s MCP install flow with this server pre-filled):
+
+<AddToCursorMcp />
+
+Alternatively, add the following configuration to your **`.cursor/mcp.json`** file manually (at the root of your project, or the path your workspace uses for MCP):
 
 ```json
 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [CTX-78](https://linear.app): a one-click **Add to Cursor** control on the [MCP docs](https://docs.ctxpipe.ai/docs/mcp/mcp-docs) page, matching the pattern used by Cursor’s ecosystem (e.g. Railway’s `https://cursor.com/en/install-mcp?name=…&config=…`).

## Changes

- New client component `AddToCursorMcp` that builds the install URL with **base64-encoded** JSON `{"type":"streamable-http","url":"…/mcp?orgSlug=your-org"}` (same encoding approach as Railway’s stdio example, extended for streamable HTTP).
- Registered the component in the docs MDX scope so `<AddToCursorMcp />` works from MDX.
- Updated the **Cursor** section of `mcp-docs.mdx`: button first, then the existing manual `.cursor/mcp.json` block.

## Behaviour notes (for the issue)

- **Multiple Cursor windows:** the OS routes the `https://cursor.com/en/install-mcp` link to the app that owns the handler; behaviour with several instances is environment-dependent. The component copy suggests reloading MCP or restarting Cursor if tools do not show.
- **vs Install MCP via PR:** one-click only updates the user’s **local** Cursor MCP config; **Install MCP via PR** still matters for **team-wide** committed config in Git. Same MCP invocation shape, different distribution channel.

## Verification

- `pnpm --filter @ctxpipe/docs build` (passes).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-78](https://linear.app/ctxpipe/issue/CTX-78/add-add-to-cursor-button-for-mcp)

<div><a href="https://cursor.com/agents/bc-c6dc32e0-26ca-4e03-b940-769d93377004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6dc32e0-26ca-4e03-b940-769d93377004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

