### PR TITLE
fix(mcp): accept topic/query aliases for ctx_advisor tool input

### DIFF
--- a/apps/backend/src/mcp/tools.test.ts
+++ b/apps/backend/src/mcp/tools.test.ts
@@ -1,5 +1,5 @@
 import { HumanMessage } from "@langchain/core/messages"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
   generateObjectIdMock,
@@ -44,9 +44,26 @@ vi.mock("../auth/context.js", () => ({
 }))
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-import { registerMcpTools } from "./tools.js"
+import { ctxAdvisorInputSchema, registerMcpTools } from "./tools.js"
 
 describe("registerMcpTools", () => {
+  beforeEach(() => {
+    streamMock.mockReset()
+    invokeMock.mockReset()
+  })
+
+  it("ctxAdvisorInputSchema accepts prompt or topic/query alias", () => {
+    const fromPrompt = ctxAdvisorInputSchema.parse({ prompt: "Hello" })
+    expect(fromPrompt.prompt).toBe("Hello")
+
+    const fromTopics = ctxAdvisorInputSchema.parse({
+      topic: "tru_v2_ui",
+      query: "What is it?",
+    })
+    expect(fromTopics.prompt).toContain("tru_v2_ui")
+    expect(fromTopics.prompt).toContain("What is it")
+  })
+
   it("registers ctx advisor tool and streams progress", async () => {
     const chunkOne = {
       messages: [{ content: "Plan the integration in phases" }],
@@ -73,7 +90,7 @@ describe("registerMcpTools", () => {
       {
         title: string
         description: string
-        inputSchema: { shape: { prompt: { _def: { type: string } } } }
+        inputSchema: typeof ctxAdvisorInputSchema
       },
       (
         input: { prompt: string },
@@ -88,9 +105,7 @@ describe("registerMcpTools", () => {
     expect(config.description).toContain("ctx_advisor")
     expect(config.description).toContain("repository search")
     expect(config.description).toContain("grep")
-    expect(config.inputSchema.shape.prompt._def.type).toBe("string")
-    expect("currentProjectName" in config.inputSchema.shape).toBe(true)
-    expect("conversationId" in config.inputSchema.shape).toBe(true)
+    expect(config.inputSchema).toBe(ctxAdvisorInputSchema)
 
     const sendNotification = vi.fn(async () => {})
     const result = await handler(

--- a/apps/backend/src/mcp/tools.ts
+++ b/apps/backend/src/mcp/tools.ts
@@ -17,6 +17,67 @@ import { trackMcpToolInvocation } from "../observability/amplitude.js"
 import { runWithLangfuseContext } from "../observability/langfuse.js"
 import { langfusePipelineCallbacks } from "../observability/langfusePipelineMetrics.js"
 
+/** Some MCP clients historically send `topic`/`query` instead of `prompt`; accept and merge. */
+export function normalizeCtxAdvisorInputs(input: {
+  prompt?: string | undefined
+  topic?: string | undefined
+  query?: string | undefined
+  currentProjectName?: string | undefined
+  conversationId?: string | undefined
+}): {
+  prompt: string
+  currentProjectName?: string | undefined
+  conversationId?: string | undefined
+} {
+  const trimmed = (s: string | undefined): string | undefined =>
+    s === undefined ? undefined : s.trim()
+
+  const explicit = trimmed(input.prompt)
+  if (explicit !== undefined && explicit.length > 0) {
+    return {
+      prompt: explicit,
+      currentProjectName: input.currentProjectName,
+      conversationId: input.conversationId,
+    }
+  }
+
+  const topic = trimmed(input.topic)
+  const query = trimmed(input.query)
+  const fromAlias = [topic ? `Topic: ${topic}` : undefined, query]
+    .filter(Boolean)
+    .join("\n\n")
+    .trim()
+
+  return {
+    prompt: fromAlias,
+    currentProjectName: input.currentProjectName,
+    conversationId: input.conversationId,
+  }
+}
+
+const ctxAdvisorRawInputSchema = z.object({
+  prompt: z.string().optional(),
+  topic: z.string().optional(),
+  query: z.string().optional(),
+  currentProjectName: z.string().optional(),
+  conversationId: z.string().optional(),
+})
+
+/** Prefer `prompt`; `topic`/`query` are tolerated for older agent clients. */
+export const ctxAdvisorInputSchema = ctxAdvisorRawInputSchema
+  .superRefine((data, ctx) => {
+    const normalized = normalizeCtxAdvisorInputs(data).prompt
+    if (normalized.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Provide prompt (non-empty string), or topic and/or query — some agents send those instead of prompt.",
+        path: ["prompt"],
+      })
+    }
+  })
+  .transform(normalizeCtxAdvisorInputs)
+
 /**
  * Register MCP tools. Tools should call into domain/ services so REST and MCP
  * share the same business logic.
@@ -75,13 +136,11 @@ export function registerMcpTools(server: McpServer): void {
         "- currentProjectName: Name of the current project (often the service, app, package, or repo). Pass the same value across the whole conversation.",
         "- conversationId: Unique string identifying this conversation/session. Use the same value for all tool calls within the same conversation.",
         "",
+        "INPUT ALIASES — Prefer the `prompt` field. Some clients send `topic` and/or `query` instead; those are accepted and combined into the advisor prompt when `prompt` is omitted.",
+        "",
         "When in doubt, call. This tool is the single entrypoint to your org's knowledge graph — use it aggressively.",
       ].join("\n"),
-      inputSchema: z.object({
-        prompt: z.string().min(1),
-        currentProjectName: z.string().optional(),
-        conversationId: z.string().optional(),
-      }),
+      inputSchema: ctxAdvisorInputSchema,
     },
     async ({ prompt, currentProjectName, conversationId }, extra) => {
       const userId = requireCurrentUserId()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces **MCP `-32602`** failures when agents call `ctx_advisor` with **`topic` / `query`** instead of **`prompt`** (observed in Cursor). The tool now normalizes those aliases into a single `prompt` before the graph runs.

## Details

- Exported `normalizeCtxAdvisorInputs` / `ctxAdvisorInputSchema`: Zod `superRefine` ensures at least one of `prompt`, `topic`, or `query` resolves to non-empty text.
- Tool description documents the alias behavior.
- Tests: alias parsing + mock reset in `beforeEach` so fallback tests don’t bleed `streamMock` state.

## Out of scope

OAuth **`401` / `invalid_grant` / `session not found`** flows are separate from this UI validation issue; runbook remains in `apps/backend/AGENTS.md` (MCP OAuth section).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-13](https://linear.app/ctxpipe/issue/CTX-13/mcp-connection-issues)

<div><a href="https://cursor.com/agents/bc-59d93be6-e150-420b-b8b6-e2fd8a3f8b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59d93be6-e150-420b-b8b6-e2fd8a3f8b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

