### PR TITLE
Handle unavailable GitHub installations on repo page

### DIFF
--- a/apps/backend/src/routes/v1/github-installation.test.ts
+++ b/apps/backend/src/routes/v1/github-installation.test.ts
@@ -35,6 +35,8 @@ const userCanAccessInstallationMock = vi.hoisted(() => vi.fn())
 const getOrganizationSlugForInstallationByUserMock = vi.hoisted(() => vi.fn())
 const resolveGithubInstallationForOrgDetailedMock = vi.hoisted(() => vi.fn())
 const deleteGithubConnectionByIdMock = vi.hoisted(() => vi.fn())
+const listReposForInstallationMock = vi.hoisted(() => vi.fn())
+const searchReposForInstallationMock = vi.hoisted(() => vi.fn())
 
 vi.mock("../../models/github-installation.js", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
@@ -49,6 +51,8 @@ vi.mock("../../models/github-installation.js", async (importOriginal) => {
     resolveGithubInstallationForOrgDetailed:
       resolveGithubInstallationForOrgDetailedMock,
     deleteGithubConnectionById: deleteGithubConnectionByIdMock,
+    listReposForInstallation: listReposForInstallationMock,
+    searchReposForInstallation: searchReposForInstallationMock,
   }
 })
 
@@ -62,6 +66,7 @@ function createApp(): OpenAPIHono<AppEnv> {
     c.set("user", { id: "user_1" } as AppEnv["Variables"]["user"])
     c.set("session", { id: "sess_1" } as AppEnv["Variables"]["session"])
     c.set("orgId", "org_1")
+    c.set("log", { error: vi.fn() } as unknown as AppEnv["Variables"]["log"])
     await next()
   })
   const scoped = new OpenAPIHono<AppEnv>()
@@ -265,6 +270,79 @@ describe("DELETE /github/installation", () => {
       error: "No GitHub installation found for this org",
     })
     expect(deleteGithubConnectionByIdMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("GET /github/installation/repositories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getActiveMemberRoleMock.mockResolvedValue({ role: "admin" })
+    resolveGithubInstallationForOrgDetailedMock.mockResolvedValue({
+      status: "ok",
+      installation: {
+        id: "con_github",
+        installationId: 123,
+        orgId: "org_1",
+        accountSlug: "acme",
+        ingestAllRepositories: false,
+        includeFutureRepos: false,
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    })
+    listReposForInstallationMock.mockResolvedValue({
+      repositories: [],
+      repositorySelection: "selected",
+      hasMore: false,
+    })
+    searchReposForInstallationMock.mockResolvedValue({
+      repositories: [],
+      hasMore: false,
+      totalCount: 0,
+    })
+  })
+
+  it("returns an empty preview with a reconnect warning when the GitHub installation is unavailable", async () => {
+    const err = new Error(
+      "Not Found - https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app",
+    )
+    err.name = "HttpError"
+    Object.assign(err, { status: 404 })
+    listReposForInstallationMock.mockRejectedValueOnce(err)
+
+    const app = createApp()
+    const res = await app.request(
+      "/github/installation/repositories?page=1&per_page=100",
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      repositories: [],
+      repositorySelection: "unavailable",
+      hasMore: false,
+      warning:
+        "GitHub installation is no longer available. Reconnect GitHub from the Connectors page.",
+    })
+  })
+
+  it("does not leak raw GitHub errors for unexpected repository list failures", async () => {
+    listReposForInstallationMock.mockRejectedValueOnce(
+      new Error(
+        "Not Found - https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app",
+      ),
+    )
+
+    const app = createApp()
+    const res = await app.request(
+      "/github/installation/repositories?page=1&per_page=100",
+    )
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { warning?: string }
+    expect(body.warning).toBe(
+      "GitHub installation is no longer available. Reconnect GitHub from the Connectors page.",
+    )
+    expect(JSON.stringify(body)).not.toContain("docs.github.com")
   })
 })
 

--- a/apps/backend/src/routes/v1/github-installation.ts
+++ b/apps/backend/src/routes/v1/github-installation.ts
@@ -82,6 +82,19 @@ async function githubInstallationResponsePayload(
   }
 }
 
