### PR TITLE
fix(ci): pass Forge environment to lint in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -270,7 +270,7 @@ jobs:
           FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
           FORGE_DISABLE_ANALYTICS: "1"
           REMOTE_BASE_URL: https://app.ctxpipe.ai/
-        run: pnpm --filter @ctxpipe/forge-ctxpipe-agent exec forge lint
+        run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run lint:forge
 
       - name: Deploy to Forge production
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -264,6 +264,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Prepare Forge CLI for CI
+        env:
+          FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
+          FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
+          FORGE_DISABLE_ANALYTICS: "1"
+        run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run prepare-forge-cli
+
       - name: Forge lint
         env:
           FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}

--- a/apps/forge-ctxpipe-agent/package.json
+++ b/apps/forge-ctxpipe-agent/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "lint": "eslint src/**/*",
+    "lint:forge": "forge lint --environment production",
     "dev": "pnpm run ngrok:tunnel",
     "dev:forge": "concurrently -n ngrok,forge \"pnpm run ngrok:tunnel\" \"forge tunnel\"",
     "ngrok:tunnel": "bash ./scripts/ngrok-tunnel.sh",

--- a/apps/forge-ctxpipe-agent/package.json
+++ b/apps/forge-ctxpipe-agent/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "lint": "eslint src/**/*",
+    "prepare-forge-cli": "forge settings set usage-analytics false",
     "lint:forge": "forge lint --environment production",
     "dev": "pnpm run ngrok:tunnel",
     "dev:forge": "concurrently -n ngrok,forge \"pnpm run ngrok:tunnel\" \"forge tunnel\"",
@@ -16,7 +17,7 @@
     "deploy:dev": "REMOTE_BASE_URL=https://flourless-kenisha-overcheaply.ngrok-free.dev forge deploy --environment development",
     "install:dev": "REMOTE_BASE_URL=https://flourless-kenisha-overcheaply.ngrok-free.dev forge install -e development -s ctxpipe.atlassian.net -p Confluence --non-interactive",
     "install:upgrade": "REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge install --upgrade",
-    "deploy:prod": "REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge deploy --environment production --non-interactive",
+    "deploy:prod": "pnpm run prepare-forge-cli && REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge deploy --environment production --non-interactive",
     "deploy:pr": "forge deploy --environment \"$FORGE_PR_ENV\" --non-interactive",
     "install:pr": "forge install --non-interactive --upgrade -e \"$FORGE_PR_ENV\" -s ctxpipe.atlassian.net -p Confluence",
     "install:pr:first": "forge install --non-interactive -e \"$FORGE_PR_ENV\" -s ctxpipe.atlassian.net -p Confluence"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes CTX-111.

## Problem

The **Deploy Forge app (production)** job failed at **Forge lint** because `forge lint` ran without `--environment`, causing non-TTY prompts in CI.

## Solution

1. **`lint:forge`** — `forge lint --environment production`
2. **`prepare-forge-cli`** — `forge settings set usage-analytics false` (required for `forge deploy --non-interactive` on fresh runners; matches `forge-provision-cli.mjs`)
3. Workflow runs **Prepare Forge CLI for CI** before lint; **`deploy:prod`** also runs `prepare-forge-cli` first

## Deploy step review (additional risks documented in PR comments)

- Deploy step already uses `--environment production --non-interactive` and embeds `REMOTE_BASE_URL` via `deploy:prod`
- CI does not run `forge install` (deploy-only for the shared reference app)
- Valid `FORGE_EMAIL` + `FORGE_API_TOKEN` in the `production` environment remain required
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-111](https://linear.app/ctxpipe/issue/CTX-111/fix-deploy-forge-app-github-action-which-is-failing)

<div><a href="https://cursor.com/agents/bc-dd6ea773-c4e1-4990-b3c6-367db75fe143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd6ea773-c4e1-4990-b3c6-367db75fe143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

