### PR TITLE
Remove GHCR pull credentials from Terraform and CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -101,8 +101,6 @@ jobs:
     env:
       TF_IN_AUTOMATION: "true"
       TF_VAR_image_tag: ${{ github.sha }}
-      TF_VAR_source_image_registry_username: ${{ secrets.GHCR_USERNAME }}
-      TF_VAR_source_image_registry_password: ${{ secrets.GHCR_PASSWORD }}
       TF_VAR_better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
       TF_VAR_langsmith_api_key: ${{ secrets.LANGSMITH_API_KEY }}
       TF_VAR_model_provider_api_key: ${{ secrets.MODEL_PROVIDER_API_KEY }}

--- a/.github/workflows/terraform-plan-pr.yaml
+++ b/.github/workflows/terraform-plan-pr.yaml
@@ -24,8 +24,6 @@ jobs:
     env:
       TF_IN_AUTOMATION: "true"
       TF_VAR_image_tag: ${{ github.event.pull_request.base.sha }}
-      TF_VAR_source_image_registry_username: ${{ secrets.GHCR_USERNAME }}
-      TF_VAR_source_image_registry_password: ${{ secrets.GHCR_PASSWORD }}
       TF_VAR_better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
       TF_VAR_langsmith_api_key: ${{ secrets.LANGSMITH_API_KEY }}
       TF_VAR_model_provider_api_key: ${{ secrets.MODEL_PROVIDER_API_KEY }}

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,7 +10,7 @@ Mirrors [ops/infra/index.ts](../ops/infra/index.ts):
   - Project + `production` environment
   - Services: UI, backend, codesearch (+ volume), OpenWorkflow worker, FalkorDB (+ volume)
   - Service variables: `FALKORDB_PORT`, `GRAPH_DB_URI`
-  - App services pull GHCR images (`ghcr.io/ctxpipe-ai/{backend,worker,ui,codesearch}`) tagged by Git commit SHA from GitHub Actions
+  - App services pull public GHCR images (`ghcr.io/ctxpipe-ai/{backend,worker,ui,codesearch,otel-collector}`) tagged by Git commit SHA from GitHub Actions (no Railway registry credentials)
 - **Neon**
   - Project `ctxpipe` in org `org-steep-pine-64462726`, region `aws-us-east-1`, pg 17
   - Default branch `production` with db `neondb` and role `neondb_owner`

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -26,24 +26,22 @@ module "ctxpipe" {
     },
   ]
 
