### PR TITLE
Remove Smee webhook proxy; harden Terraform plan on PRs

### DIFF
--- a/.github/workflows/terraform-plan-pr.yaml
+++ b/.github/workflows/terraform-plan-pr.yaml
@@ -1,3 +1,8 @@
+# Terraform speculative plans on infra PRs.
+#
+# Security: terraform plan executes provider/external code with secrets present. Assign this job to a
+# GitHub Environment named below and enable required reviewers under repo Settings → Environments
+
 name: Terraform Infra Plan (PR)
 
 on:
@@ -16,6 +21,12 @@ jobs:
   terraform-plan:
     name: Terraform Plan (PR)
     runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    # Only branches on this repository (not forks). Fork PRs lack secrets anyway; this avoids noise.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    # Required reviewers → Settings → Environments → terraform-plan
+    environment: terraform-plan
 
     permissions:
       contents: read
@@ -59,23 +70,39 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        # Railway API/CLI calls can be flaky; retry once before failing.
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 2
-          command: cd infra && terraform plan -no-color -input=false > plan.txt
+          command: |
+            set -euo pipefail
+            cd "${GITHUB_WORKSPACE}/infra"
+            terraform plan -no-color -input=false > "${GITHUB_WORKSPACE}/infra/plan.txt"
 
       - name: Generate Terraform Plan Comment
         if: always()
         run: |
