### PR TITLE
ci: use npm trusted publishing for package releases (CTX-113)

### DIFF
--- a/.github/workflows/changeset-guard.yaml
+++ b/.github/workflows/changeset-guard.yaml
@@ -20,16 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@v6
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
-
-      - uses: pnpm/action-setup@v4
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,36 +58,29 @@ jobs:
 
   release:
     name: Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - build_images
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout repository
-        uses: useblacksmith/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - name: Mount pnpm store (sticky disk)
-        uses: useblacksmith/stickydisk@v1
-        with:
-          key: ${{ github.repository }}-pnpm-store
-          path: ~/.pnpm-store
-
-      - uses: useblacksmith/setup-node@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
-      - name: Ensure pnpm store path
-        run: pnpm config set store-dir ~/.pnpm-store
-
-      - name: Configure npm auth for npmjs
-        run: |
-          echo "@ctxpipe:registry=https://registry.npmjs.org" >> ~/.npmrc
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -101,7 +94,6 @@ jobs:
           title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           IMAGE_TAG: ${{ github.sha }}
 
   migrate_production_db:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,14 +67,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -78,6 +78,7 @@ jobs:
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
+          cache: pnpm
 
       - name: Ensure npm supports trusted publishing
         run: npm install -g npm@11.5.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the **Release** job in [`.github/workflows/deploy.yaml`](.github/workflows/deploy.yaml) to publish npm packages via [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) instead of a long-lived `NPM_TOKEN`.

Closes CTX-113.

## Workflow changes

- **Runner:** `ubuntu-latest` (GitHub-hosted) for the `release` job only; other jobs still use Blacksmith.
- **OIDC:** Job-level `id-token: write` plus `actions/setup-node` with `registry-url: https://registry.npmjs.org`.
- **npm CLI:** Install `npm@11.5.1+` (required for trusted publishing).
- **Auth:** Removed manual `~/.npmrc` token wiring and `NPM_TOKEN` from the changesets publish step so npm can use OIDC automatically.

## Manual npm setup (required before the next publish)

Configure a **trusted publisher** on npm for **each published package** (one publisher per package):

| Package | npm settings URL |
|---------|------------------|
| `@ctxpipe/aws-cdk` | https://www.npmjs.com/package/@ctxpipe/aws-cdk/access |
| `ctxpipe` (CLI) | https://www.npmjs.com/package/ctxpipe/access |

For each package → **Settings** → **Trusted publishing** → **GitHub Actions**:

| Field | Value |
|-------|--------|
| Repository | `ctxpipe-ai/ctxpipe` |
| Workflow filename | `deploy.yaml` |
| Environment | *(leave empty unless you add a GitHub Environment later)* |

**Notes:**

- Workflow filename must be exactly `deploy.yaml` (matches `.github/workflows/deploy.yaml`).
- Trusted publishing only works on **GitHub-hosted** runners (why this PR switches the release job off Blacksmith).
- Each package can have **one** trusted publisher; repeat the steps for both packages above.
- Ensure `repository.url` in each package’s `package.json` points at `ctxpipe-ai/ctxpipe` (already set for both packages).

### Recommended follow-up (after verifying OIDC publish works)

1. On each package → **Settings** → **Publishing access** → enable **Require two-factor authentication and disallow tokens** (tokens are no longer needed for CI publish).
2. Revoke the legacy automation **`NPM_TOKEN`** from npm and remove the `NPM_TOKEN` GitHub Actions secret when no longer needed elsewhere.

### If publish fails with `ENEEDAUTH`

- Confirm trusted publisher workflow name is `deploy.yaml`.
- Confirm the workflow run uses `ubuntu-latest` (not self-hosted / Blacksmith).
- Confirm `id-token: write` is present on the `release` job.
- Confirm npm CLI is ≥ 11.5.1 on the runner (handled by the new workflow step).

## Testing

Workflow YAML only; no runtime test in this environment. After merging and configuring npm, the next changesets release PR merge should publish without `NPM_TOKEN`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-113](https://linear.app/ctxpipe/issue/CTX-113/update-our-packages-release-workflow-to-use-trusted-publishers-with)

<div><a href="https://cursor.com/agents/bc-ebf2de70-286b-4617-8eb8-b7e156466c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebf2de70-286b-4617-8eb8-b7e156466c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