-  image_tag                      = var.image_tag
-  source_image_registry_username = var.source_image_registry_username
-  source_image_registry_password = var.source_image_registry_password
-  better_auth_secret             = var.better_auth_secret
-  langsmith_api_key              = var.langsmith_api_key
-  model_provider_api_key         = var.model_provider_api_key
-  smtp_connection_url            = var.smtp_connection_url
-  github_private_key             = var.github_private_key
-  github_client_secret           = var.github_client_secret
-  github_webhook_secret          = var.github_webhook_secret
-  atlassian_client_id            = var.atlassian_client_id
-  atlassian_client_secret        = var.atlassian_client_secret
-  falkordb_password              = var.falkordb_password
-  better_stack_token             = var.better_stack_token
-  langfuse_auth_string           = var.langfuse_auth_string
-  langfuse_otlp_endpoint         = var.langfuse_otlp_endpoint
-  amplitude_api_key              = var.amplitude_api_key
-  amplitude_region               = var.amplitude_region
+  image_tag               = var.image_tag
+  better_auth_secret      = var.better_auth_secret
+  langsmith_api_key       = var.langsmith_api_key
+  model_provider_api_key  = var.model_provider_api_key
+  smtp_connection_url     = var.smtp_connection_url
+  github_private_key      = var.github_private_key
+  github_client_secret    = var.github_client_secret
+  github_webhook_secret   = var.github_webhook_secret
+  atlassian_client_id     = var.atlassian_client_id
+  atlassian_client_secret = var.atlassian_client_secret
+  falkordb_password       = var.falkordb_password
+  better_stack_token      = var.better_stack_token
+  langfuse_auth_string    = var.langfuse_auth_string
+  langfuse_otlp_endpoint  = var.langfuse_otlp_endpoint
+  amplitude_api_key       = var.amplitude_api_key
+  amplitude_region        = var.amplitude_region
 
   neon_project = {
     name                      = "ctxpipe"

--- a/infra/module/ctxpipe/outputs.tf
+++ b/infra/module/ctxpipe/outputs.tf
@@ -8,12 +8,12 @@ output "railway_environment_id" {
 
 output "railway_service_ids" {
   value = {
-    ui             = railway_service.ui.id
-    backend        = railway_service.backend.id
-    code_search    = railway_service.code_search.id
-    open_workflow  = railway_service.open_workflow.id
-    falkordb       = railway_service.falkordb.id
-    otelcollector  = railway_service.otelcollector.id
+    ui            = railway_service.ui.id
+    backend       = railway_service.backend.id
+    code_search   = railway_service.code_search.id
+    open_workflow = railway_service.open_workflow.id
+    falkordb      = railway_service.falkordb.id
+    otelcollector = railway_service.otelcollector.id
   }
 }
 

--- a/infra/module/ctxpipe/railway.tf
+++ b/infra/module/ctxpipe/railway.tf
@@ -114,12 +114,10 @@ locals {
 }
 
 resource "railway_service" "ui" {
-  project_id                     = railway_project.this.id
-  name                           = "ui"
-  regions                        = local.regions
-  source_image                   = "${var.ui_source_image}:${var.image_tag}"
-  source_image_registry_username = var.source_image_registry_username
-  source_image_registry_password = var.source_image_registry_password
+  project_id   = railway_project.this.id
+  name         = "ui"
+  regions      = local.regions
+  source_image = "${var.ui_source_image}:${var.image_tag}"
 
   lifecycle {
     prevent_destroy = true
@@ -143,12 +141,10 @@ resource "railway_variable_collection" "ui_env" {
 }
 
 resource "railway_service" "otelcollector" {
-  project_id                     = railway_project.this.id
-  name                           = "otelcollector"
-  regions                        = local.regions
-  source_image                   = "${var.otel_collector_source_image}:${var.image_tag}"
-  source_image_registry_username = var.source_image_registry_username
-  source_image_registry_password = var.source_image_registry_password
+  project_id   = railway_project.this.id
+  name         = "otelcollector"
+  regions      = local.regions
+  source_image = "${var.otel_collector_source_image}:${var.image_tag}"
   lifecycle {
     prevent_destroy = true
   }
@@ -175,13 +171,11 @@ resource "railway_variable_collection" "otelcollector_env" {
 }
 
 resource "railway_service" "backend" {
-  project_id                     = railway_project.this.id
-  name                           = "backend"
-  regions                        = local.regions
-  source_image                   = "${var.backend_source_image}:${var.image_tag}"
-  source_image_registry_username = var.source_image_registry_username
-  source_image_registry_password = var.source_image_registry_password
-  depends_on                     = [railway_service.falkordb, railway_service.ui, railway_service.code_search, railway_service.otelcollector]
+  project_id   = railway_project.this.id
+  name         = "backend"
+  regions      = local.regions
+  source_image = "${var.backend_source_image}:${var.image_tag}"
+  depends_on   = [railway_service.falkordb, railway_service.ui, railway_service.code_search, railway_service.otelcollector]
   lifecycle {
     prevent_destroy = true
   }
@@ -220,12 +214,10 @@ resource "railway_variable_collection" "backend_env" {
 }
 
 resource "railway_service" "code_search" {
-  project_id                     = railway_project.this.id
-  name                           = "codesearch"
-  regions                        = local.regions
-  source_image                   = "${var.codesearch_source_image}:${var.image_tag}"
-  source_image_registry_username = var.source_image_registry_username
-  source_image_registry_password = var.source_image_registry_password
+  project_id   = railway_project.this.id
+  name         = "codesearch"
+  regions      = local.regions
+  source_image = "${var.codesearch_source_image}:${var.image_tag}"
   volume = {
     name       = "codesearch-volume-vNK-"
     mount_path = "/data"
@@ -268,13 +260,11 @@ resource "railway_variable_collection" "code_search_env" {
 }
 
 resource "railway_service" "open_workflow" {
-  project_id                     = railway_project.this.id
-  name                           = "openworkflow"
-  regions                        = local.regions
-  source_image                   = "${var.worker_source_image}:${var.image_tag}"
-  source_image_registry_username = var.source_image_registry_username
-  source_image_registry_password = var.source_image_registry_password
-  depends_on                     = [railway_service.falkordb, railway_service.backend, railway_service.otelcollector]
+  project_id   = railway_project.this.id
+  name         = "openworkflow"
+  regions      = local.regions
+  source_image = "${var.worker_source_image}:${var.image_tag}"
+  depends_on   = [railway_service.falkordb, railway_service.backend, railway_service.otelcollector]
   lifecycle {
     prevent_destroy = true
   }

--- a/infra/module/ctxpipe/variables.tf
+++ b/infra/module/ctxpipe/variables.tf
@@ -62,18 +62,6 @@ variable "image_tag" {
   default     = "latest"
 }
 
-variable "source_image_registry_username" {
-  type        = string
-  description = "Username used by Railway to pull private container images."
-  sensitive   = true
-}
-
-variable "source_image_registry_password" {
-  type        = string
-  description = "Password or token used by Railway to pull private container images."
-  sensitive   = true
-}
-
 variable "better_auth_secret" {
   type        = string
   description = "value for AUTH_SECRET used in better-auth"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -4,18 +4,6 @@ variable "image_tag" {
   default     = "latest"
 }
 
-variable "source_image_registry_username" {
-  type        = string
-  description = "Username used by Railway to pull private container images."
-  sensitive   = true
-}
-
-variable "source_image_registry_password" {
-  type        = string
-  description = "Password or token used by Railway to pull private container images."
-  sensitive   = true
-}
-
 variable "better_auth_secret" {
   type        = string
   description = "value for AUTH_SECRET used in better-auth"


### PR DESCRIPTION
Railway app images on `ghcr.io/ctxpipe-ai/*` are public, so registry username/password are no longer required for pulls.

- Drop `source_image_registry_username` / `source_image_registry_password` from root and module Terraform variables and from `railway_service` resources that use GHCR images.
- Remove `TF_VAR_source_image_registry_*` from deploy and Terraform PR plan workflows (no `GHCR_USERNAME` / `GHCR_PASSWORD` for Terraform).
- Update `infra/README.md` to note public GHCR pulls and include otel-collector in the image list.

Made with [Cursor](https://cursor.com)