### PR TITLE
Add knowledge graph chat focus UI

### DIFF
--- a/apps/backend/src/graphs/conversationGraph/graph.ts
+++ b/apps/backend/src/graphs/conversationGraph/graph.ts
@@ -5,6 +5,7 @@ import { conversationNaming } from "./nodes/conversationNaming.js"
 import { agentNode } from "./nodes/agent.js"
 import { assembleNode } from "./nodes/assemble.js"
 import { extractQueryNode } from "./nodes/extractQuery.js"
+import { knowledgeGraphFocusNode } from "./nodes/knowledgeGraphFocus.js"
 import { normalizeNode } from "./nodes/normalize.js"
 import { plannerNode } from "./nodes/planner.js"
 import { rerankNode } from "./nodes/rerank.js"
@@ -17,6 +18,7 @@ const workflow = new StateGraph(ConversationGraphStateSchema)
   .addNode("retrievalChannels", retrievalChannelsNode)
   .addNode("normalize", normalizeNode)
   .addNode("rerank", rerankNode)
+  .addNode("knowledgeGraphFocus", knowledgeGraphFocusNode)
   .addNode("assemble", assembleNode)
   .addNode("agent", agentNode)
   .addNode("conversationNaming", conversationNaming)
@@ -31,7 +33,8 @@ const workflow = new StateGraph(ConversationGraphStateSchema)
   .addEdge("retrievalChannels", "normalize")
 
   .addEdge("normalize", "rerank")
-  .addEdge("rerank", "assemble")
+  .addEdge("rerank", "knowledgeGraphFocus")
+  .addEdge("knowledgeGraphFocus", "assemble")
   .addEdge("assemble", "agent")
   .addEdge("agent", END)
   .addEdge("conversationNaming", END)

--- a/apps/backend/src/graphs/conversationGraph/nodes/knowledgeGraphFocus.test.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/knowledgeGraphFocus.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import type { ConversationGraphState } from "../state.js"
+import { collectKnowledgeGraphFocusNodeIds } from "./knowledgeGraphFocus.js"
+
+describe("collectKnowledgeGraphFocusNodeIds", () => {
+  it("collects candidate, payload, graph, and traversal node ids in order", () => {
+    const state = {
+      candidates: [
+        {
+          id: "cand_1",
+          sourceChannels: ["graph"],
+          objectId: "svc:vlm",
+          payload: {
+            nodeIds: ["api:vlm.generate", "db:media"],
+          },
+        },
+        {
+          id: "cand_2",
+          sourceChannels: ["semantic"],
+          payload: {
+            sourceId: "svc:vlm",
+            targetId: "lib:torch",
+          },
+        },
+      ],
+      graphNodes: [{ id: "infra:gpu-workers" }],
+      traversalResults: [{ nodeIds: ["queue:vlm-jobs", "svc:vlm"] }],
+    } satisfies Partial<ConversationGraphState>
+
+    expect(
+      collectKnowledgeGraphFocusNodeIds(
+        state as unknown as ConversationGraphState,
+      ),
+    ).toEqual([
+      "svc:vlm",
+      "api:vlm.generate",
+      "db:media",
+      "lib:torch",
+      "infra:gpu-workers",
+      "queue:vlm-jobs",
+    ])
+  })
+})

--- a/apps/backend/src/graphs/conversationGraph/nodes/knowledgeGraphFocus.ts
+++ b/apps/backend/src/graphs/conversationGraph/nodes/knowledgeGraphFocus.ts
@@ -1,0 +1,68 @@
+import { getConfig, getWriter } from "@langchain/langgraph"
+import type { ConversationGraphState } from "../state.js"
+
+const MAX_FOCUS_NODE_IDS = 32
+
+type KnowledgeGraphFocusEvent = {
+  type: "kg-focus"
+  nodeIds: string[]
+  reason: string
+  fitView: boolean
+}
+
+function pushString(out: Set<string>, value: unknown) {
+  if (typeof value === "string" && value.trim().length > 0) {
+    out.add(value)
+  }
+}
+
+function pushStrings(out: Set<string>, value: unknown) {
+  if (!Array.isArray(value)) return
+  for (const item of value) pushString(out, item)
+}
+
+export function collectKnowledgeGraphFocusNodeIds(
+  state: ConversationGraphState,
+): string[] {
+  const out = new Set<string>()
+
+  for (const candidate of state.candidates ?? []) {
+    pushString(out, candidate.objectId)
+    pushStrings(out, candidate.payload?.nodeIds)
+    pushString(out, candidate.payload?.sourceId)
+    pushString(out, candidate.payload?.targetId)
+    if (out.size >= MAX_FOCUS_NODE_IDS) break
+  }
+
+  for (const node of state.graphNodes ?? []) {
+    pushString(out, (node as { id?: unknown }).id)
+    if (out.size >= MAX_FOCUS_NODE_IDS) break
+  }
+
+  for (const traversal of state.traversalResults ?? []) {
+    pushStrings(out, (traversal as { nodeIds?: unknown }).nodeIds)
+    if (out.size >= MAX_FOCUS_NODE_IDS) break
+  }
+
+  return [...out].slice(0, MAX_FOCUS_NODE_IDS)
+}
+
+export async function knowledgeGraphFocusNode(
+  state: ConversationGraphState,
+): Promise<Partial<ConversationGraphState>> {
+  const source = getConfig().configurable?.source as string | undefined
+  if (source !== "knowledge-graph") return {}
+
+  const nodeIds = collectKnowledgeGraphFocusNodeIds(state)
+  if (nodeIds.length === 0) return {}
+
+  const writer = getWriter()
+  writer?.({
+    type: "kg-focus",
+    nodeIds,
+    reason: state.query ?? "Graph answer focus",
+    fitView: true,
+  } satisfies KnowledgeGraphFocusEvent)
+
+  return {}
+}

