### PR TITLE
Fix connector UI regressions

### DIFF
--- a/apps/ui/src/features/connectors/components/AddConnectorCatalogDialog.tsx
+++ b/apps/ui/src/features/connectors/components/AddConnectorCatalogDialog.tsx
@@ -22,21 +22,26 @@ export function AddConnectorCatalogDialog({
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       isDismissable
-      size="wide"
+      className="max-w-[min(92vw,640px)]"
     >
-      <div className="px-6 py-5">
+      <div className="p-6">
         <div className="mb-5 flex items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-zinc-100">
+            <h2 className="text-lg font-medium tracking-tight text-foreground">
               Add connection
             </h2>
-            <p className="mt-1 text-sm text-zinc-400">
-              Choose a source to connect to this organization.
+            <p className="mt-2 text-sm text-muted-foreground">
+              Choose a source to connect to this organisation.
             </p>
           </div>
-          <Button variant="ghost" onPress={() => onOpenChange(false)}>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="rounded-none"
+            aria-label="Close"
+            onPress={() => onOpenChange(false)}
+          >
             <IconX className="size-4 shrink-0" aria-hidden />
-            Close
           </Button>
         </div>
 

--- a/apps/ui/src/features/connectors/components/AddGithubConnectorButton.tsx
+++ b/apps/ui/src/features/connectors/components/AddGithubConnectorButton.tsx
@@ -103,7 +103,7 @@ export function AddGithubConnectorButton({
         </span>
         <span className="mt-1 block text-sm text-zinc-400">
           Connect the GitHub App, then choose which repositories ctx| ingests
-          for this organization.
+          for this organisation.
         </span>
       </span>
     </button>

--- a/apps/ui/src/features/connectors/components/ConfluenceConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/ConfluenceConnectionCard.tsx
@@ -125,7 +125,7 @@ export function ConfluenceConnectionCard({
 
   if (isError) {
     return (
-      <Card>
+      <Card size="sm" className="[&>span[aria-hidden]]:hidden">
         <ConfluenceConnectionCardHeader />
         <CardContent className="flex items-start gap-2 pt-0 pb-5 text-sm text-zinc-400">
           <IconAlertCircle
@@ -148,7 +148,7 @@ export function ConfluenceConnectionCard({
 
   if (isPending || !status || oauthPending) {
     return (
-      <Card>
+      <Card size="sm" className="[&>span[aria-hidden]]:hidden">
         <ConfluenceConnectionCardHeader />
         <CardContent className="flex items-center gap-2 pt-0 pb-5 text-sm text-zinc-400">
           <Spinner className="size-4" />
@@ -169,7 +169,7 @@ export function ConfluenceConnectionCard({
 
   return (
     <>
-      <Card className="h-full min-h-0">
+      <Card size="sm" className="h-auto min-h-0 [&>span[aria-hidden]]:hidden">
         <ConfluenceConnectionCardHeader
           menu={
             <DropdownMenu>
@@ -380,7 +380,7 @@ export function ConfluenceConnectionCard({
           onAction={() => removeMutation.mutate()}
         >
           This removes the Forge installation and Confluence scope for this
-          organization. Your Atlassian account may stay linked to your user
+          organisation. Your Atlassian account may stay linked to your user
           profile.
         </AlertDialog>
       </Modal>

--- a/apps/ui/src/features/connectors/components/ConnectorsEmptyState.tsx
+++ b/apps/ui/src/features/connectors/components/ConnectorsEmptyState.tsx
@@ -9,20 +9,27 @@ export function ConnectorsEmptyState({
   onAddConnection,
 }: ConnectorsEmptyStateProps) {
   return (
-    <div className="rounded-lg border border-dashed border-zinc-700 bg-zinc-900/30 px-6 py-12 text-center">
-      <div className="mx-auto flex size-14 items-center justify-center rounded-full bg-zinc-800 text-zinc-400">
-        <IconPlugConnected className="size-8" aria-hidden />
+    <div className="flex min-h-[40vh] flex-col items-center justify-center text-center">
+      <div className="ctx-node mx-auto mb-6 h-10 w-10">
+        <IconPlugConnected
+          className="h-4 w-4 text-muted-foreground"
+          aria-hidden
+        />
       </div>
-      <h2 className="mt-4 text-lg font-semibold text-zinc-100">
+      <h2 className="text-xl font-medium tracking-tight text-foreground">
         No connections yet
       </h2>
-      <p className="mx-auto mt-2 max-w-md text-sm text-zinc-400">
+      <p className="mx-auto mt-3 max-w-md leading-relaxed text-muted-foreground">
         Connections pull docs, wikis, repos, and other sources into ctx| so your
         team loads real data into context—grounding agents and workflows instead
         of relying on whatever happens to be in the thread.
       </p>
       <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
-        <Button variant="primary" onPress={onAddConnection}>
+        <Button
+          variant="primary"
+          className="rounded-none"
+          onPress={onAddConnection}
+        >
           Add connection
         </Button>
       </div>

--- a/apps/ui/src/features/connectors/components/GithubConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/GithubConnectionCard.tsx
@@ -1,21 +1,39 @@
 "use client"
 
-import { IconBrandGithub } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
+import { IconBrandGithub, IconDotsVertical } from "@tabler/icons-react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
+import { useState } from "react"
+import { toast } from "sonner"
+import { AlertDialog } from "@/components/ui/AlertDialog"
 import { Button } from "@/components/ui/Button"
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/Card"
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Modal } from "@/components/ui/Modal"
+import { orgConnectionsKeys } from "../queries/org-connections"
 
 type GithubConnectionCardProps = {
   orgSlug: string
   connectionId: string
+}
+
+async function deleteGithubConnector(
+  orgSlug: string,
+  connectionId: string,
+): Promise<void> {
+  const qs = new URLSearchParams({ connectionId })
+  const res = await fetch(
+    `/${orgSlug}/api/v1/github/installation?${qs.toString()}`,
+    { method: "DELETE", credentials: "include" },
+  )
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(body.error ?? "Failed to remove connector")
+  }
 }
 
 export function GithubConnectionCard({
@@ -23,6 +41,8 @@ export function GithubConnectionCard({
   connectionId,
 }: GithubConnectionCardProps) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [removeOpen, setRemoveOpen] = useState(false)
   const { data: installation, isPending } = useQuery({
     queryKey: ["github-installation", orgSlug, connectionId],
     queryFn: async () => {
@@ -41,22 +61,49 @@ export function GithubConnectionCard({
     },
   })
 
+  const removeMutation = useMutation({
+    mutationFn: () => deleteGithubConnector(orgSlug, connectionId),
+    onSuccess: async () => {
+      toast.success("GitHub connector removed.")
+      await queryClient.invalidateQueries({
+        queryKey: ["github-installation", orgSlug, connectionId],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ["github-installation", orgSlug],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ["github-installation-repos-preview", orgSlug],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ["github-installation-setup", orgSlug],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ["repositories", orgSlug],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: orgConnectionsKeys.list(orgSlug),
+      })
+      setRemoveOpen(false)
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
   const accountDisplay = isPending ? (
-    <span className="text-zinc-400">Loading…</span>
+    <span className="text-muted-foreground">Loading…</span>
   ) : installation ? (
     installation.accountSlug ? (
       installation.accountSlug
     ) : (
-      <span className="text-zinc-400">
+      <span className="text-muted-foreground">
         Installation #{installation.installationId}
       </span>
     )
   ) : (
-    <span className="text-zinc-400">Not linked</span>
+    <span className="text-muted-foreground">Not linked</span>
   )
 
   const repositoriesDisplay = isPending ? (
-    <span className="text-zinc-400">Loading…</span>
+    <span className="text-muted-foreground">Loading…</span>
   ) : installation ? (
     <span className="tabular-nums">
       {typeof installation.ingestionRepositoryCount === "number" &&
@@ -65,46 +112,93 @@ export function GithubConnectionCard({
         : "0"}
     </span>
   ) : (
-    <span className="text-zinc-400">—</span>
+    <span className="text-muted-foreground">—</span>
   )
 
   return (
-    <Card className="h-full min-h-0 rounded-none">
-      <CardHeader className="shrink-0 flex flex-row items-start gap-3 space-y-0 rounded-none">
-        <div className="flex min-w-0 gap-4">
-          <IconBrandGithub className="size-10 shrink-0 text-zinc-100" />
-          <div className="min-w-0 space-y-1 -mt-1">
-            <CardTitle>GitHub</CardTitle>
-            <CardDescription>
-              GitHub App installation for repository access and ingestion.
-            </CardDescription>
+    <>
+      <article className="flex min-h-0 flex-col border border-border bg-transparent px-5 py-4 text-sm">
+        <header className="flex shrink-0 items-start justify-between gap-3">
+          <div className="flex min-w-0 gap-3">
+            <span className="ctx-node h-9 w-9">
+              <IconBrandGithub className="h-4 w-4 text-foreground" />
+            </span>
+            <div className="min-w-0 space-y-1">
+              <h2 className="font-medium text-foreground">GitHub</h2>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                GitHub App installation for repository access and ingestion.
+              </p>
+            </div>
+          </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <button
+                  type="button"
+                  aria-label="Connector actions"
+                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-none text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+                >
+                  <IconDotsVertical className="size-4" aria-hidden />
+                </button>
+              }
+            />
+            <DropdownMenuContent align="end" className="min-w-40">
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => setRemoveOpen(true)}
+              >
+                Remove connector
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </header>
+        <div className="mt-5 flex min-h-0 flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+          <dl className="grid min-w-0 flex-1 grid-cols-2 gap-4">
+            <div className="min-w-0">
+              <dt className="text-sm font-medium text-muted-foreground">
+                Account
+              </dt>
+              <dd className="mt-1 text-sm text-foreground">{accountDisplay}</dd>
+            </div>
+            <div className="min-w-0">
+              <dt className="text-sm font-medium text-muted-foreground">
+                Repositories
+              </dt>
+              <dd className="mt-1 text-sm text-foreground">
+                {repositoriesDisplay}
+              </dd>
+            </div>
+          </dl>
+          <div className="flex shrink-0 flex-wrap justify-end gap-2">
+            <Button
+              variant="outline"
+              className="rounded-none"
+              onPress={() => {
+                void navigate({
+                  to: "/$orgSlug/repositories",
+                  params: { orgSlug },
+                })
+              }}
+            >
+              Manage repositories
+            </Button>
           </div>
         </div>
-      </CardHeader>
-      <CardContent className="min-h-0 flex-1 space-y-4 py-0">
-        <dl className="flex flex-col gap-4">
-          <div className="min-w-0">
-            <dt className="text-sm font-medium text-zinc-500">Account</dt>
-            <dd className="mt-1 text-sm text-zinc-100">{accountDisplay}</dd>
-          </div>
-          <div className="min-w-0">
-            <dt className="text-sm font-medium text-zinc-500">Repositories</dt>
-            <dd className="mt-1 text-sm text-zinc-100">
-              {repositoriesDisplay}
-            </dd>
-          </div>
-        </dl>
-      </CardContent>
-      <CardFooter className="mt-auto shrink-0 flex flex-wrap justify-end gap-2">
-        <Button
-          variant="outline"
-          onPress={() => {
-            void navigate({ to: "/$orgSlug/repositories", params: { orgSlug } })
-          }}
+      </article>
+
+      <Modal isOpen={removeOpen} onOpenChange={setRemoveOpen} isDismissable>
+        <AlertDialog
+          title="Remove GitHub connector?"
+          variant="destructive"
+          actionLabel="Remove connector"
+          cancelLabel="Cancel"
+          onAction={() => removeMutation.mutate()}
         >
-          Manage repositories
-        </Button>
-      </CardFooter>
-    </Card>
+          This unlinks the GitHub App installation from ctxpipe. Existing
+          repositories stay in ctxpipe, but they will no longer be managed by
+          this connector. The GitHub App remains installed in GitHub.
+        </AlertDialog>
+      </Modal>
+    </>
   )
 }

--- a/apps/ui/src/features/connectors/components/confluence-setup/ConfluenceSetupWizard.tsx
+++ b/apps/ui/src/features/connectors/components/confluence-setup/ConfluenceSetupWizard.tsx
@@ -161,20 +161,24 @@ export function ConfluenceSetupWizard({
         onOpenChange(open)
       }}
       isDismissable
-      size="wide"
+      className="max-w-[min(92vw,720px)]"
     >
-      <div className="px-6 py-5">
+      <div className="p-6">
         <div className="mb-5 flex items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-zinc-100">
+            <h2 className="text-lg font-medium tracking-tight text-foreground">
               Set up Atlassian connector
             </h2>
-            <p className="mt-1 text-sm text-zinc-400">
+            <p className="mt-2 text-sm text-muted-foreground">
               Complete each step to connect Confluence content to this
-              organization.
+              organisation.
             </p>
           </div>
-          <Button variant="secondary" onPress={() => onOpenChange(false)}>
+          <Button
+            variant="secondary"
+            className="rounded-none"
+            onPress={() => onOpenChange(false)}
+          >
             Close
           </Button>
         </div>

--- a/apps/ui/src/routes/$orgSlug.connectors.tsx
+++ b/apps/ui/src/routes/$orgSlug.connectors.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, Navigate, useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { AppShell } from "@/components/AppShell"
 import { Button } from "@/components/ui/Button"
+import { InlineLoader } from "@/components/ui/InlineLoader"
 import { Modal } from "@/components/ui/Modal"
 import { Spinner } from "@/components/ui/spinner"
 import {
@@ -48,8 +49,8 @@ function ConnectorsPage() {
   if (sessionPending) {
     return (
       <AppShell>
-        <main className="mx-auto flex max-w-5xl items-center justify-center px-2 py-16 sm:px-6">
-          <Spinner className="text-zinc-400" />
+        <main className="mx-auto flex w-full max-w-2xl items-center justify-center p-8">
+          <Spinner className="text-muted-foreground" />
         </main>
       </AppShell>
     )
@@ -115,48 +116,53 @@ export function ConnectorsPageContent({ orgSlug }: { orgSlug: string }) {
 
   return (
     <AppShell>
-      <main className="mx-auto max-w-5xl px-2 py-2 text-zinc-100 sm:px-6 sm:py-10">
+      <main className="mx-auto box-border flex min-h-full w-full max-w-2xl flex-col p-8 text-foreground">
         {errorBanner ? (
-          <div className="mb-6">
-            <ConnectorsOAuthErrorBanner
-              title={errorBanner.title}
-              description={errorBanner.description}
-            />
-          </div>
+          <ConnectorsOAuthErrorBanner
+            title={errorBanner.title}
+            description={errorBanner.description}
+          />
         ) : null}
+        <header className="mb-8">
+          <span className="font-mono text-xs uppercase tracking-[0.24em] text-teal-400">
+            Connectors
+          </span>
+        </header>
 
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="min-w-0 space-y-2">
-            <h1 className="text-2xl font-semibold text-zinc-50">Connectors</h1>
-            <p className="text-sm text-zinc-400">
-              Connect external tools and choose what content ctxpipe should
-              ingest.
-            </p>
+        <section>
+          <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between sm:gap-8">
+            <div className="min-w-0 flex-1">
+              <h1 className="text-3xl font-medium tracking-tight text-foreground">
+                Connectors
+              </h1>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                Connect external tools and choose what content ctxpipe should
+                ingest.
+              </p>
+            </div>
+            {!showEmptyState ? (
+              <div className="flex shrink-0 flex-wrap items-center gap-2 sm:pt-1">
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  className="rounded-none"
+                  aria-label="Add connection"
+                  onPress={() => setCatalogOpen(true)}
+                >
+                  <IconPlus className="size-5" aria-hidden />
+                </Button>
+              </div>
+            ) : null}
           </div>
-          {!showEmptyState ? (
-            <Button
-              variant="secondary"
-              size="icon"
-              aria-label="Add connection"
-              onPress={() => setCatalogOpen(true)}
-            >
-              <IconPlus className="size-5" aria-hidden />
-            </Button>
-          ) : null}
-        </div>
+        </section>
 
-        <section className="mt-8 grid min-h-0 grid-cols-1 items-stretch gap-8 *:min-h-0 lg:grid-cols-2">
+        <section className="mt-12 flex min-h-0 flex-col gap-3">
           {showPageLoading ? (
-            <div className="flex items-center gap-2 text-sm text-zinc-400 lg:col-span-2">
-              <Spinner className="size-4" />
-              Loading connections…
-            </div>
+            <InlineLoader label="Loading connectors" />
           ) : showEmptyState ? (
-            <div className="lg:col-span-2">
-              <ConnectorsEmptyState
-                onAddConnection={() => setCatalogOpen(true)}
-              />
-            </div>
+            <ConnectorsEmptyState
+              onAddConnection={() => setCatalogOpen(true)}
+            />
           ) : (
             items.map((row) =>
               row.type === "forge" ? (


### PR DESCRIPTION
## Summary

Restores the connector UI polish on top of the latest `main` after the newer connector/Confluence changes regressed the page styling.

- Aligns the Connectors page with the Repositories page layout: narrow container, teal uppercase section label, and inline loader.
- Simplifies and compacts connector cards, including restoring GitHub connector actions with `Remove connector`.
- Narrows connector modals and restores UK English copy.
- Restores the original unframed empty state so it no longer looks like a drag-and-drop zone.

## Validation

- `pnpm exec biome check --write ...`
- `pnpm --filter @ctxpipe/ui build`
- `pnpm --filter @ctxpipe/backend exec vitest run src/routes/v1/github-installation.test.ts`
- `git diff --check`

## Alignment

Branch is aligned with latest `origin/main` (`ddfdc52`) and targets `main`. Head is `32dbc0e`.