### PR TITLE
fix(chat): repair SSE text-start after internal node filtering (CTX-96)

### DIFF
--- a/apps/backend/src/domain/conversations/internalNodeMessageFilter.ts
+++ b/apps/backend/src/domain/conversations/internalNodeMessageFilter.ts
@@ -12,6 +12,8 @@ type InternalNodeName = (typeof INTERNAL_MESSAGE_NODES)[number]
  * LangGraph emits text-start/text-delta/text-end for ALL model invocations (including
  * model.invoke()). The metadata includes langgraph_node to identify the source node.
  * We filter these so only the final agent reply is shown as streamed text.
+ * Dropping whole `messages` tuples can split text-start from later deltas for the same
+ * message id; `createTextStartRepairTransform` in transport.ts heals the UI stream.
  */
 export async function* filterInternalNodeMessageChunks(
   stream: AsyncIterable<unknown>,

--- a/apps/backend/src/domain/conversations/transport.ts
+++ b/apps/backend/src/domain/conversations/transport.ts
@@ -15,6 +15,7 @@ import { generateObjectId } from "../../lib/id.js"
 import { runWithLangfuseContext } from "../../observability/langfuse.js"
 import { langfusePipelineCallbacks } from "../../observability/langfusePipelineMetrics.js"
 import type { StreamEnhancer } from "./renameStream.js"
+import { createTextStartRepairTransform } from "./uiMessageStreamTextStartRepair.js"
 import { createToolInvocationRepairTransform } from "./uiMessageStreamToolInvocationRepair.js"
 
 export type StreamInput = {
@@ -74,9 +75,9 @@ class DataStreamConversationTransport implements ConversationTransportAdapter {
           wrappedStream as Parameters<typeof toUIMessageStream>[0],
         )
 
-        let stream: ReadableStream<UIMessageChunk> = uiStream.pipeThrough(
-          createToolInvocationRepairTransform(),
-        )
+        let stream: ReadableStream<UIMessageChunk> = uiStream
+          .pipeThrough(createToolInvocationRepairTransform())
+          .pipeThrough(createTextStartRepairTransform())
         for (const transform of flushTransforms) {
           stream = stream.pipeThrough(
             transform as TransformStream<UIMessageChunk, UIMessageChunk>,

--- a/apps/backend/src/domain/conversations/uiMessageStreamTextStartRepair.test.ts
+++ b/apps/backend/src/domain/conversations/uiMessageStreamTextStartRepair.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import { createTextStartRepairTransform } from "./uiMessageStreamTextStartRepair.js"
+
+describe("createTextStartRepairTransform", () => {
+  it("prepends text-start when text-delta arrives without a prior text-start", async () => {
+    const msgId = "gen-test-123"
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          type: "text-delta",
+          id: msgId,
+          delta: "hello",
+        })
+        controller.enqueue({ type: "text-end", id: msgId })
+        controller.close()
+      },
+    })
+
+    const out = input.pipeThrough(createTextStartRepairTransform())
+    const reader = out.getReader()
+    const chunks: unknown[] = []
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+    }
+
+    expect(chunks).toEqual([
+      { type: "text-start", id: msgId },
+      { type: "text-delta", id: msgId, delta: "hello" },
+      { type: "text-end", id: msgId },
+    ])
+  })
+
+  it("does not duplicate when text-start was already seen", async () => {
+    const msgId = "gen-test-456"
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-start", id: msgId })
+        controller.enqueue({
+          type: "text-delta",
+          id: msgId,
+          delta: "x",
+        })
+        controller.close()
+      },
+    })
+
+    const out = input.pipeThrough(createTextStartRepairTransform())
+    const reader = out.getReader()
+    const chunks: unknown[] = []
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+    }
+
+    expect(chunks).toEqual([
+      { type: "text-start", id: msgId },
+      { type: "text-delta", id: msgId, delta: "x" },
+    ])
+  })
+})

