### PR TITLE
CTX-33: Warn context advisor when indexing or retrieval is incomplete

### DIFF
--- a/apps/backend/src/graphs/conversationGraph/contextQuality.test.ts
+++ b/apps/backend/src/graphs/conversationGraph/contextQuality.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { formatContextQualityFlags } from "./contextQuality.js"
+
+describe("formatContextQualityFlags", () => {
+  it("marks not ready repos and weak pre-retrieval signal", () => {
+    const out = formatContextQualityFlags({
+      repositories: [
+        { name: "org/stillwood", indexReady: false },
+        { name: "org/other", indexReady: true },
+      ],
+      hasHydratedClaimsInContext: false,
+      state: {
+        candidates: [],
+        claimAggregationResults: [],
+        currentProjectName: "Stillwood",
+      },
+    })
+    expect(out).toContain("repository_index_not_ready_count: 1")
+    expect(out).toContain("org/stillwood")
+    expect(out).toContain('pre_retrieval_signal: none')
+    expect(out).toContain("at_least_one_repository_not_fully_indexed")
+    expect(out).toContain("current_project_name_matches_repository_row: false")
+  })
+
+  it("reports all ready when every repo is index_ready", () => {
+    const out = formatContextQualityFlags({
+      repositories: [{ name: "a/b", indexReady: true }],
+      hasHydratedClaimsInContext: false,
+      state: {
+        candidates: [],
+        claimAggregationResults: [],
+        currentProjectName: "a/b",
+      },
+    })
+    expect(out).toContain("all_listed_repositories_marked_index_ready")
+    expect(out).toContain("current_project_name_matches_repository_row: true")
+  })
+})

--- a/apps/backend/src/graphs/conversationGraph/contextQuality.ts
+++ b/apps/backend/src/graphs/conversationGraph/contextQuality.ts
@@ -1,0 +1,64 @@
+import type { ConversationGraphState } from "./state.js"
+
+export type RepositoryIndexRow = { name: string; indexReady: boolean }
+
+/**
+ * Machine-readable flags for the conversation advisor. Lets the model refuse
+ * confident project-level answers when indexing or retrieval is incomplete.
+ */
+export function formatContextQualityFlags(params: {
+  repositories: RepositoryIndexRow[]
+  /** True when this turn's retrieval context includes at least one hydrated claim with evidence. */
+  hasHydratedClaimsInContext: boolean
+  state: Pick<
+    ConversationGraphState,
+    "candidates" | "claimAggregationResults" | "currentProjectName"
+  >
+}): string {
+  const { repositories, state, hasHydratedClaimsInContext } = params
+  const namesNotReady = repositories
+    .filter((r) => !r.indexReady)
+    .map((r) => r.name)
+  const namesReady = repositories
+    .filter((r) => r.indexReady)
+    .map((r) => r.name)
+
+  const hasCandidates = (state.candidates?.length ?? 0) > 0
+  const hasFleetPatterns = (state.claimAggregationResults?.length ?? 0) > 0
+  const notEnoughSignal =
+    !hasCandidates && !hasFleetPatterns && !hasHydratedClaimsInContext
+
+  const project = state.currentProjectName?.trim()
+  const projectLikelyRepo =
+    project &&
+    project !== "unknown" &&
+    repositories.some((r) => r.name === project)
+
+  const lines = [
+    "CONTEXT_QUALITY_FLAGS (trust these over any assumption about coverage):",
+    `- repositories_total: ${repositories.length}`,
+    `- repository_index_ready_count: ${namesReady.length}`,
+    `- repository_index_not_ready_count: ${namesNotReady.length}`,
+    `- repository_names_index_not_ready: ${namesNotReady.length ? namesNotReady.join(", ") : "(none)"}`,
+    `- repository_names_index_ready: ${namesReady.length ? namesReady.join(", ") : "(none)"}`,
+    `- pre_retrieval_signal: ${notEnoughSignal ? "none" : "some"}`,
+    `- pre_retrieval_has_candidates: ${hasCandidates}`,
+    `- pre_retrieval_has_fleet_patterns: ${hasFleetPatterns}`,
+    `- context_includes_hydrated_claims_with_evidence: ${hasHydratedClaimsInContext}`,
+    `- current_project_name_matches_repository_row: ${projectLikelyRepo ? "true" : "false"}`,
+  ]
+
+  if (namesNotReady.length > 0) {
+    lines.push(
+      "- indexing_status: at_least_one_repository_not_fully_indexed (index_ready is false for the names above; graph and search may be partial or empty)",
+    )
+  } else if (repositories.length === 0) {
+    lines.push(
+      "- indexing_status: no_repositories_registered_for_org (no codebase attached)",
+    )
+  } else {
+    lines.push("- indexing_status: all_listed_repositories_marked_index_ready")
+  }
+
+  return lines.join("\n")
+}

