### PR TITLE
fix(backend): primary GitHub connection when multiple connectors exist (CTX-104)

### DIFF
--- a/apps/backend/src/models/github-installation.ts
+++ b/apps/backend/src/models/github-installation.ts
@@ -14,6 +14,7 @@ import {
   parseGithubConnectionStored,
   serialiseGithubConnectionConfigForDb,
 } from "../lib/connection-config.js"
+import { countRepositoriesForGithubConnection } from "./repositories.js"
 import {
   githubConnectionToShape,
   githubShapeToConfig,
@@ -423,14 +424,52 @@ export async function deleteGithubConnectionById(
 export const MULTIPLE_GITHUB_CONNECTIONS_MESSAGE =
   "Multiple GitHub connections for this organization; specify connectionId query parameter"
 
+/** When API callers omit connectionId, prefer the GitHub connector that matters most in ctx|. */
+export type ResolveGithubInstallationAmbiguousMode =
+  | "reject"
+  | "prefer-primary"
+
 export type ResolveGithubInstallationResult =
   | { status: "ok"; installation: GitHubInstallationShape }
   | { status: "none" }
   | { status: "ambiguous" }
 
+/**
+ * Pick one GitHub connection when several exist: most indexed repos wins, then a linked GitHub
+ * installation id, then most recently updated.
+ */
+export async function pickPrimaryGithubConnectionFromList(
+  installations: GitHubInstallationShape[],
+): Promise<GitHubInstallationShape | undefined> {
+  if (installations.length === 0) return undefined
+  const first = installations[0]
+  if (installations.length === 1 && first) return first
+
+  const scored = await Promise.all(
+    installations.map(async (installation) => ({
+      installation,
+      repoCount: await countRepositoriesForGithubConnection(installation.id),
+      linkedToGithub: installation.installationId != null,
+    })),
+  )
+
+  scored.sort((a, b) => {
+    if (b.repoCount !== a.repoCount) return b.repoCount - a.repoCount
+    if (a.linkedToGithub !== b.linkedToGithub) {
+      return a.linkedToGithub ? -1 : 1
+    }
+    return (
+      b.installation.updatedAt.getTime() - a.installation.updatedAt.getTime()
+    )
+  })
+
+  return scored[0]?.installation
+}
+
 export async function resolveGithubInstallationForOrgDetailed(
   orgId: string,
   connectionId?: string | null,
+  ambiguousMode: ResolveGithubInstallationAmbiguousMode = "prefer-primary",
 ): Promise<ResolveGithubInstallationResult> {
   if (connectionId) {
     const installation = await getGithubInstallationByConnectionId(
@@ -445,15 +484,25 @@ export async function resolveGithubInstallationForOrgDetailed(
   if (list.length === 1 && onlyInstallation) {
     return { status: "ok", installation: onlyInstallation }
   }
+  if (ambiguousMode === "prefer-primary") {
+    const primary = await pickPrimaryGithubConnectionFromList(list)
+    return primary
+      ? { status: "ok", installation: primary }
+      : { status: "none" }
+  }
   return { status: "ambiguous" }
 }
 
-/** Resolve org GitHub connection: explicit `connectionId`, or the only row when exactly one. */
+/** Resolve org GitHub connection: explicit `connectionId`, or primary when multiple exist. */
 export async function resolveGithubInstallationForOrg(
   orgId: string,
   connectionId?: string | null,
 ): Promise<GitHubInstallationShape | undefined> {
-  const r = await resolveGithubInstallationForOrgDetailed(orgId, connectionId)
+  const r = await resolveGithubInstallationForOrgDetailed(
+    orgId,
+    connectionId,
+    "prefer-primary",
+  )
   return r.status === "ok" ? r.installation : undefined
 }
 

--- a/apps/backend/src/routes/v1/github-installation.test.ts
+++ b/apps/backend/src/routes/v1/github-installation.test.ts
@@ -514,6 +514,7 @@ describe("DELETE /github/installation", () => {
     expect(resolveGithubInstallationForOrgDetailedMock).toHaveBeenCalledWith(
       "org_1",
       "con_github",
+      "reject",
     )
     expect(deleteGithubConnectionByIdMock).toHaveBeenCalledWith(
       "org_1",

--- a/apps/backend/src/routes/v1/github-installation.ts
+++ b/apps/backend/src/routes/v1/github-installation.ts
@@ -1130,6 +1130,7 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
       const resolved = await resolveGithubInstallationForOrgDetailed(
         orgId,
         patchConnectionId ?? null,
+        "reject",
       )
       if (resolved.status === "ambiguous") {
         return c.json({ error: MULTIPLE_GITHUB_CONNECTIONS_MESSAGE }, 400)
@@ -1194,6 +1195,7 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
     const resolved = await resolveGithubInstallationForOrgDetailed(
       orgId,
       connectionId ?? null,
+      "reject",
     )
     if (resolved.status === "ambiguous") {
       return c.json({ error: MULTIPLE_GITHUB_CONNECTIONS_MESSAGE }, 400)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **CTX-104**: home page showed “Connect GitHub” and **Install MCP via PRs** stayed disabled even though repositories were connected. That happened when an organisation had **more than one GitHub connector**: `GET .../github/installation` returned **400** without `connectionId`, the UI client threw, and TanStack Query never received installation data.

## Approach

When `connectionId` is omitted and multiple GitHub connections exist, the API now picks a **primary** connector:

1. Highest count of indexed repositories (`github_connection_id` in org repos).
2. Then prefer a row with a linked GitHub App `installationId`.
3. Then most recently `updatedAt`.

**PATCH** and **DELETE** `/github/installation` still use **reject** mode: callers must pass `connectionId` when multiple connectors exist, so destructive or configuration changes do not hit an arbitrary connector.

## Verification

- `pnpm --filter @ctxpipe/backend exec vitest run src/routes/v1/github-installation.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-104](https://linear.app/ctxpipe/issue/CTX-104/bugs-in-the-repo-page)

<div><a href="https://cursor.com/agents/bc-d4da72ed-a1c1-4bab-bb6f-724c31d8906a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4da72ed-a1c1-4bab-bb6f-724c31d8906a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

