### PR TITLE
fix(ui): align Atlassian connector modal with GitHub styling (CTX-103)

### DIFF
--- a/apps/ui/src/components/ui/Disclosure.tsx
+++ b/apps/ui/src/components/ui/Disclosure.tsx
@@ -18,17 +18,17 @@ import { Button } from "@/components/ui/Button"
 import { composeTailwindRenderProps } from "@/lib/react-aria-utils"
 
 const disclosure = tv({
-  base: "group min-w-50 font-sans rounded-lg text-neutral-900 dark:text-neutral-200",
+  base: "group min-w-50 font-sans rounded-none text-foreground",
 })
 
 const chevron = tv({
-  base: "w-4 h-4 text-neutral-500 dark:text-neutral-400 transition-transform duration-200 ease-in-out",
+  base: "w-4 h-4 text-muted-foreground transition-transform duration-200 ease-in-out",
   variants: {
     isExpanded: {
       true: "transform rotate-90",
     },
     isDisabled: {
-      true: "text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]",
+      true: "text-muted-foreground/50 forced-colors:text-[GrayText]",
     },
   },
 })
@@ -53,8 +53,8 @@ export function Disclosure({ children, ...props }: DisclosureProps) {
 export interface DisclosureHeaderProps {
   children: React.ReactNode
   /**
-   * When set, show this label in a small pill on the right instead of the
-   * expand chevron. The main `children` remain the control’s accessible name.
+   * When set, show this label on the right instead of the expand chevron. The main
+   * `children` remain the control’s accessible name.
    */
   trailingPill?: string
 }
@@ -69,11 +69,11 @@ export function DisclosureHeader({
   }
   const { isExpanded } = state
   return (
-    <Heading className="m-0 text-sm font-medium text-zinc-300">
+    <Heading className="m-0 text-sm font-medium text-foreground">
       <Button
         slot="trigger"
-        variant="quiet"
-        className="flex h-auto min-h-0 w-full items-center justify-between gap-2 px-0 py-1.5 text-left text-sm font-medium text-inherit"
+        variant="ghost"
+        className="group flex h-auto min-h-0 w-full items-center justify-between gap-2 rounded-none px-2 py-1.5 text-left text-sm font-medium text-inherit"
       >
         {({ isDisabled }) => (
           <>
@@ -81,7 +81,7 @@ export function DisclosureHeader({
             {trailingPill != null && trailingPill !== "" ? (
               <span
                 aria-hidden
-                className="shrink-0 rounded-full border border-zinc-600/90 bg-zinc-900/60 px-2 py-0.5 text-xs font-medium text-zinc-400"
+                className="shrink-0 rounded-none border border-border bg-muted/50 px-2 py-0.5 text-xs font-medium text-muted-foreground transition group-hover:bg-foreground/[0.06] group-hover:text-foreground"
               >
                 {trailingPill}
               </span>

--- a/apps/ui/src/features/connectors/components/AddConfluenceConnectorButton.tsx
+++ b/apps/ui/src/features/connectors/components/AddConfluenceConnectorButton.tsx
@@ -33,20 +33,22 @@ export function AddConfluenceConnectorButton({
     <button
       type="button"
       disabled={mutation.isPending}
-      className="flex w-full items-start gap-4 rounded-none border border-zinc-800 bg-zinc-900/40 p-4 text-left outline-none transition hover:border-zinc-700 hover:bg-zinc-900/70 focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-wait disabled:opacity-60"
+      className="group flex w-full items-start gap-4 rounded-none border border-border bg-card/40 p-4 text-left outline-none transition-colors hover:border-teal-400/40 hover:bg-foreground/[0.03] focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-wait disabled:opacity-60"
       onClick={() => {
         void mutation.mutateAsync()
       }}
     >
-      <ConfluenceMark className="size-12 shrink-0" />
+      <span className="ctx-node size-12 transition-colors group-hover:border-teal-400/60 group-hover:bg-teal-400/5">
+        <ConfluenceMark className="size-6 text-foreground" variant="outline" />
+      </span>
       <span className="min-w-0">
-        <span className="flex items-center gap-2 font-medium text-zinc-100">
+        <span className="flex items-center gap-2 font-medium text-foreground">
           Atlassian Confluence
           {mutation.isPending ? (
-            <Spinner className="size-4 text-zinc-400" aria-hidden />
+            <Spinner className="size-4 text-muted-foreground" aria-hidden />
           ) : null}
         </span>
-        <span className="mt-1 block text-sm text-zinc-400">
+        <span className="mt-1 block text-sm text-muted-foreground">
           Sync spaces and pages from Confluence into ctxpipe and your linked Git
           repositories.
         </span>

--- a/apps/ui/src/features/connectors/components/AtlassianOauthAppSavedSection.tsx
+++ b/apps/ui/src/features/connectors/components/AtlassianOauthAppSavedSection.tsx
@@ -81,12 +81,12 @@ export function AtlassianOauthAppSavedSection({
       className={
         embedded
           ? "max-w-lg space-y-3"
-          : "max-w-lg space-y-3 rounded-md border border-zinc-800 p-4"
+          : "max-w-lg space-y-3 rounded-none border border-border p-4"
       }
     >
-      <div className="space-y-2 text-sm text-zinc-400">
+      <div className="space-y-2 text-sm text-muted-foreground">
         {hideSavedHeading ? null : (
-          <p className="font-medium text-zinc-100">
+          <p className="font-medium text-foreground">
             OAuth (3LO) app is configured for this connection.
           </p>
         )}
@@ -94,7 +94,7 @@ export function AtlassianOauthAppSavedSection({
           <p>
             Client ID:{" "}
             <code
-              className="break-all rounded bg-zinc-800/70 px-1.5 py-0.5 font-mono text-zinc-200"
+              className="break-all rounded-none bg-muted/80 px-1.5 py-0.5 font-mono text-foreground"
               title={savedClientId}
             >
               {savedClientId}
@@ -106,7 +106,7 @@ export function AtlassianOauthAppSavedSection({
             id could not be read. You can re-enter the client id below.
           </p>
         )}
-        <p className="text-zinc-500">
+        <p className="text-muted-foreground">
           The client secret is stored on the server and is never returned. To
           rotate it, enter a new secret below. To only change the client id,
           update the field and save without a new secret.
@@ -133,6 +133,7 @@ export function AtlassianOauthAppSavedSection({
         />
         <Button
           variant="secondary"
+          className="rounded-none"
           isPending={save.isPending}
           onPress={() => {
             if (!clientId.trim()) return
@@ -142,7 +143,7 @@ export function AtlassianOauthAppSavedSection({
           Update OAuth app
         </Button>
         {save.error ? (
-          <p className="text-sm text-red-400">{save.error.message}</p>
+          <p className="text-sm text-destructive">{save.error.message}</p>
         ) : null}
       </div>
     </div>

--- a/apps/ui/src/features/connectors/components/ConfluenceConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/ConfluenceConnectionCard.tsx
@@ -63,16 +63,21 @@ type ConfluenceConnectionCardProps = {
 function ConfluenceConnectionCardHeader({ menu }: { menu?: ReactNode }) {
   return (
     <CardHeader className="shrink-0 flex flex-row items-start justify-between gap-3 space-y-0">
-      <div className="flex min-w-0 gap-4">
-        <ConfluenceMark className="size-10" />
-        <div className="min-w-0 space-y-1 -mt-1">
+      <div className="flex min-w-0 gap-3">
+        <span className="ctx-node h-9 w-9">
+          <ConfluenceMark
+            className="size-5 text-foreground"
+            variant="outline"
+          />
+        </span>
+        <div className="min-w-0 space-y-1">
           <CardTitle>Atlassian Confluence</CardTitle>
           <CardDescription>
             Sync spaces and pages from your Confluence instance.
           </CardDescription>
         </div>
       </div>
-      {menu ?? <span className="inline-flex h-9 w-9 shrink-0" aria-hidden />}
+      {menu ?? <span className="inline-flex h-8 w-8 shrink-0" aria-hidden />}
     </CardHeader>
   )
 }
@@ -183,7 +188,7 @@ export function ConfluenceConnectionCard({
                   <button
                     type="button"
                     aria-label="Connector actions"
-                    className="inline-flex h-9 w-9 shrink-0 items-center justify-center text-zinc-400 transition-colors hover:bg-white/[0.06] hover:text-zinc-100"
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-none text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
                   >
                     <IconDotsVertical className="size-5" aria-hidden />
                   </button>
@@ -361,6 +366,7 @@ export function ConfluenceConnectionCard({
         <CardFooter className="mt-auto shrink-0 flex flex-wrap justify-end gap-2">
           <Button
             variant="outline"
+            className="rounded-none"
             onPress={() => {
               if (primary.kind === "open_wizard") onOpenWizard()
               else if (primary.kind === "navigate_repositories") {

--- a/apps/ui/src/features/connectors/components/ConfluenceMark.tsx
+++ b/apps/ui/src/features/connectors/components/ConfluenceMark.tsx
@@ -1,8 +1,16 @@
 import { useId } from "react"
 import { cn } from "@/lib/utils"
 
+type ConfluenceMarkProps = {
+  className?: string
+  variant?: "brand" | "outline"
+}
+
 /** Confluence product mark (icon only) from Atlassian brand SVG. */
-export function ConfluenceMark({ className }: { className?: string }) {
+export function ConfluenceMark({
+  className,
+  variant = "brand",
+}: ConfluenceMarkProps) {
   const rawId = useId().replace(/:/g, "")
   const gradA = `${rawId}-cf-a`
   const gradB = `${rawId}-cf-b`
@@ -17,35 +25,45 @@ export function ConfluenceMark({ className }: { className?: string }) {
       aria-label="Confluence"
     >
       <title>Confluence</title>
-      <defs>
-        <linearGradient
-          id={gradA}
-          gradientUnits="userSpaceOnUse"
-          x1="59.68"
-          x2="20.35"
-          y1="67.65"
-          y2="45.05"
-        >
-          <stop offset=".18" stopColor="#0052cc" />
-          <stop offset="1" stopColor="#2684ff" />
-        </linearGradient>
-        <linearGradient
-          id={gradB}
-          gradientUnits="userSpaceOnUse"
-          gradientTransform="matrix(-1 0 0 -1 282.83 -1616.71)"
-          href={`#${gradA}`}
-          x1="279.76"
-          x2="240.42"
-          y1="-1616.34"
-          y2="-1638.95"
-        />
-      </defs>
+      {variant === "brand" ? (
+        <defs>
+          <linearGradient
+            id={gradA}
+            gradientUnits="userSpaceOnUse"
+            x1="59.68"
+            x2="20.35"
+            y1="67.65"
+            y2="45.05"
+          >
+            <stop offset=".18" stopColor="#0052cc" />
+            <stop offset="1" stopColor="#2684ff" />
+          </linearGradient>
+          <linearGradient
+            id={gradB}
+            gradientUnits="userSpaceOnUse"
+            gradientTransform="matrix(-1 0 0 -1 282.83 -1616.71)"
+            href={`#${gradA}`}
+            x1="279.76"
+            x2="240.42"
+            y1="-1616.34"
+            y2="-1638.95"
+          />
+        </defs>
+      ) : null}
       <path
-        fill={`url(#${gradA})`}
+        fill={variant === "brand" ? `url(#${gradA})` : "none"}
+        stroke={variant === "outline" ? "currentColor" : undefined}
+        strokeLinecap={variant === "outline" ? "round" : undefined}
+        strokeLinejoin={variant === "outline" ? "round" : undefined}
+        strokeWidth={variant === "outline" ? 4 : undefined}
         d="m2.23 49.53c-.65 1.06-1.38 2.29-2 3.27a2 2 0 0 0 .67 2.72l13 8a2 2 0 0 0 2.77-.68c.52-.87 1.19-2 1.92-3.21 5.15-8.5 10.33-7.46 19.67-3l12.89 6.13a2 2 0 0 0 2.69-1l6.19-14a2 2 0 0 0 -1-2.62c-2.72-1.28-8.13-3.83-13-6.18-17.52-8.51-32.41-7.96-43.8 10.57z"
       />
       <path
-        fill={`url(#${gradB})`}
+        fill={variant === "brand" ? `url(#${gradB})` : "none"}
+        stroke={variant === "outline" ? "currentColor" : undefined}
+        strokeLinecap={variant === "outline" ? "round" : undefined}
+        strokeLinejoin={variant === "outline" ? "round" : undefined}
+        strokeWidth={variant === "outline" ? 4 : undefined}
         d="m60.52 17.76c.65-1.06 1.38-2.29 2-3.27a2 2 0 0 0 -.67-2.72l-13-8a2 2 0 0 0 -2.85.66c-.52.87-1.19 2-1.92 3.21-5.15 8.5-10.33 7.46-19.67 3l-12.85-6.1a2 2 0 0 0 -2.69 1l-6.19 14a2 2 0 0 0 1 2.62c2.72 1.28 8.13 3.83 13 6.18 17.56 8.5 32.45 7.93 43.84-10.58z"
       />
     </svg>

--- a/apps/ui/src/features/connectors/components/ConfluenceStepper.tsx
+++ b/apps/ui/src/features/connectors/components/ConfluenceStepper.tsx
@@ -1,4 +1,4 @@
-import { IconCircleCheckFilled } from "@tabler/icons-react"
+import { IconCheck } from "@tabler/icons-react"
 import type { ConfluenceWizardStepDef } from "../confluence-setup-model"
 
 type StepVisualState = "done" | "current" | "upcoming" | "done_after"
@@ -57,25 +57,27 @@ export function ConfluenceStepper({
 
         const labelClasses =
           state === "upcoming"
-            ? "text-zinc-500"
+            ? "text-muted-foreground"
             : state === "current"
-              ? "font-medium text-zinc-100"
+              ? "font-medium text-foreground"
               : state === "done_after"
-                ? "text-zinc-400"
-                : "text-zinc-300"
+                ? "text-muted-foreground"
+                : "text-muted-foreground"
 
         const icon =
           state === "done" || state === "done_after" ? (
-            <IconCircleCheckFilled
-              className={`size-5 text-emerald-500 ${state === "done_after" ? "opacity-60" : ""}`}
+            <span
+              className={`flex size-5 shrink-0 items-center justify-center rounded-none border border-emerald-500 bg-zinc-900 ${state === "done_after" ? "opacity-60" : ""}`}
               aria-hidden
-            />
+            >
+              <IconCheck className="size-3.5 text-emerald-500" stroke={2.5} />
+            </span>
           ) : (
             <span
               className={
                 state === "current"
-                  ? "flex size-5 items-center justify-center rounded-full border border-primary bg-zinc-900 text-xs font-medium text-primary"
-                  : "flex size-5 items-center justify-center rounded-full border border-zinc-600 text-xs text-zinc-500"
+                  ? "flex size-5 shrink-0 items-center justify-center rounded-none border border-primary bg-zinc-900 text-xs font-medium text-primary"
+                  : "flex size-5 shrink-0 items-center justify-center rounded-none border border-zinc-600 bg-zinc-900 text-xs text-muted-foreground"
               }
             >
               {i + 1}
@@ -96,7 +98,7 @@ export function ConfluenceStepper({
             {isInteractive ? (
               <button
                 type="button"
-                className={`flex w-full min-w-0 gap-3 rounded-md text-left outline-none transition hover:bg-zinc-900/60 focus-visible:ring-2 focus-visible:ring-primary/50 ${state === "done_after" ? "opacity-90" : ""}`}
+                className={`flex w-full min-w-0 gap-3 rounded-none text-left outline-none transition hover:bg-foreground/[0.06] focus-visible:ring-2 focus-visible:ring-primary/50 ${state === "done_after" ? "opacity-90" : ""}`}
                 onClick={() => onStepSelect(i)}
               >
                 <span className="mt-0.5 shrink-0">{icon}</span>

--- a/apps/ui/src/features/connectors/components/ConnectorsEmptyState.tsx
+++ b/apps/ui/src/features/connectors/components/ConnectorsEmptyState.tsx
@@ -26,7 +26,7 @@ export function ConnectorsEmptyState({
       </p>
       <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
         <Button
-          variant="primary"
+          variant="outline"
           className="rounded-none"
           onPress={onAddConnection}
         >

--- a/apps/ui/src/features/connectors/components/OrgAtlassianOauthPanel.tsx
+++ b/apps/ui/src/features/connectors/components/OrgAtlassianOauthPanel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { IconCopy } from "@tabler/icons-react"
+import { IconCheck, IconCopy } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { Button } from "@/components/ui/Button"
@@ -46,8 +46,8 @@ function AtlassianThreeLoSetupGuide({
     }
   }
 
-  const code = (ch: string) => (
-    <code className="rounded bg-zinc-800/70 px-1 py-0.5 font-mono text-[0.8125rem] text-zinc-200">
+  const scopeCode = (ch: string) => (
+    <code className="rounded-none bg-muted/80 px-1 py-0.5 font-mono text-[0.8125rem] text-foreground">
       {ch}
     </code>
   )
@@ -59,7 +59,7 @@ function AtlassianThreeLoSetupGuide({
           Go to the{" "}
           <a
             href="https://developer.atlassian.com/console/myapps/create-3lo-app"
-            className="text-teal-500 underline-offset-2 hover:underline"
+            className="text-primary underline-offset-2 hover:underline"
             target="_blank"
             rel="noreferrer"
           >
@@ -69,75 +69,95 @@ function AtlassianThreeLoSetupGuide({
         </li>
         <li>
           Open{" "}
-          <strong className="font-medium text-zinc-300">Authorization</strong> →{" "}
-          <strong className="font-medium text-zinc-300">OAuth 2.0 (3LO)</strong>{" "}
-          → <strong className="font-medium text-zinc-300">Add</strong>. Paste
+          <strong className="font-medium text-foreground">Authorization</strong>{" "}
+          →{" "}
+          <strong className="font-medium text-foreground">
+            OAuth 2.0 (3LO)
+          </strong>{" "}
+          → <strong className="font-medium text-foreground">Add</strong>. Paste
           this callback URL, then save.
-          <div className="mt-2 flex flex-wrap items-stretch gap-2">
-            <code className="min-w-0 flex-1 break-all rounded-md border border-zinc-700 bg-zinc-900/60 px-2 py-2 font-mono text-xs text-zinc-200">
-              {callbackDisplay}
-            </code>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon-sm"
-              className="shrink-0"
-              aria-label={
-                copyState === "copied"
-                  ? "Callback URL copied"
-                  : "Copy callback URL"
-              }
-              title={
-                copyState === "copied"
-                  ? "Copied"
-                  : copyState === "error"
-                    ? "Copy failed"
+          <div className="mt-2 flex w-full min-w-0 items-stretch overflow-hidden rounded-md border border-border bg-muted/50">
+            <div className="flex min-h-10 min-w-0 flex-1 items-center overflow-x-auto px-2">
+              <code className="break-all font-mono text-sm text-muted-foreground">
+                {callbackDisplay}
+              </code>
+            </div>
+            <div className="flex shrink-0 items-stretch border-l border-border">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className={
+                  copyState === "copied"
+                    ? "h-full min-h-10 w-11 shrink-0 rounded-none px-0 text-emerald-600 transition-colors duration-200 hover:bg-emerald-500/10 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-400"
+                    : "h-full min-h-10 w-11 shrink-0 rounded-none px-0 text-primary transition-colors duration-200 hover:bg-primary/10 hover:text-primary pressed:bg-primary/15"
+                }
+                aria-label={
+                  copyState === "copied"
+                    ? "Callback URL copied"
                     : "Copy callback URL"
-              }
-              isDisabled={!oauthCallbackUrl}
-              onPress={() => void onCopyCallback()}
-            >
-              <IconCopy className="h-4 w-4" aria-hidden />
-            </Button>
+                }
+                title={
+                  copyState === "copied"
+                    ? "Copied"
+                    : copyState === "error"
+                      ? "Copy failed"
+                      : "Copy callback URL"
+                }
+                isDisabled={!oauthCallbackUrl}
+                onPress={() => void onCopyCallback()}
+              >
+                {copyState === "copied" ? (
+                  <IconCheck
+                    className="h-4 w-4 transition-opacity duration-200"
+                    aria-hidden
+                  />
+                ) : (
+                  <IconCopy
+                    className="h-4 w-4 transition-opacity duration-200"
+                    aria-hidden
+                  />
+                )}
+              </Button>
+            </div>
           </div>
-          {copyState !== "idle" ? (
+          {copyState === "error" ? (
             <output
               aria-live="polite"
-              className="mt-1 block text-xs text-teal-500"
+              className="mt-1 block text-xs text-destructive"
             >
-              {copyState === "copied"
-                ? "Copied to clipboard."
-                : "Could not copy — copy the URL manually."}
+              Could not copy — copy the URL manually.
             </output>
           ) : null}
         </li>
         <li>
           Under{" "}
-          <strong className="font-medium text-zinc-300">Permissions</strong>,{" "}
-          <strong className="font-medium text-zinc-300">
+          <strong className="font-medium text-foreground">Permissions</strong>,{" "}
+          <strong className="font-medium text-foreground">
             Add &amp; configure
           </strong>{" "}
           following scopes:
           <ul className={`mt-2 list-disc space-y-1.5 pl-5 ${mutedClass}`}>
             <li>
-              <span className="text-zinc-300">User identity:</span>{" "}
-              {code("read:me")}, {code("read:account")}
+              <span className="text-foreground">User identity:</span>{" "}
+              {scopeCode("read:me")}, {scopeCode("read:account")}
             </li>
             <li>
-              <span className="text-zinc-300">Confluence:</span>{" "}
-              {code("read:confluence-user")}
+              <span className="text-foreground">Confluence:</span>{" "}
+              {scopeCode("read:confluence-user")}
             </li>
             <li>
-              <span className="text-zinc-300">Jira:</span>{" "}
-              {code("read:jira-user")}
+              <span className="text-foreground">Jira:</span>{" "}
+              {scopeCode("read:jira-user")}
             </li>
           </ul>
         </li>
         <li>
-          Under <strong className="font-medium text-zinc-300">Settings</strong>,
+          Under{" "}
+          <strong className="font-medium text-foreground">Settings</strong>,
           copy the{" "}
-          <strong className="font-medium text-zinc-300">Client ID</strong> and{" "}
-          <strong className="font-medium text-zinc-300">Secret</strong> and
+          <strong className="font-medium text-foreground">Client ID</strong> and{" "}
+          <strong className="font-medium text-foreground">Secret</strong> and
           paste them into the fields below.
         </li>
       </ol>
@@ -204,7 +224,7 @@ export function OrgAtlassianOauthPanel({
   const help = (
     <AtlassianThreeLoSetupGuide
       oauthCallbackUrl={displayOAuthCallbackUrl(meta.data?.oauthCallbackUrl)}
-      mutedClass={embedded ? "text-sm text-zinc-400" : "text-sm text-zinc-500"}
+      mutedClass="text-sm text-muted-foreground"
     />
   )
 
@@ -213,11 +233,11 @@ export function OrgAtlassianOauthPanel({
       className={
         embedded
           ? "max-w-lg space-y-3"
-          : "max-w-lg space-y-3 rounded-md border border-zinc-800 p-4"
+          : "max-w-lg space-y-3 rounded-none border border-border p-4"
       }
     >
       {embedded ? null : (
-        <h3 className="text-sm font-semibold text-zinc-100">
+        <h3 className="text-sm font-semibold text-foreground">
           Atlassian OAuth (3LO)
         </h3>
       )}
@@ -241,6 +261,7 @@ export function OrgAtlassianOauthPanel({
       />
       <Button
         variant="primary"
+        className="rounded-none"
         isPending={save.isPending}
         isDisabled={meta.isPending}
         onPress={() => {
@@ -251,7 +272,7 @@ export function OrgAtlassianOauthPanel({
         Save OAuth app
       </Button>
       {save.error ? (
-        <p className="text-sm text-red-400">{save.error.message}</p>
+        <p className="text-sm text-destructive">{save.error.message}</p>
       ) : null}
     </div>
   )

--- a/apps/ui/src/features/connectors/components/confluence-setup/ConfluenceSetupWizard.tsx
+++ b/apps/ui/src/features/connectors/components/confluence-setup/ConfluenceSetupWizard.tsx
@@ -205,25 +205,29 @@ export function ConfluenceSetupWizard({
         ) : null}
 
         {statusPending ? (
-          <div className="mt-8 flex items-center justify-center gap-2 text-sm text-zinc-300">
-            <Spinner className="text-zinc-400" />
+          <div className="mt-8 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Spinner className="text-muted-foreground" />
             Loading connector status...
           </div>
         ) : statusError ? (
-          <div className="mt-6 space-y-3 text-sm text-zinc-300">
-            <p className="text-red-400">Could not load connector status.</p>
-            <Button variant="secondary" onPress={() => void refetchStatus()}>
+          <div className="mt-6 space-y-3 text-sm text-muted-foreground">
+            <p className="text-destructive">Could not load connector status.</p>
+            <Button
+              variant="secondary"
+              className="rounded-none"
+              onPress={() => void refetchStatus()}
+            >
               Retry
             </Button>
           </div>
         ) : !status ? (
-          <p className="mt-6 text-sm text-zinc-400">
+          <p className="mt-6 text-sm text-muted-foreground">
             Connector status is unavailable. Try closing and opening this dialog
             again.
           </p>
         ) : orgOauthBlocking ? (
-          <div className="mt-8 flex items-center justify-center gap-2 text-sm text-zinc-300">
-            <Spinner className="text-zinc-400" />
+          <div className="mt-8 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Spinner className="text-muted-foreground" />
             Loading OAuth settings...
           </div>
         ) : (
@@ -235,7 +239,7 @@ export function ConfluenceSetupWizard({
               />
             ) : null}
             {bodyId === "oauth_register" && !atlassianConnectionId ? (
-              <p className="text-sm text-red-400">
+              <p className="text-sm text-destructive">
                 Missing connection. Close this dialog and open setup from the
                 Confluence connector card.
               </p>
@@ -247,7 +251,7 @@ export function ConfluenceSetupWizard({
               />
             ) : null}
             {bodyId === "link" && !atlassianConnectionId ? (
-              <p className="text-sm text-red-400">
+              <p className="text-sm text-destructive">
                 Missing connection. Close this dialog and open setup from the
                 Confluence connector card.
               </p>
@@ -263,7 +267,7 @@ export function ConfluenceSetupWizard({
               />
             ) : null}
             {bodyId === "install" && !atlassianConnectionId ? (
-              <p className="text-sm text-red-400">
+              <p className="text-sm text-destructive">
                 Missing connection. Close this dialog and open setup from the
                 Confluence connector card.
               </p>
@@ -288,7 +292,7 @@ export function ConfluenceSetupWizard({
               />
             ) : null}
             {bodyId === "scope" && !atlassianConnectionId ? (
-              <p className="text-sm text-red-400">
+              <p className="text-sm text-destructive">
                 Missing connection. Close this dialog and open setup from the
                 Confluence connector card.
               </p>
@@ -300,7 +304,7 @@ export function ConfluenceSetupWizard({
               />
             ) : null}
             {bodyId === "merge" && !atlassianConnectionId ? (
-              <p className="text-sm text-red-400">
+              <p className="text-sm text-destructive">
                 Missing connection. Close this dialog and open setup from the
                 Confluence connector card.
               </p>

--- a/apps/ui/src/features/connectors/components/confluence-setup/steps/LinkAtlassianStep.tsx
+++ b/apps/ui/src/features/connectors/components/confluence-setup/steps/LinkAtlassianStep.tsx
@@ -36,25 +36,25 @@ export function LinkAtlassianStep({
   return (
     <div className="space-y-4">
       <div>
-        <h3 className="text-base font-semibold text-zinc-100">
+        <h3 className="text-base font-semibold text-foreground">
           Link Atlassian account
         </h3>
         {useGlobalOauth ? (
-          <p className="mt-2 text-sm text-zinc-400">
+          <p className="mt-2 text-sm text-muted-foreground">
             This deployment uses a single Atlassian OAuth app from its server
             configuration. Connect your account — use the same account you will
             use in the Confluence/Forge install flow.
           </p>
         ) : meta.data?.oauthAppSaved ? (
-          <p className="mt-2 text-sm text-zinc-400">
+          <p className="mt-2 text-sm text-muted-foreground">
             The 3LO app is configured for this connection. Change credentials if
             needed, then connect the Atlassian account you will use for
             Confluence/Forge.
           </p>
         ) : (
-          <p className="mt-2 text-sm text-amber-400/90">
+          <p className="mt-2 text-sm text-amber-500/90">
             If you haven&apos;t saved your OAuth credentials yet, go back to{" "}
-            <strong className="font-medium text-zinc-200">
+            <strong className="font-medium text-foreground">
               Register Atlassian OAuth app
             </strong>{" "}
             first. Otherwise reload this step after saving.
@@ -62,10 +62,10 @@ export function LinkAtlassianStep({
         )}
       </div>
       {meta.isPending ? (
-        <p className="text-sm text-zinc-500">Loading…</p>
+        <p className="text-sm text-muted-foreground">Loading…</p>
       ) : null}
       {meta.isError ? (
-        <p className="text-sm text-red-400">
+        <p className="text-sm text-destructive">
           Could not load org OAuth settings.
         </p>
       ) : null}
@@ -73,6 +73,7 @@ export function LinkAtlassianStep({
         <div className="space-y-3">
           <Button
             variant="primary"
+            className="rounded-none"
             isPending={meta.isPending}
             onPress={async () => {
               await authClient.linkSocial({
@@ -103,6 +104,7 @@ export function LinkAtlassianStep({
           </Disclosure>
           <Button
             variant="primary"
+            className="rounded-none"
             onPress={() => {
               const returnTo = `${window.location.pathname}${window.location.search}`
               const u = new URL(

--- a/apps/ui/src/features/connectors/components/confluence-setup/steps/RegisterAtlassianOauthStep.tsx
+++ b/apps/ui/src/features/connectors/components/confluence-setup/steps/RegisterAtlassianOauthStep.tsx
@@ -14,10 +14,10 @@ export function RegisterAtlassianOauthStep({
   return (
     <div className="space-y-4">
       <div>
-        <h3 className="text-base font-semibold text-zinc-100">
+        <h3 className="text-base font-semibold text-foreground">
           Register Atlassian OAuth app
         </h3>
-        <p className="mt-2 text-sm text-zinc-400">
+        <p className="mt-2 text-sm text-muted-foreground">
           Self-hosted deployments use their own OAuth 2.0 (3LO) client in the
           Atlassian developer console. Follow the steps below and save your
           Client ID and secret before linking an account.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **CTX-103**: the Confluence/Atlassian setup flow had regressed to circular step markers, pill-like tags, and a different copy control than the self-hosted GitHub connector modal.

## Changes

- **`ConfluenceStepper`**: Replaced circular step numbers and filled circle checkmarks with **square** indicators; completed steps use a check in a square border. Step row hover uses the same **subtle foreground wash** as ghost-style controls (`hover:bg-foreground/[0.06]`) with **square** hit areas (`rounded-none`). Labels use `foreground` / `muted-foreground` tokens.
- **`OrgAtlassianOauthPanel`**: Callback URL block now mirrors **`GithubSelfHostedCredentialsStep`**: `border-border` + `bg-muted/50` strip, **ghost** copy button with `rounded-none` and the same **primary / emerald** hover and copied states as GitHub. Inline scope snippets use **square** `code` chips (`rounded-none bg-muted/80`). External link uses `text-primary` like GitHub. **Save OAuth app** uses `rounded-none`.
- **Related steps / saved section**: `RegisterAtlassianOauthStep` and `LinkAtlassianStep` copy use semantic text colours; primary actions get `rounded-none`. **`AtlassianOauthAppSavedSection`** card border and code chips aligned the same way.

## Testing

- `pnpm --filter @ctxpipe/ui test --run src/features/connectors`
- `pnpm exec biome lint` on the modified files only.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-103](https://linear.app/ctxpipe/issue/CTX-103/fix-styling-on-connector-page)

<div><a href="https://cursor.com/agents/bc-71938541-fb84-4245-be24-56864d367920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71938541-fb84-4245-be24-56864d367920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

