### PR TITLE
fix(backend): improve MCP OAuth discovery for Codex Desktop

### DIFF
--- a/apps/backend/src/auth/withAuth.test.ts
+++ b/apps/backend/src/auth/withAuth.test.ts
@@ -519,10 +519,23 @@ describe("auth middleware composition", () => {
     const response = await app.request("/mcp", { method: "POST" })
     expect(response.status).toBe(401)
     const www = response.headers.get("WWW-Authenticate")
+    expect(www).not.toContain("error=")
     expect(www).toContain("resource_metadata=")
     expect(www).toContain(
       mcpOAuthProtectedResourceMetadataUrl("https://backend.example.com"),
     )
+  })
+
+  it("requireAuth on /mcp with non-empty Bearer uses invalid_token in WWW-Authenticate", async () => {
+    const app = createBaseApp()
+    app.use("/mcp", requireAuth)
+    app.post("/mcp", (c) => c.text("ok"))
+    const response = await app.request("/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer opaque-but-unverified" },
+    })
+    expect(response.status).toBe(401)
+    expect(response.headers.get("WWW-Authenticate")).toContain('error="invalid_token"')
   })
 
   it("requireAuth on non-MCP path omits resource_metadata", async () => {

--- a/apps/backend/src/auth/withAuth.ts
+++ b/apps/backend/src/auth/withAuth.ts
@@ -82,13 +82,40 @@ function wwwAuthenticateInvalidTokenMcp(
   }
 }
 
+/**
+ * RFC 6750: when the client sent no credentials, the resource server must not put
+ * `error` / `error_description` on `WWW-Authenticate`. Some OAuth/OIDC clients
+ * (including remote MCP hosts) only start the authorization code flow when they
+ * see a bare `Bearer` challenge plus `resource_metadata`.
+ */
+function wwwAuthenticateMcpDiscovery(authBaseUrl: string): Record<string, string> {
+  const meta = mcpOAuthProtectedResourceMetadataUrl(authBaseUrl)
+  const metaEsc = meta.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+  return {
+    "WWW-Authenticate": `Bearer resource_metadata="${metaEsc}"`,
+  }
+}
+
+type WwwAuthMcpKind = "invalid_token" | "discovery"
+
 function wwwAuthenticateForMcpRoute(
   c: { req: { path: string }; var: { env: AppEnv["Variables"]["env"] } },
   errorDescription: string,
+  kind: WwwAuthMcpKind = "invalid_token",
 ): Record<string, string> {
-  return isMcpRequestPath(c.req.path)
-    ? wwwAuthenticateInvalidTokenMcp(errorDescription, c.var.env.AUTH_BASE_URL)
-    : wwwAuthenticateInvalidToken(errorDescription)
+  if (!isMcpRequestPath(c.req.path)) {
+    return wwwAuthenticateInvalidToken(errorDescription)
+  }
+  if (kind === "discovery") {
+    return wwwAuthenticateMcpDiscovery(c.var.env.AUTH_BASE_URL)
+  }
+  return wwwAuthenticateInvalidTokenMcp(errorDescription, c.var.env.AUTH_BASE_URL)
+}
+
+function requestHasBearerCredential(raw: Request): boolean {
+  const h = raw.headers.get("authorization")
+  if (!h?.startsWith("Bearer ")) return false
+  return h.slice("Bearer ".length).trim().length > 0
 }
 
 function logBearerAuthFailure(
@@ -394,10 +421,14 @@ export const withBearerAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
 export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   if (!c.get("user") || !c.get("session")) {
     getLogger().warn("Unauthorized because of no session")
+    const mcpKind: WwwAuthMcpKind =
+      isMcpRequestPath(c.req.path) && !requestHasBearerCredential(c.req.raw)
+        ? "discovery"
+        : "invalid_token"
     return c.json(
       { error: "Unauthorized" },
       401,
-      wwwAuthenticateForMcpRoute(c, "Authentication required"),
+      wwwAuthenticateForMcpRoute(c, "Authentication required", mcpKind),
     )
   }
   return next()

--- a/apps/backend/src/routes/auth.test.ts
+++ b/apps/backend/src/routes/auth.test.ts
@@ -59,6 +59,15 @@ describe("auth metadata routes", () => {
     expect(body.authorization_servers).toEqual(["https://auth.example.com"])
   })
 
+  it("serves the same MCP protected-resource document at the RFC 9728 root path", async () => {
+    const app = await createTestApp()
+    const root = await app.request("/.well-known/oauth-protected-resource")
+    const mcp = await app.request("/.well-known/oauth-protected-resource/mcp")
+    expect(root.status).toBe(200)
+    expect(mcp.status).toBe(200)
+    expect(await root.text()).toBe(await mcp.text())
+  })
+
   it("serves authorization server metadata at RFC 8414 path-inserted /.well-known URLs", async () => {
     const app = await createTestApp()
     const oauthRoot = await app.request("/.well-known/oauth-authorization-server")

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -12,9 +12,6 @@ import { getAuth } from "../auth/config.js"
 import { getSystemDb } from "../db/client.js"
 import { invitations, organizations } from "../db/schema/auth.js"
 
-const PROTECTED_RESOURCE_CACHE_CONTROL =
-  "public, max-age=15, stale-while-revalidate=15, stale-if-error=86400"
-
 function isNonEmptyStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) &&
@@ -139,7 +136,8 @@ export function registerAuthRoutes(app: Hono<AppEnv>) {
   const serveMcpProtectedResourceMetadata = async (c: Context<AppEnv>) => {
     const metadata = await getMcpProtectedResourceMetadata(c, auth, serverClient)
     return c.json(metadata, 200, {
-      "Cache-Control": PROTECTED_RESOURCE_CACHE_CONTROL,
+      "Cache-Control":
+        "public, max-age=15, stale-while-revalidate=15, stale-if-error=86400",
     })
   }
 

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -5,12 +5,55 @@ import {
 import { oauthProviderResourceClient } from "@better-auth/oauth-provider/resource-client"
 import { createAuthClient } from "better-auth/client"
 import { and, eq, gt } from "drizzle-orm"
-import type { Hono } from "hono"
+import type { Context } from "hono"
 import type { AppEnv } from "../app/env.js"
 import { atlassianLinkCallbackFirst } from "../auth/atlassian-link-callback.js"
 import { getAuth } from "../auth/config.js"
 import { getSystemDb } from "../db/client.js"
 import { invitations, organizations } from "../db/schema/auth.js"
+
+const PROTECTED_RESOURCE_CACHE_CONTROL =
+  "public, max-age=15, stale-while-revalidate=15, stale-if-error=86400"
+
+function isNonEmptyStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => typeof item === "string")
+  )
+}
+
+async function getMcpProtectedResourceMetadata(
+  c: { var: AppEnv["Variables"] },
+  auth: ReturnType<typeof getAuth>,
+  serverClient: ReturnType<typeof createAuthClient>,
+): Promise<Record<string, unknown>> {
+  const authorizationServer = c.var.env.AUTH_ISSUER ?? c.var.env.AUTH_BASE_URL
+  const authServerRes = await oauthProviderAuthServerMetadata(auth)(c.req.raw)
+  let authServerMeta: Record<string, unknown> = {}
+  if (authServerRes.ok) {
+    try {
+      authServerMeta = (await authServerRes.json()) as Record<string, unknown>
+    } catch {
+      authServerMeta = {}
+    }
+  }
+
+  const metadata = await serverClient.getProtectedResourceMetadata({
+    resource: `${c.var.env.AUTH_BASE_URL}/mcp`,
+    authorization_servers: [authorizationServer],
+  })
+  const merged: Record<string, unknown> = {
+    ...(metadata as Record<string, unknown>),
+  }
+  if (
+    !isNonEmptyStringArray(merged.scopes_supported) &&
+    isNonEmptyStringArray(authServerMeta.scopes_supported)
+  ) {
+    merged.scopes_supported = authServerMeta.scopes_supported
+  }
+  return merged
+}
 
 export function registerAuthRoutes(app: Hono<AppEnv>) {
   const auth = getAuth()
@@ -93,16 +136,16 @@ export function registerAuthRoutes(app: Hono<AppEnv>) {
     oauthProviderOpenIdConfigMetadata(auth)(c.req.raw),
   )
 
-  app.get("/.well-known/oauth-protected-resource/mcp", async (c) => {
-    const authorizationServer = c.var.env.AUTH_ISSUER ?? c.var.env.AUTH_BASE_URL
-    const metadata = await serverClient.getProtectedResourceMetadata({
-      resource: `${c.var.env.AUTH_BASE_URL}/mcp`,
-      authorization_servers: [authorizationServer],
-    })
+  const serveMcpProtectedResourceMetadata = async (c: Context<AppEnv>) => {
+    const metadata = await getMcpProtectedResourceMetadata(c, auth, serverClient)
     return c.json(metadata, 200, {
-      "Cache-Control":
-        "public, max-age=15, stale-while-revalidate=15, stale-if-error=86400",
+      "Cache-Control": PROTECTED_RESOURCE_CACHE_CONTROL,
     })
-  })
+  }
+
+  // RFC 9728 default path; some MCP clients probe here before path-specific metadata.
+  app.get("/.well-known/oauth-protected-resource", serveMcpProtectedResourceMetadata)
+
+  app.get("/.well-known/oauth-protected-resource/mcp", serveMcpProtectedResourceMetadata)
   return app
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Codex Desktop was probing `/.well-known/oauth-*` successfully but repeatedly POSTing `/mcp` without a session. Public reports ([openai/codex#15643](https://github.com/openai/codex/issues/15643), [openai/codex#18527](https://github.com/openai/codex/issues/18527)) point to client bugs around protected-resource metadata and strict handling of auth challenges.

## Changes

1. **RFC 6750-style `WWW-Authenticate` for unauthenticated `/mcp`** — When there is no non-empty `Authorization: Bearer`, return `Bearer resource_metadata="…"` **without** `error="invalid_token"`. Some MCP hosts only start OAuth when the challenge looks like discovery, not invalid-token.

2. **`scopes_supported` on protected-resource metadata** — After building PRM via Better Auth’s resource client, copy `scopes_supported` from the authorization-server metadata when PRM omits it, so clients that only read PRM scopes (per MCP spec) still get a scope list.

3. **Root PRM alias** — Added `GET /.well-known/oauth-protected-resource` mirroring `/.well-known/oauth-protected-resource/mcp` for clients that probe the default RFC 9728 path first.

## Verification

- [ ] `pnpm --filter @ctxpipe/backend test` (not run in this sandbox — no pnpm in path)
- Codex Desktop: retry remote MCP after deploy; confirm browser OAuth opens after first `401` on `/mcp`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd824355-43bb-4e79-bf8b-a822f09b0215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd824355-43bb-4e79-bf8b-a822f09b0215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

