### PR TITLE
fix(backend): MCP OAuth path-inserted discovery and WWW-Authenticate resource_metadata

### DIFF
--- a/apps/backend/src/auth/withAuth.test.ts
+++ b/apps/backend/src/auth/withAuth.test.ts
@@ -55,6 +55,7 @@ vi.mock("../observability/logger.js", () => ({
 }))
 
 import {
+  mcpOAuthProtectedResourceMetadataUrl,
   requireAuth,
   resetBearerJwksCacheForTests,
   withBearerAuth,
@@ -509,5 +510,46 @@ describe("auth middleware composition", () => {
       orgSlug: "acme",
       orgId: "org_token",
     })
+  })
+
+  it("requireAuth on /mcp includes resource_metadata in WWW-Authenticate", async () => {
+    const app = createBaseApp()
+    app.use("/mcp", requireAuth)
+    app.post("/mcp", (c) => c.text("ok"))
+    const response = await app.request("/mcp", { method: "POST" })
+    expect(response.status).toBe(401)
+    const www = response.headers.get("WWW-Authenticate")
+    expect(www).toContain("resource_metadata=")
+    expect(www).toContain(
+      mcpOAuthProtectedResourceMetadataUrl("https://backend.example.com"),
+    )
+  })
+
+  it("requireAuth on non-MCP path omits resource_metadata", async () => {
+    const app = createBaseApp()
+    app.use("/api/v1/onboarding", requireAuth)
+    app.post("/api/v1/onboarding", (c) => c.text("ok"))
+    const response = await app.request("/api/v1/onboarding", { method: "POST" })
+    expect(response.status).toBe(401)
+    expect(response.headers.get("WWW-Authenticate")).not.toContain(
+      "resource_metadata",
+    )
+  })
+
+  it("withBearerAuth 401 on /mcp includes resource_metadata", async () => {
+    testState.db = createMockDb({ opaqueTokenRows: [] })
+    const app = createBaseApp()
+    app.use("/mcp", withBearerAuth)
+    app.post("/mcp", (c) => c.text("ok"))
+    const response = await app.request("/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer bad" },
+    })
+    expect(response.status).toBe(401)
+    const www = response.headers.get("WWW-Authenticate")
+    expect(www).toContain("resource_metadata=")
+    expect(www).toContain(
+      mcpOAuthProtectedResourceMetadataUrl("https://backend.example.com"),
+    )
   })
 })

--- a/apps/backend/src/auth/withAuth.ts
+++ b/apps/backend/src/auth/withAuth.ts
@@ -49,6 +49,18 @@ function setJwksCache(jwks: JSONWebKeySet): void {
   jwksCache = { jwks, fetchedAt: Date.now() }
 }
 
+/** Absolute URL of RFC 9728 protected resource metadata for the MCP HTTP endpoint. */
+export function mcpOAuthProtectedResourceMetadataUrl(
+  authBaseUrl: string,
+): string {
+  const base = authBaseUrl.replace(/\/$/, "")
+  return `${base}/.well-known/oauth-protected-resource/mcp`
+}
+
+function isMcpRequestPath(pathname: string): boolean {
+  return pathname === "/mcp" || pathname.startsWith("/mcp/")
+}
+
 function wwwAuthenticateInvalidToken(
   errorDescription: string,
 ): Record<string, string> {
@@ -56,6 +68,27 @@ function wwwAuthenticateInvalidToken(
   return {
     "WWW-Authenticate": `Bearer error="invalid_token", error_description="${esc}"`,
   }
+}
+
+function wwwAuthenticateInvalidTokenMcp(
+  errorDescription: string,
+  authBaseUrl: string,
+): Record<string, string> {
+  const esc = errorDescription.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+  const meta = mcpOAuthProtectedResourceMetadataUrl(authBaseUrl)
+  const metaEsc = meta.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+  return {
+    "WWW-Authenticate": `Bearer error="invalid_token", error_description="${esc}", resource_metadata="${metaEsc}"`,
+  }
+}
+
+function wwwAuthenticateForMcpRoute(
+  c: { req: { path: string }; var: { env: AppEnv["Variables"]["env"] } },
+  errorDescription: string,
+): Record<string, string> {
+  return isMcpRequestPath(c.req.path)
+    ? wwwAuthenticateInvalidTokenMcp(errorDescription, c.var.env.AUTH_BASE_URL)
+    : wwwAuthenticateInvalidToken(errorDescription)
 }
 
 function logBearerAuthFailure(
@@ -164,7 +197,7 @@ export const withCookieAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     return c.json(
       { error: "Unauthorized" },
       401,
-      wwwAuthenticateInvalidToken("Session invalid or missing"),
+      wwwAuthenticateForMcpRoute(c, "Session invalid or missing"),
     )
   }
 
@@ -196,7 +229,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     return c.json(
       { error: "Unauthorized" },
       401,
-      wwwAuthenticateInvalidToken("The access token could not be validated"),
+      wwwAuthenticateForMcpRoute(c, "The access token could not be validated"),
     )
   }
 
@@ -234,7 +267,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     return c.json(
       { error: "Unauthorized" },
       401,
-      wwwAuthenticateInvalidToken("The access token could not be validated"),
+      wwwAuthenticateForMcpRoute(c, "The access token could not be validated"),
     )
   }
 
