### PR TITLE
fix(otel-collector): reduce Better Stack export churn on quota limits

### DIFF
--- a/apps/otel-collector/README.md
+++ b/apps/otel-collector/README.md
@@ -30,3 +30,13 @@ This is intended to be used only when running in ctx| environment (BetterStack +
 2. Put your local secrets in `.env.local` (it overrides `.env`). Set `BETTER_STACK_TOKEN`, `LANGFUSE_*` vars (see `.env.example` for how to derive `LANGFUSE_AUTH_STRING` and `LANGFUSE_OTLP_ENDPOINT`).
 
 The collector loads `.env` then `.env.local` when started via docker compose. Without valid tokens, exports to Better Stack and LangFuse will fail.
+
+## Better Stack quota (HTTP 402) and log noise
+
+If Better Stack returns **HTTP 402 — Quota reached**, the OTLP exporter treats that as a **permanent** failure: batches are dropped and the collector logs `Exporting failed. Dropping data` for each failure. That is a **billing / plan limit** on the Better Stack side, not a bug in this repo.
+
+**What actually fixes delivery:** raise the Better Stack quota, reduce ingest (sample or disable auto-instrumentation spans you do not need), or temporarily stop sending telemetry to Better Stack (for example unset `OTEL_EXPORTER_OTLP_*` on services or remove the Better Stack exporter from `config.yaml` in your deployment fork).
+
+**What this repo does to help:** pipelines that export to Better Stack use a **larger batch** (`batch/betterstack`: 5s timeout, 512 items) so fewer HTTP requests are made for the same traffic, which reduces both quota pressure and the rate of error lines when the quota is already exceeded.
+
+**Langfuse `Span not found in runMap` warnings** in application logs are a separate SDK concern (often benign under concurrency). They are not caused by Better Stack returning 402.

--- a/apps/otel-collector/config.yaml
+++ b/apps/otel-collector/config.yaml
@@ -8,7 +8,14 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
-  batch:
+  # Default batch (200ms) is very chatty toward upstream exporters; larger batches reduce
+  # HTTP requests when Better Stack / LangFuse quotas are tight.
+  batch/betterstack:
+    timeout: 5s
+    send_batch_size: 512
+  batch/langfuse:
+    timeout: 5s
+    send_batch_size: 512
   # Allowlist (Tier 1 + 2): keep spans with Gen AI semconv attributes OR Langfuse/LangChain/LangGraph
   # instrumentation scope. Drops everything else from the LangFuse pipeline only (APM still gets full traces).
   filter/llm_only:
@@ -31,17 +38,17 @@ service:
   pipelines:
     traces/apm:
       receivers: [otlp]
-      processors: [batch]
+      processors: [batch/betterstack]
       exporters: [otlphttp/betterstack]
     traces/llm:
       receivers: [otlp]
-      processors: [filter/llm_only, batch]
+      processors: [filter/llm_only, batch/langfuse]
       exporters: [otlphttp/langfuse]
     logs:
       receivers: [otlp]
-      processors: [batch]
+      processors: [batch/betterstack]
       exporters: [otlphttp/betterstack]
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [batch/betterstack]
       exporters: [otlphttp/betterstack]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses **CTX-95** (huge volume of OpenTelemetry collector errors on Railway).

### Root cause (from stack traces)

Better Stack’s OTLP endpoint returns **HTTP 402 — Quota reached**. The collector correctly classifies that as a **non-retryable** permanent failure, drops batches, and logs `Exporting failed. Dropping data` for each failure. The “huge amount of issues” is therefore primarily **quota exhaustion on the Better Stack account** plus **high export frequency** from the default batch processor (200ms flush).

### Code / docs changes

- **Collector**: Replace the default `batch` processor with **`batch/betterstack`** and **`batch/langfuse`** using `timeout: 5s` and `send_batch_size: 512` so each successful or failed upstream request carries more data and **fewer HTTP round-trips** occur for the same ingest rate. When quota is exceeded, this also **reduces the rate of error log lines** (each line is still one dropped batch, but batches arrive less often).
- **README**: Document 402 as a billing/quota issue, list real fixes (upgrade quota, reduce telemetry, disable exporter / env), and note that Langfuse `Span not found in runMap` warnings are separate from Better Stack 402.

### What operators still need to do

If 402 persists, **ingest must be reduced or the Better Stack plan increased** — batching alone cannot make a hard quota unlimited.

## Testing

- Config YAML structure follows OpenTelemetry batch processor docs (`timeout`, `send_batch_size`).
- Docker-based `otelcol validate` was not run in this environment (Docker unavailable on the agent VM).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-95](https://linear.app/ctxpipe/issue/CTX-95/huge-amount-of-otel-issues)

<div><a href="https://cursor.com/agents/bc-de402e39-0949-4ab7-aacf-87f509db38f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de402e39-0949-4ab7-aacf-87f509db38f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

