### PR TITLE
fix(backend): repair AI SDK text-start stream sequence after flush transforms (CTX-110)

### DIFF
--- a/apps/backend/src/domain/conversations/conversationUiStreamPipeline.ts
+++ b/apps/backend/src/domain/conversations/conversationUiStreamPipeline.ts
@@ -1,0 +1,21 @@
+import type { UIMessageChunk } from "ai"
+import { createTextStartRepairTransform } from "./uiMessageStreamTextStartRepair.js"
+import { createToolInvocationRepairTransform } from "./uiMessageStreamToolInvocationRepair.js"
+
+/**
+ * Applies tool-invocation repair, optional flush transforms (e.g. rename onFinish),
+ * then text-start repair last so no downstream transform can emit text-delta/text-end
+ * without a matching text-start reaching the client.
+ */
+export function pipeConversationUiStreamTransforms(
+  uiStream: ReadableStream<UIMessageChunk>,
+  flushTransforms: TransformStream<UIMessageChunk, UIMessageChunk>[] = [],
+): ReadableStream<UIMessageChunk> {
+  let stream: ReadableStream<UIMessageChunk> = uiStream.pipeThrough(
+    createToolInvocationRepairTransform(),
+  )
+  for (const transform of flushTransforms) {
+    stream = stream.pipeThrough(transform)
+  }
+  return stream.pipeThrough(createTextStartRepairTransform())
+}

--- a/apps/backend/src/domain/conversations/internalNodeMessageFilter.ts
+++ b/apps/backend/src/domain/conversations/internalNodeMessageFilter.ts
@@ -13,7 +13,7 @@ type InternalNodeName = (typeof INTERNAL_MESSAGE_NODES)[number]
  * model.invoke()). The metadata includes langgraph_node to identify the source node.
  * We filter these so only the final agent reply is shown as streamed text.
  * Dropping whole `messages` tuples can split text-start from later deltas for the same
- * message id; `createTextStartRepairTransform` in transport.ts heals the UI stream.
+ * message id; `createTextStartRepairTransform` in conversationUiStreamPipeline.ts heals the UI stream.
  */
 export async function* filterInternalNodeMessageChunks(
   stream: AsyncIterable<unknown>,

--- a/apps/backend/src/domain/conversations/transport.test.ts
+++ b/apps/backend/src/domain/conversations/transport.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import type { UIMessageChunk } from "ai"
+import { pipeConversationUiStreamTransforms } from "./conversationUiStreamPipeline.js"
+
+async function readAllChunks(
+  stream: ReadableStream<UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+  const reader = stream.getReader()
+  const chunks: UIMessageChunk[] = []
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  return chunks
+}
+
+describe("pipeConversationUiStreamTransforms", () => {
+  it("repairs text-end emitted by a later flush transform without text-start", async () => {
+    const msgId = "gen-1779258149-JKCU23nzgbXiWMotz6jt"
+    const lateTextEndOnFlush = new TransformStream<UIMessageChunk, UIMessageChunk>(
+      {
+        transform(chunk, controller) {
+          controller.enqueue(chunk)
+        },
+        flush(controller) {
+          controller.enqueue({ type: "text-end", id: msgId })
+        },
+      },
+    )
+
+    const input = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    const out = pipeConversationUiStreamTransforms(input, [lateTextEndOnFlush])
+    const chunks = await readAllChunks(out)
+
+    expect(chunks).toEqual([
+      { type: "text-start", id: msgId },
+      { type: "text-end", id: msgId },
+    ])
+  })
+
+  it("applies tool repair before text-start repair", async () => {
+    const toolCallId = "tool_search_abc12345678"
+    const input = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        controller.enqueue({
+          type: "tool-output-available",
+          toolCallId,
+          output: { ok: true },
+        })
+        controller.close()
+      },
+    })
+
+    const chunks = await readAllChunks(pipeConversationUiStreamTransforms(input))
+
+    expect(chunks[0]).toMatchObject({
+      type: "tool-input-start",
+      toolCallId,
+      toolName: "search",
+    })
+    expect(chunks[1]?.type).toBe("tool-output-available")
+  })
+})

--- a/apps/backend/src/domain/conversations/transport.ts
+++ b/apps/backend/src/domain/conversations/transport.ts
@@ -15,8 +15,7 @@ import { generateObjectId } from "../../lib/id.js"
 import { runWithLangfuseContext } from "../../observability/langfuse.js"
 import { langfusePipelineCallbacks } from "../../observability/langfusePipelineMetrics.js"
 import type { StreamEnhancer } from "./renameStream.js"