@@ -253,7 +286,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
       return c.json(
         { error: "Unauthorized" },
         401,
-        wwwAuthenticateInvalidToken("The access token expired"),
+        wwwAuthenticateForMcpRoute(c, "The access token expired"),
       )
     }
     if (!isLikelyJwksKeyProblem(verifyErr)) {
@@ -261,7 +294,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
       return c.json(
         { error: "Unauthorized" },
         401,
-        wwwAuthenticateInvalidToken("The access token could not be validated"),
+        wwwAuthenticateForMcpRoute(c, "The access token could not be validated"),
       )
     }
     invalidateJwksCache()
@@ -273,7 +306,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
       return c.json(
         { error: "Unauthorized" },
         401,
-        wwwAuthenticateInvalidToken("The access token could not be validated"),
+        wwwAuthenticateForMcpRoute(c, "The access token could not be validated"),
       )
     }
     ;[payload, verifyErr] = await jwtVerify(
@@ -288,7 +321,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
       return c.json(
         { error: "Unauthorized" },
         401,
-        wwwAuthenticateInvalidToken("The access token could not be validated"),
+        wwwAuthenticateForMcpRoute(c, "The access token could not be validated"),
       )
     }
   }
@@ -297,7 +330,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     return c.json(
       { error: "Unauthorized" },
       401,
-      wwwAuthenticateInvalidToken("The access token could not be validated"),
+      wwwAuthenticateForMcpRoute(c, "The access token could not be validated"),
     )
   }
 
@@ -305,7 +338,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     return c.json(
       { error: "Unauthorized" },
       401,
-      wwwAuthenticateInvalidToken("The access token subject is invalid"),
+      wwwAuthenticateForMcpRoute(c, "The access token subject is invalid"),
     )
   }
   tokenSessionId =
@@ -354,7 +387,7 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   return c.json(
     { error: "Unauthorized" },
     401,
-    wwwAuthenticateInvalidToken("The access token could not be validated"),
+    wwwAuthenticateForMcpRoute(c, "The access token could not be validated"),
   )
 }
 
@@ -364,7 +397,7 @@ export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     return c.json(
       { error: "Unauthorized" },
       401,
-      wwwAuthenticateInvalidToken("Authentication required"),
+      wwwAuthenticateForMcpRoute(c, "Authentication required"),
     )
   }
   return next()

--- a/apps/backend/src/routes/auth.test.ts
+++ b/apps/backend/src/routes/auth.test.ts
@@ -59,6 +59,27 @@ describe("auth metadata routes", () => {
     expect(body.authorization_servers).toEqual(["https://auth.example.com"])
   })
 
+  it("serves authorization server metadata at RFC 8414 path-inserted /.well-known URLs", async () => {
+    const app = await createTestApp()
+    const oauthRoot = await app.request("/.well-known/oauth-authorization-server")
+    const oauthInserted = await app.request(
+      "/.well-known/oauth-authorization-server/mcp",
+    )
+    expect(oauthRoot.status).toBe(200)
+    expect(oauthInserted.status).toBe(200)
+    expect(await oauthInserted.text()).toBe(await oauthRoot.text())
+
+    const oidcRoot = await app.request("/.well-known/openid-configuration")
+    const oidcInserted = await app.request("/.well-known/openid-configuration/mcp")
+    const oidcAppended = await app.request("/mcp/.well-known/openid-configuration")
+    expect(oidcRoot.status).toBe(200)
+    expect(oidcInserted.status).toBe(200)
+    expect(oidcAppended.status).toBe(200)
+    const oidcRootBody = await oidcRoot.text()
+    expect(await oidcInserted.text()).toBe(oidcRootBody)
+    expect(await oidcAppended.text()).toBe(oidcRootBody)
+  })
+
   it("mounts oauth2 authorize endpoint under /.auth/api/v1/auth", async () => {
     const app = await createTestApp()
     const response = await app.request("/.auth/api/v1/auth/oauth2/authorize")

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -80,6 +80,19 @@ export function registerAuthRoutes(app: Hono<AppEnv>) {
     oauthProviderOpenIdConfigMetadata(auth)(c.req.raw),
   )
 
+  // RFC 8414 path-inserted discovery when clients treat the issuer as …/mcp
+  app.get("/.well-known/oauth-authorization-server/mcp", (c) =>
+    oauthProviderAuthServerMetadata(auth)(c.req.raw),
+  )
+
+  app.get("/.well-known/openid-configuration/mcp", (c) =>
+    oauthProviderOpenIdConfigMetadata(auth)(c.req.raw),
+  )
+
+  app.get("/mcp/.well-known/openid-configuration", (c) =>
+    oauthProviderOpenIdConfigMetadata(auth)(c.req.raw),
+  )
+
   app.get("/.well-known/oauth-protected-resource/mcp", async (c) => {
     const authorizationServer = c.var.env.AUTH_ISSUER ?? c.var.env.AUTH_BASE_URL
     const metadata = await serverClient.getProtectedResourceMetadata({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
MCP clients probe RFC 8414 path-inserted authorization server metadata URLs when they treat the issuer as having a `/mcp` pathname. This change serves those aliases with the same Better Auth OAuth/OIDC metadata as the root `/.well-known/*` endpoints, eliminating 404 noise.

Unauthenticated MCP requests now include `resource_metadata` in `WWW-Authenticate` (RFC 9728) so clients can fetch protected resource metadata directly instead of speculative well-known probing.

Tests: `pnpm exec vitest run src/routes/auth.test.ts src/auth/withAuth.test.ts` in `apps/backend`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dbac8b5-5fc8-47ab-bb19-700ecf8dbcb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dbac8b5-5fc8-47ab-bb19-700ecf8dbcb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