--- a/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/agent.ts
@@ -33,6 +33,12 @@ EPISTEMIC RULES (hard — apply to every answer):
 - Do NOT claim a symbol is unused, dead, legacy-only, or "never called" without calling graph_get_callers and/or find_symbol_references for that symbol in this turn when the question is about reachability or lifecycle. If tools are inconclusive or empty, say that explicitly instead of inferring.
 - If retrieval context or tools show conflicting facts (e.g. different defaults in different files or docs vs code), report the conflict — do not flatten into one authoritative story.
 
+INCOMPLETE CONTEXT AND INDEXING (hard — read CONTEXT_QUALITY_FLAGS in the first system message):
+- When CONTEXT_QUALITY_FLAGS shows repository_index_not_ready_count > 0, indexing_status includes at_least_one_repository_not_fully_indexed, or pre_retrieval_signal is "none", you do NOT have a complete picture of the codebase. Do not invent architecture, frameworks, domains, or project "character" from thin cues, ADR titles, or repo names.
+- If the user asks what a project/repo "is", what you "think" of it, or for an overall assessment, and flags indicate incomplete indexing or no pre-retrieval signal: answer briefly that indexing is incomplete or retrieval returned nothing substantive, name the repositories still not index_ready (from the flags), and say you cannot characterise the project yet. Offer to help after indexing finishes or after they narrow the question. Do not fill the gap with plausible-sounding technical narrative.
+- If CONTEXT_QUALITY_FLAGS says all repositories are index_ready but pre_retrieval_signal is still "none", treat graph/search as potentially empty: say evidence is missing, then use tools (list_files, search, get_file) before asserting implementation facts.
+- Org-wide standards (ADRs, fleet patterns) may still be valid when present in context; separate "org guidance from context" from "this specific repo" claims, and do not imply a repo matches org patterns without evidence.
+
 When both org guidance and codebase facts apply, separate them:
 - Org standard / recommendation (from ADRs, instructions, claims, patterns).
 - What the codebase shows — only state precise implementation facts here when grounded in tool output from this turn.

--- a/apps/backend/src/graphs/conversationGraph/nodes/assemble.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/assemble.ts
@@ -1,6 +1,7 @@
 import { listRepositoriesForOrg } from "../../../models/repositories.js"
 import { toToon } from "../../../lib/agentToolRuntime.js"
 import { hydrateClaimsWithEvidence } from "../../../retrieval/index.js"
+import { formatContextQualityFlags } from "../contextQuality.js"
 import type { ConversationGraphState } from "../state.js"
 
 const TOP_CANDIDATES_FOR_CLAIM_HYDRATION = 20
@@ -115,7 +116,15 @@ export async function assembleNode(
   })
 
   const projectName = state.currentProjectName?.trim() || "unknown"
-  const fullContext = `Current project name: ${projectName}\n\nRetrieval context:\n${retrievalContext}\n\nRepositories (TOON):\n${repoSnapshot}`
+  const contextQuality = formatContextQualityFlags({
+    repositories: repositories.map((r) => ({
+      name: r.name,
+      indexReady: r.indexReady,
+    })),
+    hasHydratedClaimsInContext: hydratedClaimsWithEvidence.length > 0,
+    state,
+  })
+  const fullContext = `${contextQuality}\n\nCurrent project name: ${projectName}\n\nRetrieval context:\n${retrievalContext}\n\nRepositories (TOON):\n${repoSnapshot}`
 
   return { retrievalContext: fullContext }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses **CTX-33** (insufficient context threshold): the organisational context advisor could invent plausible project narratives when Zoekt/graph ingestion was cancelled, slow, or incomplete.

## Changes

- **`CONTEXT_QUALITY_FLAGS`** block is prepended to the first system message (assembled retrieval context). It encodes:
  - per-repository `index_ready` from Postgres (`repositories.index_ready`, only repos returned by `listRepositoriesForOrg`)
  - whether pre-rerank retrieval already had candidates, fleet patterns, or hydrated claims in the assembled context
  - whether `currentProjectName` matches a repository row name (helps MCP callers who pass a display name instead of `org/repo`)
- **Advisor system prompt** (`agent.ts`): hard rules to refuse confident "what is this project?" answers when those flags indicate incomplete indexing or no substantive pre-retrieval signal; instructs use of tools when repos are marked ready but context is still empty.
- **Unit tests** for `formatContextQualityFlags`.

## Testing

- `pnpm exec vitest run src/graphs/conversationGraph/contextQuality.test.ts` (from `apps/backend`)

Full `pnpm --filter @ctxpipe/backend test` was not used as a gate here: the workspace test run pulls in DB-backed suites when `DATABASE_URL` is unset or Postgres is down.

## Notes / limits

- `index_ready` is only flipped true after ingestion completes successfully (`repository-ingestion` workflow). Cancelled or partial runs keep `index_ready: false`, which now surfaces explicitly to the model.
- This does not add a new DB column for "user cancelled UI job"; it uses the existing completion signal the product already persists.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-33](https://linear.app/ctxpipe/issue/CTX-33/insufficient-context-threshold)

<div><a href="https://cursor.com/agents/bc-245b4fa1-bb05-4d26-8bb3-249b8901b8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-245b4fa1-bb05-4d26-8bb3-249b8901b8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