--- a/apps/backend/src/domain/conversations/uiMessageStreamTextStartRepair.ts
+++ b/apps/backend/src/domain/conversations/uiMessageStreamTextStartRepair.ts
@@ -1,0 +1,41 @@
+import type { UIMessageChunk } from "ai"
+
+/**
+ * When upstream LangGraph chunks are filtered (e.g. internal planner/naming nodes),
+ * @ai-sdk/langchain can emit `text-delta` / `text-end` for a message id without a prior
+ * `text-start` for that id. The AI SDK UI stream processor then throws
+ * "Received text-end for missing text part...".
+ *
+ * This transform prepends a synthetic `text-start` whenever we see text-delta or
+ * text-end for an id that has not yet received `text-start` in this stream.
+ */
+export function createTextStartRepairTransform(): TransformStream<
+  UIMessageChunk,
+  UIMessageChunk
+> {
+  const textStartSeen = new Set<string>()
+
+  return new TransformStream<UIMessageChunk, UIMessageChunk>({
+    transform(chunk, controller) {
+      if (chunk.type === "text-start") {
+        const id = (chunk as { id?: unknown }).id
+        if (typeof id === "string" && id.length > 0) {
+          if (textStartSeen.has(id)) return
+          textStartSeen.add(id)
+        }
+        controller.enqueue(chunk)
+        return
+      }
+
+      if (chunk.type === "text-delta" || chunk.type === "text-end") {
+        const id = (chunk as { id?: unknown }).id
+        if (typeof id === "string" && id.length > 0 && !textStartSeen.has(id)) {
+          controller.enqueue({ type: "text-start", id })
+          textStartSeen.add(id)
+        }
+      }
+
+      controller.enqueue(chunk)
+    },
+  })
+}

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphAskPanel.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphAskPanel.tsx
@@ -7,8 +7,8 @@ import {
 import type { UIMessage } from "ai"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { ConversationThread } from "@/features/chat/ConversationThread"
-import { MessageInputBox } from "@/features/chat/MessageInputBox"
 import { createTransport } from "@/features/chat/chatTransport"
+import { MessageInputBox } from "@/features/chat/MessageInputBox"
 import { createObjectId } from "@/lib/id"
 import { cn } from "@/lib/utils"
 import { PanelLabel } from "./FloatingPanel"
@@ -27,7 +27,8 @@ type NodeSearchEntry = {
 }
 
 const LOCAL_FOCUS_LIMIT = 24
-const STREAM_FOCUS_THROTTLE_MS = 700
+/** Debounce local graph focus derived from streamed text (avoids heavy re-renders each token). */
+const STREAM_FOCUS_DEBOUNCE_MS = 400
 const STOP_WORDS = new Set([
   "about",
   "again",
@@ -64,7 +65,10 @@ const STOP_WORDS = new Set([
 ])
 
 function normalizeText(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9_./:-]+/g, " ").trim()
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_./:-]+/g, " ")
+    .trim()
 }
 
 function tokensFromText(value: string): string[] {
@@ -241,12 +245,11 @@ export function KnowledgeGraphAskPanel(props: {
   const [conversationId] = useState(() => createObjectId("conv"))
   const contextRef = useRef<string | null>(null)
   const lastAutoFocusKeyRef = useRef("")
-  const lastStreamFocusAtRef = useRef(0)
-  const { nodes, onFocus, onSeedConsumed, seed } = props
-  const nodeSearchIndex = useMemo(
-    () => buildNodeSearchIndex(nodes),
-    [nodes],
+  const streamFocusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
   )
+  const { nodes, onFocus, onSeedConsumed, seed } = props
+  const nodeSearchIndex = useMemo(() => buildNodeSearchIndex(nodes), [nodes])
   const suggestedQuestions = useMemo(
     () =>
       buildSuggestedQuestions({
@@ -304,24 +307,42 @@ export function KnowledgeGraphAskPanel(props: {
   const handleSendMessage = ({ text }: { text: string }) => {
     contextRef.current = promptContext()
     lastAutoFocusKeyRef.current = ""
-    lastStreamFocusAtRef.current = 0
+    if (streamFocusTimeoutRef.current) {
+      clearTimeout(streamFocusTimeoutRef.current)
+      streamFocusTimeoutRef.current = null
+    }
     props.onClearFocus()
     void sendMessage({ text })
   }
 
   useEffect(() => {
     if (!isStreaming) return
-    const now = Date.now()
-    if (now - lastStreamFocusAtRef.current < STREAM_FOCUS_THROTTLE_MS) return
 
-    const streamedText = latestAssistantTextAfterLastUser(messages)
-    const localFocusIds = matchKnowledgeGraphNodes(nodeSearchIndex, streamedText)
-    const key = localFocusIds.join("\0")
-    if (localFocusIds.length === 0 || key === lastAutoFocusKeyRef.current) return
+    if (streamFocusTimeoutRef.current) {
+      clearTimeout(streamFocusTimeoutRef.current)
+    }
 
-    lastStreamFocusAtRef.current = now
-    lastAutoFocusKeyRef.current = key
-    onFocus({ nodeIds: localFocusIds, fitView: true })
+    streamFocusTimeoutRef.current = setTimeout(() => {
+      streamFocusTimeoutRef.current = null
+      const streamedText = latestAssistantTextAfterLastUser(messages)
+      const localFocusIds = matchKnowledgeGraphNodes(
+        nodeSearchIndex,
+        streamedText,
+      )
+      const key = localFocusIds.join("\0")
+      if (localFocusIds.length === 0 || key === lastAutoFocusKeyRef.current)
+        return
+
+      lastAutoFocusKeyRef.current = key
+      onFocus({ nodeIds: localFocusIds, fitView: true })
+    }, STREAM_FOCUS_DEBOUNCE_MS)
+
+    return () => {
+      if (streamFocusTimeoutRef.current) {
+        clearTimeout(streamFocusTimeoutRef.current)
+        streamFocusTimeoutRef.current = null
+      }
+    }
   }, [isStreaming, messages, nodeSearchIndex, onFocus])
 
   if (!props.open) return null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **CTX-96**: the AI SDK UI error *"Received text-end for missing text part..."* after chat completes, and reduces stilted streaming in the knowledge graph **Ask** panel.

## Root cause (backend)

`filterInternalNodeMessageChunks` drops entire LangGraph `messages` tuples for internal nodes (planner, conversationNaming). When the first chunk for a shared message id was on an internal node and later chunks reached the visible agent, `@ai-sdk/langchain` could emit `text-delta` / `text-end` without a prior `text-start` for that id — which `process-ui-message-stream` rejects.

## Changes

- **`createTextStartRepairTransform`**: after `toUIMessageStream`, inject a synthetic `text-start` before the first `text-delta` or `text-end` for any message id that has not yet seen `text-start`. Unit tests cover the happy path and duplicate avoidance.
- **`KnowledgeGraphAskPanel`**: debounce (400ms) local auto-focus derived from streamed assistant text so we do not re-run heavy graph matching on every token (reduces pauses/jank during streaming).

## Testing

- `pnpm --filter @ctxpipe/backend test src/domain/conversations/uiMessageStreamTextStartRepair.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-96](https://linear.app/ctxpipe/issue/CTX-96/sse-error-in-chat)

<div><a href="https://cursor.com/agents/bc-2cab47cf-0a27-491c-89c3-3521b589223a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cab47cf-0a27-491c-89c3-3521b589223a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