--- a/apps/ui/src/features/chat/ConversationThread.tsx
+++ b/apps/ui/src/features/chat/ConversationThread.tsx
@@ -15,6 +15,8 @@ import {
 import { formatDate } from "@/lib/format"
 import { cn } from "@/lib/utils"
 
+const HIDDEN_DATA_PARTS = new Set(["data-rename-conversation", "data-kg-focus"])
+
 function formatMessageTimeLabel(message: UIMessage): string | null {
   const meta = message.metadata as { createdAt?: string } | undefined
   if (!meta?.createdAt) return null
@@ -24,7 +26,7 @@ function formatMessageTimeLabel(message: UIMessage): string | null {
 }
 
 function isRenderableMessagePart(part: UIMessage["parts"][number]) {
-  if (part.type === "data-rename-conversation") return false
+  if (HIDDEN_DATA_PARTS.has(part.type)) return false
   if (part.type === "text") return Boolean(part.text?.trim())
   if (part.type === "reasoning") return Boolean(part.text?.trim())
   if (part.type === "source-url") return true
@@ -89,8 +91,9 @@ export function ConversationThread(props: {
   messages: UIMessage[]
   error: Error | null
   status?: ChatStatus
+  contentClassName?: string
 }) {
-  const { messages, error, status } = props
+  const { messages, error, status, contentClassName } = props
   const lastMessage = messages[messages.length - 1]
   const lastAssistantHasRenderableParts =
     lastMessage?.role === "assistant"
@@ -104,7 +107,9 @@ export function ConversationThread(props: {
     <div className="flex min-h-0 flex-1 flex-col bg-transparent">
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <Conversation className="min-h-0 flex-1">
-          <ConversationContent className="mx-auto max-w-2xl space-y-6 p-6">
+          <ConversationContent
+            className={cn("mx-auto max-w-2xl space-y-6 p-6", contentClassName)}
+          >
             {messages.length === 0 ? (
               <ConversationEmptyState
                 icon={

--- a/apps/ui/src/features/chat/MessageInputBox.tsx
+++ b/apps/ui/src/features/chat/MessageInputBox.tsx
@@ -2,13 +2,16 @@
 
 import { IconArrowUp } from "@tabler/icons-react"
 import type { ChatStatus } from "ai"
+import { useEffect } from "react"
 import {
   PromptInput,
   PromptInputBody,
   PromptInputFooter,
+  PromptInputProvider,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputTools,
+  usePromptInputController,
 } from "@/components/ai-elements/prompt-input"
 import { cn } from "@/lib/utils"
 
@@ -21,8 +24,22 @@ export function MessageInputBox(props: {
   isDisabled?: boolean
   /** thread: footer dock with top border; empty: hero composer */
   layout?: MessageInputLayout
+  placeholder?: string
+  draftSeed?: string | null
+  onDraftSeedConsumed?: () => void
+  contentClassName?: string
 }) {
-  const { sendMessage, status, onStop, isDisabled, layout = "thread" } = props
+  const {
+    sendMessage,
+    status,
+    onStop,
+    isDisabled,
+    layout = "thread",
+    placeholder,
+    draftSeed,
+    onDraftSeedConsumed,
+    contentClassName,
+  } = props
   const isGenerating = status === "submitted" || status === "streaming"
 
   const handleSubmit = ({ text }: { text: string }) => {
@@ -32,47 +49,54 @@ export function MessageInputBox(props: {
   }
 
   const inputShell = (
-    <div className="relative ctx-border ctx-surface overflow-hidden transition-colors focus-within:border-primary/30">
-      <PromptInput
-        className="w-full [&_[data-slot=input-group]]:min-h-0 [&_[data-slot=input-group]]:flex-col [&_[data-slot=input-group]]:items-stretch [&_[data-slot=input-group]]:rounded-none [&_[data-slot=input-group]]:border-0 [&_[data-slot=input-group]]:bg-transparent [&_[data-slot=input-group]]:shadow-none"
-        onSubmit={(message) => handleSubmit(message)}
-      >
-        <PromptInputBody>
-          <PromptInputTextarea
-            placeholder={
-              layout === "empty"
-                ? "Ask anything…"
-                : "Continue the conversation…"
-            }
-            className={cn(
-              "resize-none border-0 bg-transparent text-[15px] leading-relaxed focus-visible:ring-0",
-              layout === "empty"
-                ? "min-h-[120px] p-4 pb-16"
-                : "min-h-[80px] p-4 pb-12",
-            )}
-            autoFocus={layout === "empty"}
-          />
-        </PromptInputBody>
-        <PromptInputFooter className="absolute bottom-4 right-4 flex items-center gap-3 border-0 bg-transparent p-0 shadow-none">
-          <PromptInputTools />
-          <PromptInputSubmit
-            size="sm"
-            variant="primary"
-            status={status}
-            onStop={onStop}
-            isDisabled={isDisabled}
-            className="h-8 gap-2 rounded-none border-0 bg-teal-500 px-3 text-sm font-medium text-white shadow-none hover:bg-teal-400 focus-visible:ring-2 focus-visible:ring-teal-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          >
-            {isGenerating ? undefined : (
-              <>
-                Send
-                <IconArrowUp aria-hidden className="h-3.5 w-3.5" />
-              </>
-            )}
-          </PromptInputSubmit>
-        </PromptInputFooter>
-      </PromptInput>
-    </div>
+    <PromptInputProvider>
+      <MessageInputDraftSeed
+        seed={draftSeed ?? null}
+        onConsumed={onDraftSeedConsumed}
+      />
+      <div className="relative ctx-border ctx-surface overflow-hidden transition-colors focus-within:border-primary/30">
+        <PromptInput
+          className="w-full [&_[data-slot=input-group]]:min-h-0 [&_[data-slot=input-group]]:flex-col [&_[data-slot=input-group]]:items-stretch [&_[data-slot=input-group]]:rounded-none [&_[data-slot=input-group]]:border-0 [&_[data-slot=input-group]]:bg-transparent [&_[data-slot=input-group]]:shadow-none"
+          onSubmit={(message) => handleSubmit(message)}
+        >
+          <PromptInputBody>
+            <PromptInputTextarea
+              placeholder={
+                placeholder ??
+                (layout === "empty"
+                  ? "Ask anything…"
+                  : "Continue the conversation…")
+              }
+              className={cn(
+                "resize-none border-0 bg-transparent text-[15px] leading-relaxed focus-visible:ring-0",
+                layout === "empty"
+                  ? "min-h-[120px] p-4 pb-16"
+                  : "min-h-[80px] p-4 pb-12",
+              )}
+              autoFocus={layout === "empty"}
+            />
+          </PromptInputBody>
+          <PromptInputFooter className="absolute bottom-4 right-4 flex items-center gap-3 border-0 bg-transparent p-0 shadow-none">
+            <PromptInputTools />
+            <PromptInputSubmit
+              size="sm"
+              variant="primary"
+              status={status}
+              onStop={onStop}
+              isDisabled={isDisabled}
+              className="h-8 gap-2 rounded-none border-0 bg-teal-500 px-3 text-sm font-medium text-white shadow-none hover:bg-teal-400 focus-visible:ring-2 focus-visible:ring-teal-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              {isGenerating ? undefined : (
+                <>
+                  Send
+                  <IconArrowUp aria-hidden className="h-3.5 w-3.5" />
+                </>
+              )}
+            </PromptInputSubmit>
+          </PromptInputFooter>
+        </PromptInput>
+      </div>
+    </PromptInputProvider>
   )
 
   if (layout === "empty") {
@@ -81,7 +105,24 @@ export function MessageInputBox(props: {
 
   return (
     <div className="shrink-0 border-t border-white/[0.04] p-4">
-      <div className="mx-auto max-w-2xl">{inputShell}</div>
+      <div className={cn("mx-auto max-w-2xl", contentClassName)}>
+        {inputShell}
+      </div>
     </div>
   )
+}
+
+function MessageInputDraftSeed(props: {
+  seed: string | null
+  onConsumed?: () => void
+}) {
+  const controller = usePromptInputController()
+
+  useEffect(() => {
+    if (!props.seed) return
+    controller.textInput.setInput(props.seed)
+    props.onConsumed?.()
+  }, [props.seed, props.onConsumed, controller])
+
+  return null
 }

--- a/apps/ui/src/features/chat/chatTransport.ts
+++ b/apps/ui/src/features/chat/chatTransport.ts
@@ -3,15 +3,53 @@ import { DefaultChatTransport } from "ai"
 export function createTransport(input: {
   orgSlug: string
   conversationId: string
+  source?: string
+  getMessageContext?: () => string | null
 }) {
   return new DefaultChatTransport({
     api: `/${input.orgSlug}/api/v1/conversations/${input.conversationId}`,
     credentials: "include",
     prepareSendMessagesRequest: ({ messages }) => ({
       body: {
-        message: messages[messages.length - 1],
-        source: "ui",
+        message: withMessageContext(
+          messages[messages.length - 1],
+          input.getMessageContext?.() ?? null,
+        ),
+        source: input.source ?? "ui",
       },
     }),
   })
+}
+
+function withMessageContext<T>(message: T, context: string | null): T {
+  if (!context?.trim()) return message
+  if (!message || typeof message !== "object") return message
+
+  const suffix = `\n\nKnowledge graph context:\n${context.trim()}`
+  const out = { ...(message as Record<string, unknown>) }
+  const parts = out.parts
+  if (Array.isArray(parts)) {
+    out.parts = parts.map((part, index) => {
+      if (
+        index === parts.length - 1 &&
+        part &&
+        typeof part === "object" &&
+        "type" in part &&
+        (part as { type?: unknown }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string"
+      ) {
+        return {
+          ...(part as Record<string, unknown>),
+          text: `${(part as { text: string }).text}${suffix}`,
+        }
+      }
+      return part
+    })
+    return out as T
+  }
+
+  if (typeof out.content === "string") {
+    out.content = `${out.content}${suffix}`
+  }
+  return out as T
 }

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphAskPanel.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphAskPanel.tsx
@@ -1,0 +1,420 @@
+import { useChat } from "@ai-sdk/react"
+import {
+  IconFocusCentered,
+  IconMessageCircle,
+  IconX,
+} from "@tabler/icons-react"
+import type { UIMessage } from "ai"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { ConversationThread } from "@/features/chat/ConversationThread"
+import { MessageInputBox } from "@/features/chat/MessageInputBox"
+import { createTransport } from "@/features/chat/chatTransport"
+import { createObjectId } from "@/lib/id"
+import { cn } from "@/lib/utils"
+import { PanelLabel } from "./FloatingPanel"
+import type { KnowledgeGraphNode } from "./types"
+
+type KnowledgeGraphFocusPayload = {
+  nodeIds?: unknown
+  reason?: unknown
+  fitView?: unknown
+}
+
+type NodeSearchEntry = {
+  id: string
+  haystack: string
+  name: string
+}
+
+const LOCAL_FOCUS_LIMIT = 24
+const STREAM_FOCUS_THROTTLE_MS = 700
+const STOP_WORDS = new Set([
+  "about",
+  "again",
+  "also",
+  "and",
+  "are",
+  "backend",
+  "does",
+  "during",
+  "explain",
+  "for",
+  "from",
+  "graph",
+  "have",
+  "how",
+  "into",
+  "key",
+  "learn",
+  "more",
+  "node",
+  "nodes",
+  "should",
+  "show",
+  "system",
+  "that",
+  "the",
+  "this",
+  "use",
+  "what",
+  "when",
+  "where",
+  "which",
+  "with",
+])
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9_./:-]+/g, " ").trim()
+}
+
+function tokensFromText(value: string): string[] {
+  const normalized = normalizeText(value)
+  if (!normalized) return []
+  return [
+    ...new Set(
+      normalized
+        .split(/\s+/)
+        .filter((token) => token.length >= 2 && !STOP_WORDS.has(token)),
+    ),
+  ]
+}
+
+function latestAssistantTextAfterLastUser(messages: UIMessage[]): string {
+  const latestUserIndex = messages.findLastIndex(
+    (message) => message.role === "user",
+  )
+  if (latestUserIndex < 0) return ""
+  for (let i = messages.length - 1; i > latestUserIndex; i--) {
+    const message = messages[i]
+    if (message?.role !== "assistant") continue
+    return message.parts
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join("\n")
+  }
+  return ""
+}
+
+function buildNodeSearchIndex(nodes: KnowledgeGraphNode[]): NodeSearchEntry[] {
+  return nodes.map((node) => ({
+    id: node.id,
+    name: normalizeText(node.name ?? ""),
+    haystack: normalizeText(
+      [node.id, node.kind, node.name ?? "", node.summary ?? ""].join(" "),
+    ),
+  }))
+}
+
+function matchKnowledgeGraphNodes(
+  index: NodeSearchEntry[],
+  text: string,
+): string[] {
+  const query = normalizeText(text)
+  const tokens = tokensFromText(text)
+  if (!query || tokens.length === 0) return []
+
+  const scored: Array<{ id: string; score: number }> = []
+  for (const node of index) {
+    let score = 0
+    if (node.haystack.includes(query)) score += 8
+    if (node.name && query.includes(node.name)) score += 10
+    for (const token of tokens) {
+      if (node.haystack.includes(token)) score += token.length >= 4 ? 2 : 1
+    }
+    if (score > 0) scored.push({ id: node.id, score })
+  }
+
+  return scored
+    .sort((a, b) => b.score - a.score)
+    .slice(0, LOCAL_FOCUS_LIMIT)
+    .map((item) => item.id)
+}
+
+function parseFocusPayload(data: unknown): {
+  nodeIds: string[]
+  reason: string | null
+  fitView: boolean
+} | null {
+  if (!data || typeof data !== "object") return null
+  const payload = data as KnowledgeGraphFocusPayload
+  if (!Array.isArray(payload.nodeIds)) return null
+  const nodeIds = payload.nodeIds.filter(
+    (id): id is string => typeof id === "string" && id.length > 0,
+  )
+  if (nodeIds.length === 0) return null
+  return {
+    nodeIds,
+    reason: typeof payload.reason === "string" ? payload.reason : null,
+    fitView: payload.fitView !== false,
+  }
+}
+
+function displayNodeName(node: KnowledgeGraphNode): string {
+  return node.name?.trim() || node.id
+}
+
+function topNodeKinds(nodes: KnowledgeGraphNode[]): string[] {
+  const counts = new Map<string, number>()
+  for (const node of nodes) {
+    const kind = node.kind || "Unknown"
+    counts.set(kind, (counts.get(kind) ?? 0) + 1)
+  }
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([kind]) => kind)
+}
+
+function buildSuggestedQuestions({
+  nodes,
+  search,
+  selectedNode,
+}: {
+  nodes: KnowledgeGraphNode[]
+  search: string
+  selectedNode: KnowledgeGraphNode | null
+}): string[] {
+  const suggestions: string[] = []
+  const add = (question: string) => {
+    if (!suggestions.includes(question)) suggestions.push(question)
+  }
+
+  if (selectedNode) {
+    add(
+      `Explain ${displayNodeName(selectedNode)} and the most important nodes connected to it.`,
+    )
+  }
+
+  const trimmedSearch = search.trim()
+  if (trimmedSearch) {
+    add(`Summarize the ${trimmedSearch} area and highlight the key nodes.`)
+  }
+
+  const kinds = topNodeKinds(nodes)
+  if (kinds[0]) {
+    add(`Which ${kinds[0]} nodes should I inspect first, and why?`)
+  }
+  if (kinds[0] && kinds[1]) {
+    add(`How do ${kinds[0]} and ${kinds[1]} relate in this graph?`)
+  }
+
+  add("Give me a high-level map of the main areas in this knowledge graph.")
+  add("What dependencies or relationships look most important here?")
+  add("What should I inspect first if I want to understand this repo quickly?")
+
+  return suggestions.slice(0, 3)
+}
+
+export function KnowledgeGraphAskButton(props: {
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      aria-pressed={props.active}
+      className={cn(
+        "inline-flex h-10 items-center gap-2 border border-zinc-800/95 bg-zinc-950/85 px-3 text-[12px] font-medium text-zinc-400 shadow-xl shadow-black/30 backdrop-blur transition-colors hover:border-zinc-700 hover:bg-zinc-900/90 hover:text-teal-300",
+        props.active && "border-teal-500/45 bg-teal-500/10 text-teal-200",
+      )}
+    >
+      <IconMessageCircle className="h-3.5 w-3.5" aria-hidden />
+      Ask
+    </button>
+  )
+}
+
+export function KnowledgeGraphAskPanel(props: {
+  orgSlug: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  selectedNode: KnowledgeGraphNode | null
+  nodes: KnowledgeGraphNode[]
+  highlightedNodeCount: number
+  search: string
+  seed: string | null
+  onSeedConsumed: () => void
+  onFocus: (input: { nodeIds: string[]; fitView: boolean }) => void
+  onFitFocus: () => void
+  onClearFocus: () => void
+}) {
+  const [draftSeed, setDraftSeed] = useState<string | null>(null)
+  const [conversationId] = useState(() => createObjectId("conv"))
+  const contextRef = useRef<string | null>(null)
+  const lastAutoFocusKeyRef = useRef("")
+  const lastStreamFocusAtRef = useRef(0)
+  const { nodes, onFocus, onSeedConsumed, seed } = props
+  const nodeSearchIndex = useMemo(
+    () => buildNodeSearchIndex(nodes),
+    [nodes],
+  )
+  const suggestedQuestions = useMemo(
+    () =>
+      buildSuggestedQuestions({
+        nodes,
+        search: props.search,
+        selectedNode: props.selectedNode,
+      }),
+    [nodes, props.search, props.selectedNode],
+  )
+
+  const transport = useMemo(
+    () =>
+      createTransport({
+        orgSlug: props.orgSlug,
+        conversationId,
+        source: "knowledge-graph",
+        getMessageContext: () => contextRef.current,
+      }),
+    [props.orgSlug, conversationId],
+  )
+
+  const { messages, sendMessage, status, stop, error } = useChat({
+    id: conversationId,
+    transport,
+    onData: ({ type, data }) => {
+      if (type !== "data-kg-focus") return
+      const focus = parseFocusPayload(data)
+      if (!focus) return
+      lastAutoFocusKeyRef.current = focus.nodeIds.join("\0")
+      onFocus({ nodeIds: focus.nodeIds, fitView: focus.fitView })
+    },
+  })
+
+  const isStreaming = status === "submitted" || status === "streaming"
+
+  useEffect(() => {
+    if (!seed) return
+    setDraftSeed(seed)
+    onSeedConsumed()
+  }, [seed, onSeedConsumed])
+
+  const promptContext = () => {
+    const lines: string[] = []
+    if (props.selectedNode) {
+      lines.push(
+        `Selected node: ${props.selectedNode.name ?? props.selectedNode.id} (${props.selectedNode.kind}, id=${props.selectedNode.id}).`,
+      )
+    }
+    if (props.search.trim()) {
+      lines.push(`Current graph search: ${props.search.trim()}.`)
+    }
+    return lines.join("\n") || null
+  }
+
+  const handleSendMessage = ({ text }: { text: string }) => {
+    contextRef.current = promptContext()
+    lastAutoFocusKeyRef.current = ""
+    lastStreamFocusAtRef.current = 0
+    props.onClearFocus()
+    void sendMessage({ text })
+  }
+
+  useEffect(() => {
+    if (!isStreaming) return
+    const now = Date.now()
+    if (now - lastStreamFocusAtRef.current < STREAM_FOCUS_THROTTLE_MS) return
+
+    const streamedText = latestAssistantTextAfterLastUser(messages)
+    const localFocusIds = matchKnowledgeGraphNodes(nodeSearchIndex, streamedText)
+    const key = localFocusIds.join("\0")
+    if (localFocusIds.length === 0 || key === lastAutoFocusKeyRef.current) return
+
+    lastStreamFocusAtRef.current = now
+    lastAutoFocusKeyRef.current = key
+    onFocus({ nodeIds: localFocusIds, fitView: true })
+  }, [isStreaming, messages, nodeSearchIndex, onFocus])
+
+  if (!props.open) return null
+
+  return (
+    <aside className="pointer-events-auto absolute right-0 top-0 z-20 flex h-[100dvh] w-[560px] max-w-[94vw] flex-col border-l border-zinc-800/95 bg-zinc-950/95 shadow-2xl shadow-black/50 backdrop-blur-md">
+      <div className="flex shrink-0 items-start justify-between gap-3 border-b border-zinc-800/95 p-4">
+        <div>
+          <PanelLabel className="mb-1 flex items-center gap-1.5">
+            Ask the graph
+          </PanelLabel>
+          <p className="text-[12px] leading-snug text-zinc-500">
+            Explore your knowledge graph by asking questions.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => props.onOpenChange(false)}
+          aria-label="Close graph chat"
+          className="flex h-8 w-8 shrink-0 items-center justify-center border border-zinc-800/95 bg-zinc-950/90 text-zinc-500 transition-colors hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-100"
+        >
+          <IconX className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <ConversationThread
+          messages={messages}
+          error={error ?? null}
+          status={status}
+          contentClassName="max-w-none px-6 py-5 [&_.ctx-streamdown_ol]:pl-6 [&_.ctx-streamdown_ul]:pl-6 [&_.ctx-streamdown_li]:pl-1"
+        />
+
+        {messages.length === 0 ? (
+          <div className="shrink-0 space-y-2 border-t border-zinc-800/80 px-4 py-3 text-[13px] text-zinc-500">
+            <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-zinc-600">
+              Try asking
+            </p>
+            {suggestedQuestions.map((example) => (
+              <button
+                key={example}
+                type="button"
+                onClick={() => handleSendMessage({ text: example })}
+                disabled={isStreaming}
+                className="block w-full border border-zinc-800/80 px-2.5 py-2 text-left text-zinc-400 transition-colors hover:border-zinc-700 hover:bg-white/5 hover:text-zinc-100"
+              >
+                {example}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {props.highlightedNodeCount > 0 ? (
+        <div className="flex shrink-0 items-center justify-between gap-3 border-t border-zinc-800/80 px-4 py-2 text-[12px] text-zinc-500">
+          <span>
+            <span className="font-mono uppercase tracking-[0.16em] text-teal-400">
+              Focus
+            </span>{" "}
+            {props.highlightedNodeCount.toLocaleString()} node
+            {props.highlightedNodeCount === 1 ? "" : "s"} highlighted
+          </span>
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              onClick={props.onFitFocus}
+              className="inline-flex items-center gap-1.5 text-zinc-400 transition-colors hover:text-teal-200"
+            >
+              <IconFocusCentered className="h-3 w-3" aria-hidden />
+              Fit
+            </button>
+            <button
+              type="button"
+              onClick={props.onClearFocus}
+              className="text-zinc-500 transition-colors hover:text-zinc-200"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <MessageInputBox
+        layout="thread"
+        sendMessage={handleSendMessage}
+        status={status}
+        onStop={stop}
+        isDisabled={isStreaming}
+        placeholder="Ask about this graph…"
+        draftSeed={draftSeed}
+        onDraftSeedConsumed={() => setDraftSeed(null)}
+        contentClassName="max-w-none"
+      />
+    </aside>
+  )
+}

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphCosmographCanvas.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphCosmographCanvas.tsx
@@ -7,22 +7,27 @@ import {
 } from "@cosmograph/react"
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
   useState,
 } from "react"
 import { ProgressLoader } from "@/components/ui/InlineLoader"
+import { buildFocusFitTarget } from "./knowledgeGraphFocusFit"
 import { KIND_FALLBACK_COLOR, LINK_BASE, PAGE_BG, UNKNOWN_COLOR } from "./theme"
 
 export type KnowledgeGraphCosmographCanvasHandle = {
   fitView: () => void
-  fitToIds: (ids: string[]) => void
+  fitToIds: (ids: string[], options?: FitToIdsOptions) => void
   focusNode: (id: string) => void
   /** Zoom so the node and its 1-hop neighbours fit the viewport — contextual
    * framing for deep-link landings, unlike `focusNode` which over-zooms. */
   focusNeighbourhood: (id: string) => void
   selectPoints: (ids: string[]) => void
+  /** Focus points plus their 1-hop neighbours; used to keep incident edges
+   * visually bright while preserving the caller's smaller focus list. */
+  selectPointsWithAdjacentEdges: (ids: string[]) => void
   /** Node + its 1-hop neighbours; others dim. */
   selectNeighbourhood: (id: string) => void
   unselectAll: () => void
@@ -41,6 +46,11 @@ export type GraphLinkRow = {
   color: string
 }
 
+type FitToIdsOptions = {
+  padding?: number
+  strategy?: "all" | "robust"
+}
+
 type KnowledgeGraphCosmographCanvasProps = {
   points: GraphPointRow[]
   links: GraphLinkRow[]
@@ -50,6 +60,48 @@ type KnowledgeGraphCosmographCanvasProps = {
 }
 
 const REVEAL_AFTER_FIT_MS = 80
+const FOCUS_FIT_PADDING = 0.12
+const FOCUS_LINK_COLOR = "rgba(248, 250, 252, 0.82)"
+const FOCUS_SELECTION_THRESHOLD = 500
+
+function resolveLinkColor(v: unknown) {
+  return typeof v === "string" ? v : LINK_BASE
+}
+
+function linkStyleForGraphSize(pointCount: number, focused: boolean) {
+  const isLargeGraph = pointCount > 20_000
+  if (focused) {
+    return {
+      linkColorByFn: () => FOCUS_LINK_COLOR,
+      linkDefaultWidth: isLargeGraph ? 0.82 : 1.9,
+      linkGreyoutOpacity: 0.03,
+      linkOpacity: isLargeGraph ? 0.84 : 0.92,
+      linkVisibilityMinTransparency: isLargeGraph ? 0.52 : 0.66,
+    } satisfies Pick<
+      CosmographConfig,
+      | "linkColorByFn"
+      | "linkDefaultWidth"
+      | "linkGreyoutOpacity"
+      | "linkOpacity"
+      | "linkVisibilityMinTransparency"
+    >
+  }
+  return {
+    linkColorByFn: resolveLinkColor,
+    linkDefaultWidth: isLargeGraph ? 0.6 : 1.6,
+    linkGreyoutOpacity: 0.05,
+    linkOpacity: 1,
+    linkVisibilityMinTransparency: 0.25,
+  } satisfies Pick<
+    CosmographConfig,
+    | "linkColorByFn"
+    | "linkDefaultWidth"
+    | "linkGreyoutOpacity"
+    | "linkOpacity"
+    | "linkVisibilityMinTransparency"
+  >
+}
+
 /** Fallback reveal when `onSimulationEnd` never fires. Kept short even for big
  * graphs — Cosmograph's sim runs live after reveal, so a not-yet-settled layout
  * visibly drifts into place rather than hiding behind a 30s overlay. */
@@ -76,11 +128,25 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
   )
   const [prepError, setPrepError] = useState<string | null>(null)
   const hasInitialFitRef = useRef(false)
+  const focusLinkModeRef = useRef(false)
   const pointIdsRef = useRef<string[]>([])
   const onPointClickRef = useRef(onPointClick)
   const onBackgroundClickRef = useRef(onBackgroundClick)
   onPointClickRef.current = onPointClick
   onBackgroundClickRef.current = onBackgroundClick
+
+  const setFocusLinkMode = useCallback((focused: boolean) => {
+    if (focusLinkModeRef.current === focused) return
+    focusLinkModeRef.current = focused
+    setConfig((prev) =>
+      prev
+        ? {
+            ...prev,
+            ...linkStyleForGraphSize(pointIdsRef.current.length, focused),
+          }
+        : prev,
+    )
+  }, [])
 
   useImperativeHandle(
     ref,
@@ -88,14 +154,33 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
       fitView: () => {
         cosmographRef.current?.fitView?.(400)
       },
-      fitToIds: (ids: string[]) => {
+      fitToIds: (ids: string[], options?: FitToIdsOptions) => {
         const idSet = new Set(ids)
         const indices: number[] = []
         pointIdsRef.current.forEach((id, index) => {
           if (idSet.has(id)) indices.push(index)
         })
         if (indices.length) {
-          cosmographRef.current?.fitViewByIndices?.(indices, 600)
+          const getPosition = (index: number) =>
+            cosmographRef.current?.getPointPositionByIndex?.(index)
+          const { coordinates, indices: fitIndices } = buildFocusFitTarget(
+            indices,
+            getPosition,
+            options,
+          )
+          if (coordinates.length >= 4) {
+            cosmographRef.current?.fitViewByCoordinates?.(
+              coordinates,
+              600,
+              options?.padding ?? FOCUS_FIT_PADDING,
+            )
+            return
+          }
+          cosmographRef.current?.fitViewByIndices?.(
+            fitIndices,
+            600,
+            options?.padding ?? FOCUS_FIT_PADDING,
+          )
         }
       },
       focusNode: (id: string) => {
@@ -117,20 +202,40 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
         pointIdsRef.current.forEach((id, index) => {
           if (idSet.has(id)) indices.push(index)
         })
+        setFocusLinkMode(
+          indices.length > 0 && indices.length <= FOCUS_SELECTION_THRESHOLD,
+        )
         cosmographRef.current?.selectPoints?.(indices.length ? indices : [])
+      },
+      selectPointsWithAdjacentEdges: (ids: string[]) => {
+        const idSet = new Set(ids)
+        const indices = new Set<number>()
+        pointIdsRef.current.forEach((id, index) => {
+          if (!idSet.has(id)) return
+          indices.add(index)
+          const adjacent =
+            cosmographRef.current?.getConnectedPointIndices?.(index) ?? []
+          for (const adjacentIndex of adjacent) indices.add(adjacentIndex)
+        })
+        setFocusLinkMode(indices.size > 0)
+        cosmographRef.current?.selectPoints?.(
+          indices.size ? Array.from(indices) : [],
+        )
       },
       selectNeighbourhood: (id: string) => {
         const index = pointIdsRef.current.indexOf(id)
         if (index < 0) return
         const adj =
           cosmographRef.current?.getConnectedPointIndices?.(index) ?? []
+        setFocusLinkMode(true)
         cosmographRef.current?.selectPoints?.([index, ...adj])
       },
       unselectAll: () => {
+        setFocusLinkMode(false)
         cosmographRef.current?.unselectAllPoints?.()
       },
     }),
-    [],
+    [setFocusLinkMode],
   )
 
   useEffect(() => {
@@ -143,6 +248,7 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
     }
 
     hasInitialFitRef.current = false
+    focusLinkModeRef.current = false
     setIsSettled(false)
     setPrepStage("preparing")
     setPrepError(null)
@@ -217,7 +323,7 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
         pointColorByFn: (v: unknown) =>
           typeof v === "string" ? v : KIND_FALLBACK_COLOR,
         pointSizeByFn: (v: unknown) => (typeof v === "number" ? v : 7),
-        linkColorByFn: (v: unknown) => (typeof v === "string" ? v : LINK_BASE),
+        linkColorByFn: resolveLinkColor,
         pointDefaultColor: KIND_FALLBACK_COLOR,
         pointDefaultSize: 7,
         /* Exaggerated range for large graphs: low-degree nodes render sub-pixel
@@ -225,11 +331,12 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
          * landmarks readable — progressive disclosure via zoom. */
         pointSizeRange: isLargeGraph ? [1, 28] : [6, 14],
         linkDefaultColor: LINK_BASE,
-        linkDefaultWidth: isLargeGraph ? 0.6 : 1.6,
+        ...linkStyleForGraphSize(n, false),
+        hoveredLinkColor: "#f8fafc",
+        hoveredLinkWidthIncrease: isLargeGraph ? 1.4 : 2.2,
         backgroundColor: "transparent",
         focusPointOnClick: true,
         pointGreyoutOpacity: 0.15,
-        linkGreyoutOpacity: 0.05,
         disableLogging: import.meta.env.PROD,
         unknownColor: UNKNOWN_COLOR,
         spaceSize,

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
@@ -5,12 +5,15 @@ import {
   IconX,
 } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
-import { useRouter } from "@tanstack/react-router"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { client } from "@/lib/api"
 import { cn } from "@/lib/utils"
 import { type ActivityBuckets, ActivitySparkline } from "./ActivitySparkline"
 import { FloatingPanel, PanelLabel } from "./FloatingPanel"
+import {
+  KnowledgeGraphAskButton,
+  KnowledgeGraphAskPanel,
+} from "./KnowledgeGraphAskPanel"
 import {
   KnowledgeGraphCosmographCanvas,
   type KnowledgeGraphCosmographCanvasHandle,
@@ -34,6 +37,9 @@ const SEARCH_DEBOUNCE_MS = 220
 /* When search matches <= this, we auto-fit the viewport to them. Above that the
  * fitted box is indistinguishable from the whole graph. */
 const FIT_TO_MATCHES_THRESHOLD = 200
+/* KG chat can highlight a richer context set than we should naively frame.
+ * Robust fitting keeps most focus nodes while trimming positional outliers. */
+const KG_FIT_STRATEGY = "robust" as const
 
 function buildSearchIdSet(
   nodes: KnowledgeGraphPayload["nodes"],
@@ -71,7 +77,6 @@ function syncDeepLink(nodeId: string | null): void {
 }
 
 export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
-  const router = useRouter()
   const [search, setSearch] = useState("")
   const [hiddenKinds, setHiddenKinds] = useState<Set<string>>(new Set())
   const [selectedId, setSelectedId] = useState<string | null>(() =>
@@ -80,6 +85,9 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
   const [kgIntroOpen, setKgIntroOpen] = useState(() =>
     shouldShowKnowledgeGraphIntro(orgSlug),
   )
+  const [kgChatOpen, setKgChatOpen] = useState(false)
+  const [kgChatSeed, setKgChatSeed] = useState<string | null>(null)
+  const [kgFocusIds, setKgFocusIds] = useState<string[]>([])
   const cgRef = useRef<KnowledgeGraphCosmographCanvasHandle>(null)
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -296,9 +304,9 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
     [searchPool, search],
   )
 
-  /* Selection priority: clicked node (neighbourhood) > search > kind filter >
-   * nothing. The first wins regardless of the others because an open drawer
-   * trumps ambient filtering. */
+  /* Selection priority: clicked node (neighbourhood) > KG chat focus > search
+   * > kind filter > nothing. The first wins because explicit investigation
+   * should beat ambient filtering. */
   useEffect(() => {
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
     if (!data) return
@@ -312,6 +320,12 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
         deepLinkFocusedRef.current = true
         cgRef.current?.focusNeighbourhood(selectedId)
       }
+      return
+    }
+
+    const visibleKgFocusIds = kgFocusIds.filter((id) => nodeById.has(id))
+    if (visibleKgFocusIds.length > 0) {
+      cgRef.current?.selectPointsWithAdjacentEdges(visibleKgFocusIds)
       return
     }
 
@@ -332,7 +346,7 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
       }
       cgRef.current?.selectPoints(ids)
       if (hasSearch && ids.length <= FIT_TO_MATCHES_THRESHOLD) {
-        cgRef.current?.fitToIds(ids)
+        cgRef.current?.fitToIds(ids, { padding: 0.12 })
       }
     }
 
@@ -352,14 +366,21 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
     data,
     selectedId,
     nodeById,
+    kgFocusIds,
   ])
 
   const onPointClick = useCallback((id: string | null) => {
+    if (id) {
+      setKgChatOpen(false)
+      setKgChatSeed(null)
+      setKgFocusIds([])
+    }
     setSelectedId(id)
   }, [])
 
   const onBackgroundClick = useCallback(() => {
     setSelectedId(null)
+    setKgFocusIds([])
     cgRef.current?.unselectAll()
   }, [])
 
@@ -438,6 +459,23 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
     return { counts, rangeStart: min, rangeEnd: max, total: stamps.length }
   }, [data])
 
+  const focusKnowledgeGraphNodes = useCallback(
+    ({ nodeIds, fitView }: { nodeIds: string[]; fitView: boolean }) => {
+      const visibleIds = [...new Set(nodeIds)].filter((id) => nodeById.has(id))
+      setKgFocusIds(visibleIds)
+      setSelectedId(null)
+      if (visibleIds.length === 0) {
+        cgRef.current?.unselectAll()
+        return
+      }
+      cgRef.current?.selectPointsWithAdjacentEdges(visibleIds)
+      if (fitView) {
+        cgRef.current?.fitToIds(visibleIds, { strategy: KG_FIT_STRATEGY })
+      }
+    },
+    [nodeById],
+  )
+
   return (
     <div className="relative z-10 h-[100dvh] min-h-[100dvh] w-full shrink-0">
       {showGraph ? (
@@ -489,8 +527,8 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
       </div>
 
       {showGraph ? (
-        <div className="pointer-events-auto absolute left-1/2 top-4 z-10 -translate-x-1/2">
-          <FloatingPanel className="flex items-center gap-2 px-3 py-2 focus-within:border-teal-500/55">
+        <div className="pointer-events-auto absolute left-1/2 top-4 z-10 flex -translate-x-1/2 items-center gap-3">
+          <FloatingPanel className="flex h-10 items-center gap-2 px-3 py-0 focus-within:border-teal-500/55">
             <IconSearch
               className="h-3.5 w-3.5 shrink-0 text-zinc-500"
               aria-hidden
@@ -507,10 +545,10 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
                 if (e.key === "Escape") setSearch("")
               }}
               placeholder="Search nodes, kinds, summaries…"
-              className="w-72 bg-transparent text-[13px] text-zinc-100 outline-none placeholder:text-zinc-500"
+              className="h-full w-72 bg-transparent text-[13px] text-zinc-100 outline-none placeholder:text-zinc-500"
             />
             {search.trim() ? (
-              <div className="flex shrink-0 items-center gap-2 border-l border-zinc-800/95 pl-2">
+              <div className="flex h-full shrink-0 items-center gap-2 border-l border-zinc-800/95 pl-2">
                 <span className="text-[12px] tabular-nums text-zinc-400">
                   {searchMatchCount === null
                     ? "…"
@@ -529,14 +567,22 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
               </div>
             ) : null}
           </FloatingPanel>
+          <div className="h-6 w-px shrink-0 bg-zinc-800/95" aria-hidden />
+          <KnowledgeGraphAskButton
+            active={kgChatOpen}
+            onClick={() => {
+              setSelectedId(null)
+              setKgChatOpen((open) => !open)
+            }}
+          />
         </div>
       ) : null}
 
       <div
         className="pointer-events-auto absolute right-4 top-4 z-10 flex items-start gap-3 transition-opacity duration-200"
         style={{
-          opacity: drawerOpen ? 0 : 1,
-          pointerEvents: drawerOpen ? "none" : "auto",
+          opacity: drawerOpen || kgChatOpen ? 0 : 1,
+          pointerEvents: drawerOpen || kgChatOpen ? "none" : "auto",
         }}
       >
         {activityBuckets ? (
@@ -679,7 +725,30 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
         <div className="pointer-events-none absolute inset-0 z-[5] bg-zinc-950/75" />
       ) : null}
 
-      {displayedNode && displayedFacts ? (
+      {showGraph ? (
+        <KnowledgeGraphAskPanel
+          orgSlug={orgSlug}
+          open={kgChatOpen}
+          onOpenChange={setKgChatOpen}
+          selectedNode={selectedId ? (nodeById.get(selectedId) ?? null) : null}
+          nodes={sanitizedNodes}
+          highlightedNodeCount={kgFocusIds.length}
+          search={search}
+          seed={kgChatSeed}
+          onSeedConsumed={() => setKgChatSeed(null)}
+          onFocus={focusKnowledgeGraphNodes}
+          onFitFocus={() => {
+            if (kgFocusIds.length === 0) return
+            cgRef.current?.fitToIds(kgFocusIds, { strategy: KG_FIT_STRATEGY })
+          }}
+          onClearFocus={() => {
+            setKgFocusIds([])
+            cgRef.current?.unselectAll()
+          }}
+        />
+      ) : null}
+
+      {displayedNode && displayedFacts && !kgChatOpen ? (
         <NodeDetailDrawer
           node={displayedNode}
           facts={displayedFacts}
@@ -700,11 +769,12 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
           }}
           onNeighbourSelect={(id) => setSelectedId(id)}
           onAskAgent={(seed) => {
-            void router.navigate({
-              to: "/$orgSlug/chat",
-              params: { orgSlug },
-              search: { seed },
-            })
+            setKgChatSeed(seed)
+            setKgChatOpen(true)
+            setKgFocusIds([displayedNode.id])
+            setSelectedId(null)
+            cgRef.current?.selectPointsWithAdjacentEdges([displayedNode.id])
+            cgRef.current?.fitToIds([displayedNode.id])
           }}
         />
       ) : null}

--- a/apps/ui/src/features/knowledge-graph/NodeDetailDrawer.tsx
+++ b/apps/ui/src/features/knowledge-graph/NodeDetailDrawer.tsx
@@ -303,36 +303,38 @@ export function NodeDetailDrawer({
       </div>
 
       <div className="flex-1 space-y-4 overflow-y-auto p-4">
-        <div className="flex flex-wrap items-center gap-1.5">
-          {peerRank ? (
-            <span
-              className="inline-flex items-center gap-1.5 border border-teal-500/30 bg-teal-500/5 px-2 py-0.5 text-[12px] text-teal-200"
-              title={`Rank ${peerRank.rankFromTop.toLocaleString()} of ${peerRank.totalPeers.toLocaleString()} ${kind} nodes by total connections`}
-            >
-              <span className="font-mono uppercase tracking-[0.12em] text-teal-400/80">
-                Rank
+        <div className="flex items-start gap-2">
+          <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
+            {peerRank ? (
+              <span
+                className="inline-flex max-w-full items-center gap-1.5 border border-teal-500/30 bg-teal-500/5 px-2 py-0.5 text-[12px] text-teal-200"
+                title={`Rank ${peerRank.rankFromTop.toLocaleString()} of ${peerRank.totalPeers.toLocaleString()} ${kind} nodes by total connections`}
+              >
+                <span className="font-mono uppercase tracking-[0.12em] text-teal-400/80">
+                  Rank
+                </span>
+                <span className="truncate tabular-nums">
+                  Top {formatPercentile(peerRank.percentile)} of {kind}
+                </span>
               </span>
-              <span className="tabular-nums">
-                Top {formatPercentile(peerRank.percentile)} of {kind}
+            ) : null}
+            {isIsolated ? (
+              <span
+                className="inline-flex max-w-full items-center gap-1.5 border border-amber-500/30 bg-amber-500/5 px-2 py-0.5 text-[12px] text-amber-200"
+                title="Few or no connections — may indicate a stub or stale entity"
+              >
+                <span className="font-mono uppercase tracking-[0.12em] text-amber-400/80">
+                  ⚠
+                </span>
+                <span className="truncate">Loosely connected</span>
               </span>
-            </span>
-          ) : null}
-          {isIsolated ? (
-            <span
-              className="inline-flex items-center gap-1.5 border border-amber-500/30 bg-amber-500/5 px-2 py-0.5 text-[12px] text-amber-200"
-              title="Few or no connections — may indicate a stub or stale entity"
-            >
-              <span className="font-mono uppercase tracking-[0.12em] text-amber-400/80">
-                ⚠
-              </span>
-              <span>Loosely connected</span>
-            </span>
-          ) : null}
+            ) : null}
+          </div>
           <button
             type="button"
             onClick={() => onAskAgent(buildAskSeed())}
-            className="ml-auto inline-flex items-center gap-1.5 border border-teal-500/55 bg-teal-500/10 px-2 py-0.5 text-[12px] text-teal-200 transition-colors hover:border-teal-500/70 hover:bg-teal-500/15"
-            title="Open a new chat seeded with this node's context"
+            className="inline-flex shrink-0 items-center gap-1.5 border border-teal-500/55 bg-teal-500/10 px-2 py-0.5 text-[12px] text-teal-200 transition-colors hover:border-teal-500/70 hover:bg-teal-500/15"
+            title="Ask the graph chat about this node"
           >
             Ask ctx|
           </button>

--- a/apps/ui/src/features/knowledge-graph/knowledgeGraphFocusFit.test.ts
+++ b/apps/ui/src/features/knowledge-graph/knowledgeGraphFocusFit.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildFocusFitTarget,
+  chooseRobustFocusFitIndices,
+} from "./knowledgeGraphFocusFit"
+
+describe("chooseRobustFocusFitIndices", () => {
+  it("keeps small focus sets intact", () => {
+    const indices = [1, 2, 3, 4]
+    const result = chooseRobustFocusFitIndices(indices, (index) => [index, 0])
+
+    expect(result).toEqual(indices)
+  })
+
+  it("keeps most nodes instead of collapsing to a tiny dense cluster", () => {
+    const indices = Array.from({ length: 24 }, (_, index) => index)
+    const result = chooseRobustFocusFitIndices(indices, (index) => [index, 0])
+
+    expect(result).toHaveLength(18)
+    expect(result).toEqual(Array.from({ length: 18 }, (_, index) => index + 3))
+  })
+
+  it("trims distant positional outliers", () => {
+    const indices = Array.from({ length: 24 }, (_, index) => index)
+    const result = chooseRobustFocusFitIndices(indices, (index) =>
+      index >= 20 ? [1000 + index, 1000 + index] : [index, index % 3],
+    )
+
+    expect(result).toHaveLength(18)
+    expect(result).not.toContain(20)
+    expect(result).not.toContain(21)
+    expect(result).not.toContain(22)
+    expect(result).not.toContain(23)
+  })
+
+  it("falls back to the minimum useful set when positions are unavailable", () => {
+    const indices = Array.from({ length: 24 }, (_, index) => index)
+    const result = chooseRobustFocusFitIndices(indices, () => undefined)
+
+    expect(result).toEqual(Array.from({ length: 12 }, (_, index) => index))
+  })
+
+  it("builds coordinates for the selected fit indices", () => {
+    const result = buildFocusFitTarget([2, 4], (index) => [index, index * 10])
+
+    expect(result.indices).toEqual([2, 4])
+    expect(result.coordinates).toEqual([2, 20, 4, 40])
+  })
+
+  it("keeps the index fallback available when coordinates are missing", () => {
+    const result = buildFocusFitTarget([2, 4], () => undefined)
+
+    expect(result.indices).toEqual([2, 4])
+    expect(result.coordinates).toEqual([])
+  })
+
+  it("uses the robust strategy before producing fit coordinates", () => {
+    const indices = Array.from({ length: 24 }, (_, index) => index)
+    const result = buildFocusFitTarget(
+      indices,
+      (index) =>
+        index >= 20 ? [1000 + index, 1000 + index] : [index, index % 3],
+      { strategy: "robust" },
+    )
+
+    expect(result.indices).toHaveLength(18)
+    expect(result.indices).not.toContain(20)
+    expect(result.indices).not.toContain(21)
+    expect(result.coordinates).toHaveLength(36)
+  })
+})

--- a/apps/ui/src/features/knowledge-graph/knowledgeGraphFocusFit.ts
+++ b/apps/ui/src/features/knowledge-graph/knowledgeGraphFocusFit.ts
@@ -1,0 +1,103 @@
+type PointPosition = readonly [number, number]
+
+type PositionedIndex = {
+  index: number
+  position: PointPosition
+}
+
+type RobustFocusFitOptions = {
+  minNodes?: number
+  retainedRatio?: number
+}
+
+type FocusFitOptions = RobustFocusFitOptions & {
+  strategy?: "all" | "robust"
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)] ?? 0
+}
+
+function interquartileRange(values: number[]): number {
+  if (values.length < 4) return 1
+  const sorted = [...values].sort((a, b) => a - b)
+  const q1 = sorted[Math.floor(sorted.length * 0.25)] ?? 0
+  const q3 = sorted[Math.floor(sorted.length * 0.75)] ?? q1
+  return Math.max(1, q3 - q1)
+}
+
+/**
+ * Choose a camera-fit subset for KG answer focus. We keep most focused nodes in
+ * frame, but trim positional outliers so one far-away match does not make the
+ * actual answer unreadably small.
+ */
+export function chooseRobustFocusFitIndices(
+  indices: number[],
+  getPosition: (index: number) => PointPosition | undefined,
+  options?: RobustFocusFitOptions,
+): number[] {
+  const minNodes = options?.minNodes ?? 12
+  const retainedRatio = options?.retainedRatio ?? 0.75
+  if (indices.length <= minNodes) return indices
+
+  const positioned: PositionedIndex[] = []
+  for (const index of indices) {
+    const position = getPosition(index)
+    if (position) positioned.push({ index, position })
+  }
+
+  if (positioned.length <= minNodes) {
+    return positioned.length > 0
+      ? positioned.map((item) => item.index)
+      : indices.slice(0, minNodes)
+  }
+
+  const targetCount = Math.min(
+    positioned.length,
+    Math.max(minNodes, Math.ceil(positioned.length * retainedRatio)),
+  )
+  if (positioned.length <= targetCount) {
+    return positioned.map((item) => item.index)
+  }
+
+  const xs = positioned.map((item) => item.position[0])
+  const ys = positioned.map((item) => item.position[1])
+  const centerX = median(xs)
+  const centerY = median(ys)
+  const scaleX = interquartileRange(xs)
+  const scaleY = interquartileRange(ys)
+
+  const selected = new Set(
+    positioned
+      .map((item) => {
+        const dx = (item.position[0] - centerX) / scaleX
+        const dy = (item.position[1] - centerY) / scaleY
+        return { index: item.index, distance: dx * dx + dy * dy }
+      })
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, targetCount)
+      .map((item) => item.index),
+  )
+
+  return indices.filter((index) => selected.has(index))
+}
+
+export function buildFocusFitTarget(
+  indices: number[],
+  getPosition: (index: number) => PointPosition | undefined,
+  options?: FocusFitOptions,
+): { coordinates: number[]; indices: number[] } {
+  const fitIndices =
+    options?.strategy === "robust"
+      ? chooseRobustFocusFitIndices(indices, getPosition, options)
+      : indices
+
+  const coordinates = fitIndices.flatMap((index) => {
+    const position = getPosition(index)
+    return position ?? []
+  })
+
+  return { coordinates, indices: fitIndices }
+}


### PR DESCRIPTION
## Summary
- Add an Ask panel to the Knowledge Graph UI that reuses the existing chat message/input styling.
- Stream KG focus events from backend chat responses so relevant nodes and their connecting edges can be highlighted and fit into view.
- Tune focused-edge brightness, focus-fit behavior, drawer interactions, and node detail layout polish.

## Verification
- `pnpm exec biome lint apps/backend/src/graphs/conversationGraph/graph.ts apps/backend/src/graphs/conversationGraph/nodes/knowledgeGraphFocus.ts apps/backend/src/graphs/conversationGraph/nodes/knowledgeGraphFocus.test.ts apps/ui/src/features/chat/ConversationThread.tsx apps/ui/src/features/chat/MessageInputBox.tsx apps/ui/src/features/chat/chatTransport.ts apps/ui/src/features/knowledge-graph/KnowledgeGraphAskPanel.tsx apps/ui/src/features/knowledge-graph/KnowledgeGraphCosmographCanvas.tsx apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx apps/ui/src/features/knowledge-graph/NodeDetailDrawer.tsx apps/ui/src/features/knowledge-graph/knowledgeGraphFocusFit.ts apps/ui/src/features/knowledge-graph/knowledgeGraphFocusFit.test.ts`
- `pnpm --filter @ctxpipe/ui test -- src/features/knowledge-graph/knowledgeGraphFocusFit.test.ts`
- `pnpm --filter @ctxpipe/backend exec vitest run src/graphs/conversationGraph/nodes/knowledgeGraphFocus.test.ts`
- `pnpm --filter @ctxpipe/ui build`

Note: `pnpm --filter @ctxpipe/backend test -- src/graphs/conversationGraph/nodes/knowledgeGraphFocus.test.ts` also confirmed the new backend test passes, but the package script swept in unrelated DB/socket suites that fail in this sandbox without local DB/socket access.