### PR TITLE
chore(backend): refresh default OpenRouter LLM tiers

### DIFF
--- a/apps/backend/src/retrieval/services/modelProvider.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.ts
@@ -34,6 +34,7 @@ export type GetModelOptions = {
  * Returns a ChatOpenAI-compatible model for the given tier.
  * Uses OpenRouter or any OpenAI-compatible provider.
  * OpenRouter: always requests the context-compression plugin and `cache_control: { type: "ephemeral" }` so prompt caching applies where the routed model supports it (see OpenRouter prompt caching docs).
+ * OpenRouter **fast** tier: `reasoning: { effort: "none" }` so models that support configurable reasoning (e.g. Gemini 3 Flash) do not run extended thinking; see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
  */
 export function getModel(
   tier: ModelTier,
@@ -50,6 +51,9 @@ export function getModel(
     ? ({
         plugins: [{ id: "context-compression" }],
         cache_control: { type: "ephemeral" as const },
+        ...(tier === "fast" && {
+          reasoning: { effort: "none" as const },
+        }),
       } as Record<string, unknown>)
     : undefined
 

--- a/apps/backend/src/retrieval/services/modelProvider.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.ts
@@ -10,9 +10,9 @@ const modelEnvSchema = z.object({
     .string()
     .min(1, "MODEL_PROVIDER_API_KEY is required for LLM operations"),
   MODEL_PROVIDER_URL: z.string().url().default("https://openrouter.ai/api/v1"),
-  MODEL_FAST_NAME: z.string().default("xiaomi/mimo-v2-flash"),
-  MODEL_MEDIUM_NAME: z.string().default("google/gemini-3-flash-preview"),
-  MODEL_HIGH_NAME: z.string().default("z-ai/glm-5.1"),
+  MODEL_FAST_NAME: z.string().default("google/gemini-3-flash-preview"),
+  MODEL_MEDIUM_NAME: z.string().default("deepseek/deepseek-v4-flash"),
+  MODEL_HIGH_NAME: z.string().default("moonshotai/kimi-k2.6"),
   MODEL_EMBEDDING_PROVIDER_URL: z.string().url().optional(),
   MODEL_EMBEDDING_PROVIDER_API_KEY: z.string().optional(),
   MODEL_EMBEDDING_NAME: z.string().default("openai/text-embedding-3-large"),

--- a/apps/docs/content/docs/self-hosting/models.mdx
+++ b/apps/docs/content/docs/self-hosting/models.mdx
@@ -21,9 +21,9 @@ LLM and embeddings both use OpenRouter by default. No extra configuration needed
 | ---------------------------------- | --------- | --------------------------------- | ---------------------------------------------------------------------------------- |
 | `MODEL_PROVIDER_API_KEY`           | Yes (LLM) | —                                 | API key for the LLM provider. Also used for embeddings unless overridden.          |
 | `MODEL_PROVIDER_URL`               | No        | `https://openrouter.ai/api/v1`    | Base URL for the LLM provider.                                                     |
-| `MODEL_FAST_NAME`                  | No        | `xiaomi/mimo-v2-flash`            | LLM model for the fast tier (cheap, quick).                                        |
-| `MODEL_MEDIUM_NAME`                | No        | `google/gemini-3-flash-preview`   | LLM model for the medium tier (balanced).                                          |
-| `MODEL_HIGH_NAME`                  | No        | `z-ai/glm-5`                      | LLM model for the high tier (best quality).                                        |
+| `MODEL_FAST_NAME`                  | No        | `google/gemini-3-flash-preview`   | LLM model for the fast tier (cheap, quick).                                        |
+| `MODEL_MEDIUM_NAME`                | No        | `deepseek/deepseek-v4-flash`      | LLM model for the medium tier (balanced).                                          |
+| `MODEL_HIGH_NAME`                  | No        | `moonshotai/kimi-k2.6`            | LLM model for the high tier (best quality).                                        |
 | `MODEL_EMBEDDING_PROVIDER_URL`     | No        | `{MODEL_PROVIDER_URL}/embeddings` | Embedding endpoint. Override for e.g. Ollama at `http://host:11434/v1/embeddings`. |
 | `MODEL_EMBEDDING_PROVIDER_API_KEY` | No        | `MODEL_PROVIDER_API_KEY`          | Embedding API key. Use a separate key if embeddings use a different provider.      |
 | `MODEL_EMBEDDING_NAME`             | No        | `openai/text-embedding-3-large`   | Embedding model ID.                                                                |
@@ -34,11 +34,11 @@ LLM and embeddings both use OpenRouter by default. No extra configuration needed
 
 The service uses three tiers for different workloads:
 
-| Tier       | Use case                          | Default model  |
-| ---------- | --------------------------------- | -------------- |
-| **fast**   | Quick tasks, naming, planning     | MiMo V2 Flash  |
-| **medium** | Main agent, balanced cost/quality | Gemini 3 Flash |
-| **high**   | Complex reasoning, best quality   | GLM-5          |
+| Tier       | Use case                          | Default model      |
+| ---------- | --------------------------------- | ------------------ |
+| **fast**   | Quick tasks, naming, planning     | Gemini 3 Flash     |
+| **medium** | Main agent, balanced cost/quality | DeepSeek V4 Flash  |
+| **high**   | Complex reasoning, best quality   | Kimi K2.6          |
 
 Override any tier with `MODEL_FAST_NAME`, `MODEL_MEDIUM_NAME`, or `MODEL_HIGH_NAME`. Use model IDs from your provider (e.g. OpenRouter format: `org/model-name`).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates default LLM tiers and ensures the **fast** tier explicitly disables OpenRouter extended reasoning.

### Model defaults
- **fast**: `google/gemini-3-flash-preview`
- **medium**: `deepseek/deepseek-v4-flash`
- **high**: `moonshotai/kimi-k2.6`

Self-hosting docs updated for the defaults.

### Fast tier + reasoning
`getModel("fast", …)` is only used from `identifyRoots` and `conversationNaming`. Previously nothing sent OpenRouter’s unified `reasoning` parameter, so configurable thinking was not explicitly off. For OpenRouter, fast-tier requests now include `reasoning: { effort: "none" }` in `modelKwargs` (see [OpenRouter reasoning tokens](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens)).

LangChain’s `ChatOpenAI.reasoning` field only forwards to the API for OpenAI o-series / GPT-5–style models (`isReasoningModel`), so OpenRouter/Gemini needs this via `modelKwargs` alongside existing `plugins` / `cache_control`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://ctxpipe.slack.com/archives/C0AMVSR0EBW/p1777348213151589?thread_ts=1777348213.151589&cid=C0AMVSR0EBW)

<div><a href="https://cursor.com/agents/bc-6cce70ae-8ef3-5757-99bf-aec50a640aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cce70ae-8ef3-5757-99bf-aec50a640aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

