### PR TITLE
fix(release): bind --if-present to pnpm run, not package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "changeset": "changeset",
     "ci:stamp-aws-cdk-image-tag": "node scripts/release/stamp-aws-cdk-image-tag.mjs",
     "ci:version": "changeset version",
-    "release": "pnpm -r --filter \"./packages/*\" run build --if-present && pnpm -r --filter \"./packages/*\" run test --if-present && changeset publish"
+    "release": "pnpm -r --filter \"./packages/*\" run --if-present build && pnpm -r --filter \"./packages/*\" run --if-present test && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deploy workflow **Release** job failed on `main` after merging `chore(release): version packages (#185)` ([run 26158946208](https://github.com/ctxpipe-ai/ctxpipe/actions/runs/26158946208/job/76945817766)).

`changesets/action` ran `pnpm release`, which executed:

```bash
pnpm -r --filter "./packages/*" run build --if-present
```

pnpm forwards flags after the script name to the underlying command, so `packages/cli` ran `tsc -p tsconfig.build.json --if-present` and failed with `TS5023: Unknown compiler option '--if-present'`.

## Fix

Place `--if-present` on `pnpm run` so it applies to pnpm (skip packages without the script), not to `tsc`:

```bash
pnpm -r --filter "./packages/*" run --if-present build
pnpm -r --filter "./packages/*" run --if-present test
```

## Verification

Locally ran the corrected build and test steps; `packages/cli` and `@ctxpipe/aws-cdk` both succeed.

## After merge

Merge triggers **Deploy** on `main`. With no pending changesets, the Release job should publish the version-bumped packages from #185.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0915f04-6593-467b-b6f5-b5669c264ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0915f04-6593-467b-b6f5-b5669c264ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