-import { createTextStartRepairTransform } from "./uiMessageStreamTextStartRepair.js"
-import { createToolInvocationRepairTransform } from "./uiMessageStreamToolInvocationRepair.js"
+import { pipeConversationUiStreamTransforms } from "./conversationUiStreamPipeline.js"
 
 export type StreamInput = {
   conversationId: string
@@ -75,14 +74,10 @@ class DataStreamConversationTransport implements ConversationTransportAdapter {
           wrappedStream as Parameters<typeof toUIMessageStream>[0],
         )
 
-        let stream: ReadableStream<UIMessageChunk> = uiStream
-          .pipeThrough(createToolInvocationRepairTransform())
-          .pipeThrough(createTextStartRepairTransform())
-        for (const transform of flushTransforms) {
-          stream = stream.pipeThrough(
-            transform as TransformStream<UIMessageChunk, UIMessageChunk>,
-          )
-        }
+        const stream = pipeConversationUiStreamTransforms(
+          uiStream,
+          flushTransforms as TransformStream<UIMessageChunk, UIMessageChunk>[],
+        )
 
         return createUIMessageStreamResponse({ stream })
       },

--- a/apps/backend/src/domain/conversations/uiMessageStreamTextStartRepair.test.ts
+++ b/apps/backend/src/domain/conversations/uiMessageStreamTextStartRepair.test.ts
@@ -32,6 +32,30 @@ describe("createTextStartRepairTransform", () => {
     ])
   })
 
+  it("prepends text-start when only text-end arrives", async () => {
+    const msgId = "gen-1779258149-JKCU23nzgbXiWMotz6jt"
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-end", id: msgId })
+        controller.close()
+      },
+    })
+
+    const out = input.pipeThrough(createTextStartRepairTransform())
+    const reader = out.getReader()
+    const chunks: unknown[] = []
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+    }
+
+    expect(chunks).toEqual([
+      { type: "text-start", id: msgId },
+      { type: "text-end", id: msgId },
+    ])
+  })
+
   it("does not duplicate when text-start was already seen", async () => {
     const msgId = "gen-test-456"
     const input = new ReadableStream({

--- a/apps/backend/src/domain/conversations/uiMessageStreamTextStartRepair.ts
+++ b/apps/backend/src/domain/conversations/uiMessageStreamTextStartRepair.ts
@@ -1,4 +1,5 @@
 import type { UIMessageChunk } from "ai"
+import { log } from "../../observability/logger.js"
 
 /**
  * When upstream LangGraph chunks are filtered (e.g. internal planner/naming nodes),
@@ -30,6 +31,12 @@ export function createTextStartRepairTransform(): TransformStream<
       if (chunk.type === "text-delta" || chunk.type === "text-end") {
         const id = (chunk as { id?: unknown }).id
         if (typeof id === "string" && id.length > 0 && !textStartSeen.has(id)) {
+          log.warn({
+            step: "conversation.ui_stream.text_start_repair",
+            message: "Synthesised missing text-start before text chunk",
+            textPartId: id,
+            followingChunkType: chunk.type,
+          })
           controller.enqueue({ type: "text-start", id })
           textStartSeen.add(id)
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The chat client could receive an invalid AI SDK UI stream sequence: `text-end(id)` without a prior matching `text-start(id)`. This happens when LangGraph internal nodes (planner, conversationNaming) are filtered post-hoc—dropping a `text-start` while later chunks for the same generated message id still flow through `@ai-sdk/langchain`.

## Solution

- Move `createTextStartRepairTransform()` to the **end** of the UI stream pipeline (after tool repair and enhancer `flushTransforms`).
- Extract `pipeConversationUiStreamTransforms()` into `conversationUiStreamPipeline.ts` for focused unit tests without loading the conversation graph.
- Add regression test proving a late flush transform emitting `text-end` is repaired.
- Emit structured `warn` logs when synthesising a missing `text-start` (includes part id and following chunk type).

## Testing

- `pnpm exec vitest run src/domain/conversations/transport.test.ts`
- `pnpm exec vitest run src/domain/conversations/uiMessageStreamTextStartRepair.test.ts`

Closes CTX-110.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-110](https://linear.app/ctxpipe/issue/CTX-110/invalid-ai-sdk-stream-sequence)

<div><a href="https://cursor.com/agents/bc-465393ee-9ed7-493b-8353-b1000ccf5f4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-465393ee-9ed7-493b-8353-b1000ccf5f4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

