### PR TITLE
feat(backend): OpenRouter fallbacks for medium LLM tier

### DIFF
--- a/apps/backend/src/retrieval/services/modelProvider.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.ts
@@ -30,11 +30,25 @@ export type GetModelOptions = {
   temperature?: number
 }
 
+/** Dedupes while preserving order (for OpenRouter `models` fallback chain). */
+function uniqueModelIdsInOrder(ids: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const id of ids) {
+    if (!seen.has(id)) {
+      seen.add(id)
+      out.push(id)
+    }
+  }
+  return out
+}
+
 /**
  * Returns a ChatOpenAI-compatible model for the given tier.
  * Uses OpenRouter or any OpenAI-compatible provider.
  * OpenRouter: always requests the context-compression plugin and `cache_control: { type: "ephemeral" }` so prompt caching applies where the routed model supports it (see OpenRouter prompt caching docs).
  * OpenRouter **fast** tier: `reasoning: { effort: "none" }` so models that support configurable reasoning (e.g. Gemini 3 Flash) do not run extended thinking; see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
+ * OpenRouter **medium** tier: adds a `models` fallback chain (primary → Gemini 3 Flash → Kimi K2.6) per https://openrouter.ai/docs/guides/routing/model-fallbacks — fallbacks use `MODEL_FAST_NAME` and `MODEL_HIGH_NAME` so they stay aligned with tier overrides.
  */
 export function getModel(
   tier: ModelTier,
@@ -47,6 +61,14 @@ export function getModel(
     high: env.MODEL_HIGH_NAME,
   }
   const isOpenRouter = env.MODEL_PROVIDER_URL.includes("openrouter.ai")
+  const mediumFallbacks =
+    tier === "medium" && isOpenRouter
+      ? uniqueModelIdsInOrder([
+          env.MODEL_FAST_NAME,
+          env.MODEL_HIGH_NAME,
+        ]).filter((id) => id !== modelNames.medium)
+      : []
+
   const modelKwargs = isOpenRouter
     ? ({
         plugins: [{ id: "context-compression" }],
@@ -54,6 +76,7 @@ export function getModel(
         ...(tier === "fast" && {
           reasoning: { effort: "none" as const },
         }),
+        ...(mediumFallbacks.length > 0 && { models: mediumFallbacks }),
       } as Record<string, unknown>)
     : undefined
 

--- a/apps/docs/content/docs/self-hosting/models.mdx
+++ b/apps/docs/content/docs/self-hosting/models.mdx
@@ -42,6 +42,8 @@ The service uses three tiers for different workloads:
 
 Override any tier with `MODEL_FAST_NAME`, `MODEL_MEDIUM_NAME`, or `MODEL_HIGH_NAME`. Use model IDs from your provider (e.g. OpenRouter format: `org/model-name`).
 
+When **`MODEL_PROVIDER_URL`** points at OpenRouter, the **medium** tier sends OpenRouter’s `models` array so that if the primary model errors (rate limits, downtime, moderation), routing tries **`MODEL_FAST_NAME`** next, then **`MODEL_HIGH_NAME`** — see [OpenRouter model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks). With defaults that is medium → Gemini 3 Flash → Kimi K2.6.
+
 ### Embedding model
 
 **Important:** The embedding model must support **2000 dimensions**. The schema stores vectors in `vector(2000)`; incompatible models will fail.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `MODEL_PROVIDER_URL` points at OpenRouter, **medium** tier chat requests now include OpenRouter’s `models` fallback list ([model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks)): try the primary `MODEL_MEDIUM_NAME`, then `MODEL_FAST_NAME`, then `MODEL_HIGH_NAME`. With repo defaults that is DeepSeek V4 Flash → **Gemini 3 Flash** (`google/gemini-3-flash-preview`) → **Kimi K2.6** (`moonshotai/kimi-k2.6`).

Fallback IDs are **deduped** and omit the primary so overriding any tier env var still produces a sensible chain.

## Changes

- `apps/backend/src/retrieval/services/modelProvider.ts` — medium + OpenRouter: pass `models` in `modelKwargs` (merged into the completions body by LangChain).
- `apps/docs/content/docs/self-hosting/models.mdx` — document behavior for operators.

## Notes

- Non-OpenRouter providers are unchanged (no `models` array).
- Full `pnpm --filter @ctxpipe/backend exec tsc --noEmit` still reports pre-existing errors in email templates and some tests; this diff does not touch those files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bf03c74-444a-4c8e-b9f4-d98713847e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bf03c74-444a-4c8e-b9f4-d98713847e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