+          set -euo pipefail
+          cd "${GITHUB_WORKSPACE}/infra"
+          max_bytes=65536
+          truncated_note=""
+          if [[ -f plan.txt ]]; then
+            size=$(wc -c < plan.txt | tr -d ' ')
+            if [[ "$size" -gt "$max_bytes" ]]; then
+              head -c "$max_bytes" plan.txt > plan.tmp && mv plan.tmp plan.txt
+              truncated_note=$'\n\n_Plan output truncated (first '"$max_bytes"' bytes); see the workflow run artifact / logs for the full plan._'
+            fi
+          else
+            truncated_note=$'\n\n_No plan.txt produced (Terraform plan failed or did not write output)._'
+          fi
           {
             echo "## Terraform Plan"
             echo
             echo "<details><summary>Show plan</summary>"
             echo
             echo '```hcl'
-            cat plan.txt
+            cat plan.txt 2>/dev/null || true
+            echo "$truncated_note"
             echo '```'
             echo
             echo "</details>"
@@ -99,4 +126,3 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: infra/plan-comment.md
           edit-mode: replace
-

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -76,7 +76,6 @@ GITHUB_WEBHOOK_SECRET=
 # GITHUB_APP_SLUG=ctxpipe-agent
 # Optional: 64 hex chars (32-byte AES). Encrypts connector secrets in DB; defaults to deriving from AUTH_SECRET
 # CONNECTION_SECRETS_ENCRYPTION_KEY=
-SMEE_URL="https://smee.io/naliyA6yt5p9UmLf"
 
 # Atlassian OAuth Auth to allow linking user account to Atlassian account
 ATLASSIAN_CLIENT_ID="SQcoGc4W3Jzi29HPvIkleG2aEP6W0ht2"

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -38,6 +38,8 @@ Core HTTP API and MCP service for [ctx|](https://ctxpipe.ai). Built with **Hono*
 
 The GitHub App must be subscribed to `push` webhook events on connected repositories for re-indexing to fire on merge / direct push. `pull_request` events are intentionally not a fallback — they don't cover direct pushes to the default branch (hotfixes, incident response).
 
+For **local development**, GitHub cannot deliver webhooks to `localhost`; use an HTTPS tunnel (for example Cloudflare Tunnel, ngrok, or Tailscale Funnel), register the forwarded URL with your GitHub App, and ensure it reaches `POST …/api/v1/webhook/github`.
+
 ## Scripts (this package)
 
 | Script | Description |

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -22,8 +22,7 @@
     "openworkflow:dashboard": "pnpm dlx @openworkflow/cli dashboard --port 8000",
     "openworkflow:doctor": "pnpm dlx @openworkflow/cli doctor",
     "rerun-skill-derivation": "bun run src/scripts/rerunSkillDerivation.ts",
-    "verify-instruction-ingestion": "bun run src/scripts/verifyInstructionIngestion.ts",
-    "forward-github-webhook": "NODE_EXTRA_CA_CERTS=$HOME/.portless/ca.pem smee -u ${SMEE_URL:-https://smee.io/naliyA6yt5p9UmLf} -t https://app.ctxpipe.localhost/api/v1/webhook/github"
+    "verify-instruction-ingestion": "bun run src/scripts/verifyInstructionIngestion.ts"
   },
   "dependencies": {
     "@ai-sdk/langchain": "^2.0.111",
@@ -92,7 +91,6 @@
     "@types/pg": "^8.16.0",
     "@vitest/coverage-v8": "^4.0.18",
     "drizzle-kit": "beta",
-    "smee-client": "^5.0.0",
     "tsx": "4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"

--- a/infra/README.md
+++ b/infra/README.md
@@ -104,3 +104,11 @@ PR deploys are driven by `.github/workflows/pr-deploy.yaml`:
 - Enable **Serverless** (`sleepApplication: true`) on backend, ui, codesearch, and otel-collector in the PR environment via GraphQL (**production** defaults stay as configured in Terraform / dashboard — typically off)
 - For the PR **openworkflow worker**, single `serviceInstanceUpdate` sets image, **Serverless**, and **restart on failure only** (`restartPolicyType: ON_FAILURE`) so idle supervisor exits (status 0) are not auto-restarted
 
+## PR Terraform plans (GitHub Actions)
+
+The workflow [.github/workflows/terraform-plan-pr.yaml](../.github/workflows/terraform-plan-pr.yaml) runs `terraform plan` on infra changes. Before it can run with production secrets:
+
+1. Create a GitHub **Environment** named `terraform-plan` (Settings → Environments).
+2. Add **required reviewers** (and optional wait timers) so the job only runs after infra approval. That limits unreviewed HCL executing with full Terraform secrets on in-repo branches.
+3. Fork PRs skip this job by design (same-repo branches only).
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,6 @@ importers:
       drizzle-kit:
         specifier: beta
         version: 1.0.0-beta.22
-      smee-client:
-        specifier: ^5.0.0
-        version: 5.0.0
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -11714,11 +11711,6 @@ packages:
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
-
-  smee-client@5.0.0:
-    resolution: {integrity: sha512-OYL8xPr1Tc0iqGohTGqHO/qEvUrPktK0a2Qcb0Uuj+j4KLnH5bsOhOlmpnmdh4zgzL3OwTfodcmkg5fVgiMUHw==}
-    engines: {node: ^20.18 || >= 22}
-    hasBin: true
 
   smob@1.6.1:
     resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
@@ -27184,11 +27176,6 @@ snapshots:
   slash@3.0.0: {}
 
   slash@5.1.0: {}
-
-  smee-client@5.0.0:
-    dependencies:
-      eventsource: 4.1.0
-      undici: 7.22.0
 
   smob@1.6.1: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the revised pre-publish scope: remove Smee-based local GitHub webhook forwarding, and reduce the risk profile of the PR Terraform plan workflow.

## Smee removal

- Dropped the `forward-github-webhook` npm script and the `smee-client` devDependency; removed `SMEE_URL` from `apps/backend/.env.example` and refreshed `pnpm-lock.yaml`.
- Added a short note under **Webhooks** in `apps/backend/README.md` describing HTTPS tunnels (Cloudflare Tunnel, ngrok, Tailscale Funnel) for local webhook delivery.

## terraform-plan-pr.yaml

- Same-repo gate: job runs only when `github.event.pull_request.head.repo.full_name == github.repository` (fork PRs skipped).
- Environment `terraform-plan`: plans that use production secrets wait for a GitHub Environment approval. Create the environment under Settings → Environments and add required reviewers (see `infra/README.md`).
- PR comment truncates plan output to 64 KiB with a pointer to workflow logs for the full plan.
- Terraform plan invokes `terraform` after `cd ${GITHUB_WORKSPACE}/infra` so the retry action always runs against the infra directory.

**Operator follow-up:** after merge, configure the `terraform-plan` environment in GitHub so the workflow is not permanently waiting on deployment approval.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92d7d761-cc80-4583-8e72-4da7f3ea0c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92d7d761-cc80-4583-8e72-4da7f3ea0c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