+const GITHUB_INSTALLATION_UNAVAILABLE_MESSAGE =
+  "GitHub installation is no longer available. Reconnect GitHub from the Connectors page."
+
+function isGitHubInstallationUnavailableError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false
+  const status =
+    "status" in e && typeof (e as { status: unknown }).status === "number"
+      ? (e as { status: number }).status
+      : undefined
+  if (status === 404) return true
+  return e.message.includes("create-an-installation-access-token-for-an-app")
+}
+
 const GitHubRepoItemSchema = z
   .object({
     id: z.number(),
@@ -105,6 +118,7 @@ const ListInstallationReposResponseSchema = z
     repositorySelection: z.string(),
     hasMore: z.boolean(),
     totalCount: z.number().optional(),
+    warning: z.string().optional(),
   })
   .openapi("ListInstallationReposResponse")
 
@@ -650,9 +664,20 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
       c.get("log").error(e instanceof Error ? e : new Error(String(e)), {
         step: "github_installation.list_repos",
       })
+      if (isGitHubInstallationUnavailableError(e)) {
+        return c.json(
+          {
+            repositories: [],
+            repositorySelection: "unavailable",
+            hasMore: false,
+            warning: GITHUB_INSTALLATION_UNAVAILABLE_MESSAGE,
+          },
+          200,
+        )
+      }
       return c.json(
         {
-          error: e instanceof Error ? e.message : "Failed to list repositories",
+          error: "Failed to list GitHub repositories for this installation",
         },
         500,
       )

--- a/apps/ui/src/routes/$orgSlug.repositories.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.repositories.index.tsx
@@ -42,6 +42,7 @@ type GitHubConnectedRepo = {
 type GitHubReposPreview = {
   repositories: GitHubConnectedRepo[]
   error: string | null
+  warning?: string | null
 }
 type GitHubSetupData = {
   savedRepositories: Array<{ name: string; gitUrl: string }>
@@ -105,18 +106,26 @@ function RepositoriesPage() {
         return { repositories: [], error: null } satisfies GitHubReposPreview
       }
       if (!res.ok) {
-        const json = (await res.json().catch(() => ({}))) as { error?: string }
+        const json = (await res.json().catch(() => ({}))) as {
+          code?: string
+          error?: string
+        }
         return {
           repositories: [],
-          error: json.error ?? "Failed to fetch connected GitHub repositories",
+          error:
+            json.code === "GITHUB_INSTALLATION_UNAVAILABLE"
+              ? "GitHub needs to be reconnected from the Connectors page."
+              : (json.error ?? "Failed to fetch connected GitHub repositories"),
         } satisfies GitHubReposPreview
       }
       const json = (await res.json()) as {
         repositories: GitHubConnectedRepo[]
+        warning?: string
       }
       return {
         repositories: json.repositories,
         error: null,
+        warning: json.warning ?? null,
       } satisfies GitHubReposPreview
     },
     enabled: !!installation,
@@ -273,6 +282,7 @@ function RepositoriesPage() {
   const hasRepos = repos.length > 0
   const connectedGithubRepos = githubPreview?.repositories ?? []
   const githubPreviewError = githubPreview?.error ?? null
+  const githubPreviewWarning = githubPreview?.warning ?? null
   const savedSetupRepos = githubSetupData?.savedRepositories ?? []
   const existingGitUrls = new Set(repos.map((repo) => repo.gitUrl))
   const pendingConnectedGithubRepos = connectedGithubRepos.filter(
@@ -427,8 +437,12 @@ function RepositoriesPage() {
                   : "Failed to load repositories"}
               </p>
             ) : null}
-            {!error && githubPreviewError ? (
-              <p className="text-sm text-amber-300">{githubPreviewError}</p>
+            {!error &&
+            !hasRepos &&
+            (githubPreviewError || githubPreviewWarning) ? (
+              <p className="text-sm text-amber-300">
+                {githubPreviewError ?? githubPreviewWarning}
+              </p>
             ) : null}
 
             {isPending ? <InlineLoader label="Loading repositories" /> : null}


### PR DESCRIPTION
The repo page calls the GitHub “installation repositories” preview endpoint so it can show repos available from the GitHub App. For ctx-tev (our org), GitHub is returning a 404 while creating an installation access token, which usually means the stored installation is no longer accessible to this GitHub App: uninstalled, moved, wrong app credentials, or stale connection row.

Backend now treats that GitHub installation-token 404 as “installation unavailable” and returns an empty preview with a friendly reconnect warning instead of a 500 with raw GitHub docs text.
Backend no longer leaks raw Octokit error messages for repo-list failures.
Repositories page no longer shows the GitHub preview warning above an existing repo list. Existing repositories remain usable.
Added route tests for this failure mode.