### PR TITLE
fix(github): break onboarding connect loop after App install

### DIFF
--- a/apps/backend/src/models/github-installation.resolve.test.ts
+++ b/apps/backend/src/models/github-installation.resolve.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import type { GitHubInstallationShape } from "./connection-rows.js"
+import {
+  githubConnectionIsLinked,
+  resolveGithubInstallationFromList,
+} from "./github-installation.js"
+
+function row(
+  partial: Partial<GitHubInstallationShape> & Pick<GitHubInstallationShape, "id">,
+): GitHubInstallationShape {
+  return {
+    orgId: "org_1",
+    installationId: null,
+    accountSlug: null,
+    ingestAllRepositories: false,
+    includeFutureRepos: false,
+    appSlug: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...partial,
+  }
+}
+
+describe("resolveGithubInstallationFromList", () => {
+  it("returns none for an empty list", () => {
+    expect(resolveGithubInstallationFromList([])).toEqual({ status: "none" })
+  })
+
+  it("returns the single linked installation when a draft row also exists", () => {
+    const linked = row({ id: "con_linked", installationId: 42 })
+    const draft = row({ id: "con_draft" })
+    const result = resolveGithubInstallationFromList([draft, linked])
+    expect(result).toEqual({ status: "ok", installation: linked })
+  })
+
+  it("returns ambiguous when multiple linked installations exist", () => {
+    const a = row({ id: "con_a", installationId: 1 })
+    const b = row({ id: "con_b", installationId: 2 })
+    expect(resolveGithubInstallationFromList([a, b])).toEqual({
+      status: "ambiguous",
+    })
+  })
+
+  it("returns the sole row when it is an unlinked draft", () => {
+    const draft = row({ id: "con_draft" })
+    expect(resolveGithubInstallationFromList([draft])).toEqual({
+      status: "ok",
+      installation: draft,
+    })
+  })
+
+  it("returns ambiguous when multiple unlinked rows exist", () => {
+    const a = row({ id: "con_a" })
+    const b = row({ id: "con_b" })
+    expect(resolveGithubInstallationFromList([a, b])).toEqual({
+      status: "ambiguous",
+    })
+  })
+})
+
+describe("githubConnectionIsLinked", () => {
+  it("is false without installationId", () => {
+    expect(githubConnectionIsLinked(row({ id: "con_1" }))).toBe(false)
+  })
+
+  it("is true when installationId is set", () => {
+    expect(
+      githubConnectionIsLinked(row({ id: "con_1", installationId: 99 })),
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/models/github-installation.ts
+++ b/apps/backend/src/models/github-installation.ts
@@ -428,6 +428,37 @@ export type ResolveGithubInstallationResult =
   | { status: "none" }
   | { status: "ambiguous" }
 
+/** True when the GitHub App installation id is stored on the connection row. */
+export function githubConnectionIsLinked(
+  installation: GitHubInstallationShape,
+): boolean {
+  return installation.installationId != null
+}
+
+/**
+ * Picks the default org GitHub connection when `connectionId` is omitted.
+ * Prefers rows with a linked GitHub App installation so draft/placeholder rows
+ * from aborted self-hosted setup do not mask a successful install.
+ */
+export function resolveGithubInstallationFromList(
+  list: GitHubInstallationShape[],
+): ResolveGithubInstallationResult {
+  if (list.length === 0) return { status: "none" }
+
+  const linked = list.filter(githubConnectionIsLinked)
+  if (linked.length === 1) {
+    return { status: "ok", installation: linked[0]! }
+  }
+  if (linked.length > 1) {
+    return { status: "ambiguous" }
+  }
+
+  if (list.length === 1) {
+    return { status: "ok", installation: list[0]! }
+  }
+  return { status: "ambiguous" }
+}
+
 export async function resolveGithubInstallationForOrgDetailed(
   orgId: string,
   connectionId?: string | null,
@@ -440,12 +471,7 @@ export async function resolveGithubInstallationForOrgDetailed(
     return installation ? { status: "ok", installation } : { status: "none" }
   }
   const list = await listGithubConnectionsForOrg(orgId)
-  if (list.length === 0) return { status: "none" }
-  const onlyInstallation = list[0]
-  if (list.length === 1 && onlyInstallation) {
-    return { status: "ok", installation: onlyInstallation }
-  }
-  return { status: "ambiguous" }
+  return resolveGithubInstallationFromList(list)
 }
 
 /** Resolve org GitHub connection: explicit `connectionId`, or the only row when exactly one. */

--- a/apps/ui/src/components/onboarding/OnboardingGithubSlide.tsx
+++ b/apps/ui/src/components/onboarding/OnboardingGithubSlide.tsx
@@ -6,6 +6,7 @@ import { GITHUB_FINALISING_MIN_MS } from "@/components/onboarding/constants"
 import {
   fetchGithubInstallationSummary,
   githubConnectorKeys,
+  isGithubInstallationLinked,
 } from "@/features/connectors/queries/github-connector"
 import { useGithubConnectFlow } from "@/features/connectors/useGithubConnectFlow"
 
@@ -32,7 +33,8 @@ export function OnboardingGithubSlide({
     enabled: !!orgSlug,
   })
 
-  const hasGithubInstallation = Boolean(installation) || connectOptimistic
+  const hasGithubInstallation =
+    isGithubInstallationLinked(installation) || connectOptimistic
 
   const hookOrg = orgSlug ?? ""
   const flowEnabled = !!orgSlug

--- a/apps/ui/src/features/connectors/githubConnectFlow.test.ts
+++ b/apps/ui/src/features/connectors/githubConnectFlow.test.ts
@@ -13,15 +13,27 @@ describe("getGithubConnectStartBranch", () => {
     ).toBe("noop_bootstrap_pending")
   })
 
-  it("returns already_installed when installation exists", () => {
+  it("returns already_installed when installation is linked", () => {
     expect(
       getGithubConnectStartBranch({
         bootstrapPending: false,
         installationPending: false,
-        installation: { id: "con_1" },
+        installation: { id: "con_1", installationId: 42 },
         hostedDefaultAppInstallUrl: null,
       }),
     ).toBe("already_installed")
+  })
+
+  it("returns managed_install when only an unlinked draft row exists", () => {
+    expect(
+      getGithubConnectStartBranch({
+        bootstrapPending: false,
+        installationPending: false,
+        installation: { id: "con_draft", installationId: null },
+        hostedDefaultAppInstallUrl:
+          "https://github.com/apps/ctxpipe-agent/installations/select_target",
+      }),
+    ).toBe("managed_install")
   })
 
   it("returns noop when installation query is still pending", () => {

--- a/apps/ui/src/features/connectors/githubConnectFlow.ts
+++ b/apps/ui/src/features/connectors/githubConnectFlow.ts
@@ -11,12 +11,12 @@ export type GithubConnectStartBranch =
 
 export function getGithubConnectStartBranch(args: {
   installationPending: boolean
-  installation: unknown
+  installation: { installationId?: number | null } | null | undefined
   bootstrapPending: boolean
   hostedDefaultAppInstallUrl: string | null | undefined
 }): GithubConnectStartBranch {
   if (args.bootstrapPending) return "noop_bootstrap_pending"
-  if (args.installation) return "already_installed"
+  if (args.installation?.installationId != null) return "already_installed"
   if (args.installationPending) return "noop_installation_pending"
   const hosted = args.hostedDefaultAppInstallUrl
   if (hosted != null && hosted !== "") return "managed_install"

--- a/apps/ui/src/features/connectors/queries/github-connector.ts
+++ b/apps/ui/src/features/connectors/queries/github-connector.ts
@@ -38,9 +38,20 @@ export type GithubConnectorBootstrap = Awaited<
   ReturnType<typeof fetchGithubConnectorBootstrap>
 >
 
+export type GithubInstallationSummary = {
+  id: string
+  installationId: number | null
+}
+
+export function isGithubInstallationLinked(
+  installation: GithubInstallationSummary | null | undefined,
+): boolean {
+  return installation?.installationId != null
+}
+
 export async function fetchGithubInstallationSummary(
   orgSlug: string,
-): Promise<{ id: string } | null> {
+): Promise<GithubInstallationSummary | null> {
   const res = await client[":orgSlug"].api.v1.github.installation.$get({
     param: { orgSlug },
   })

--- a/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
+++ b/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
@@ -17,6 +17,7 @@ import {
   setGithubSetupOrgHint,
   useWatchPopupClose,
 } from "@/lib/popup"
+import { resolveGithubInstallPopupUrl } from "@/lib/github-app-url"
 import { useGithubConnectorBootstrap } from "@/lib/useGithubConnectorBootstrap"
 
 export type UseGithubConnectFlowOptions = {
@@ -61,9 +62,11 @@ export function useGithubConnectFlow({
     enabled: Boolean(orgSlug),
   })
 
-  const hasHostedApp = bootstrapPending
-    ? null
-    : Boolean(bootstrap?.hostedDefaultAppInstallUrl)
+  const hostedInstallUrl = resolveGithubInstallPopupUrl(
+    bootstrap?.hostedDefaultAppInstallUrl,
+  )
+
+  const hasHostedApp = bootstrapPending ? null : Boolean(hostedInstallUrl)
 
   const onWizardOpenChange = useCallback(
     (open: boolean) => {
@@ -105,7 +108,7 @@ export function useGithubConnectFlow({
       installationPending,
       installation,
       bootstrapPending,
-      hostedDefaultAppInstallUrl: bootstrap?.hostedDefaultAppInstallUrl,
+      hostedDefaultAppInstallUrl: hostedInstallUrl,
     })
 
     if (branch === "already_installed") {
@@ -119,8 +122,7 @@ export function useGithubConnectFlow({
       return
     }
     if (branch === "managed_install") {
-      const hostedUrl = bootstrap?.hostedDefaultAppInstallUrl
-      if (!hostedUrl) return
+      if (!hostedInstallUrl) return
       onFlowStarted?.()
       try {
         localStorage.removeItem(GITHUB_DRAFT_CONNECTION_KEY)
@@ -129,7 +131,7 @@ export function useGithubConnectFlow({
       }
       setGithubSetupOrgHint(orgSlug)
       setInstallStarting(true)
-      const popup = openCenteredPopup(hostedUrl, {
+      const popup = openCenteredPopup(hostedInstallUrl, {
         name: GITHUB_POPUP_NAME,
         width: 1120,
         height: 780,
@@ -165,7 +167,7 @@ export function useGithubConnectFlow({
     installation,
     installationPending,
     bootstrapPending,
-    bootstrap?.hostedDefaultAppInstallUrl,
+    hostedInstallUrl,
     orgSlug,
     queryClient,
     watchPopupClose,

--- a/apps/ui/src/lib/popup.ts
+++ b/apps/ui/src/lib/popup.ts
@@ -21,6 +21,84 @@ export type GithubSetupRegistrationStatus =
 /** Window name used when opening the GitHub app install popup. */
 export const GITHUB_POPUP_NAME = "github-app-install"
 
+/** Set on the opener before `window.open`; read in the callback when `window.name` is lost. */
+export const GITHUB_INSTALL_POPUP_SESSION_KEY = "github-install-popup-session"
+
+export type GithubSetupResultPayload = {
+  installationId: number
+  connectionId?: string
+}
+
+export function markGithubInstallPopupSession() {
+  if (typeof window === "undefined") return
+  try {
+    sessionStorage.setItem(GITHUB_INSTALL_POPUP_SESSION_KEY, "1")
+  } catch {
+    // ignore
+  }
+}
+
+export function clearGithubInstallPopupSession() {
+  if (typeof window === "undefined") return
+  try {
+    sessionStorage.removeItem(GITHUB_INSTALL_POPUP_SESSION_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+export function isGithubInstallPopupWindow() {
+  if (typeof window === "undefined") return false
+  if (window.opener || window.name === GITHUB_POPUP_NAME) return true
+  try {
+    return sessionStorage.getItem(GITHUB_INSTALL_POPUP_SESSION_KEY) === "1"
+  } catch {
+    return false
+  }
+}
+
+/** Write setup result synchronously so the opener can read it as soon as the popup closes. */
+export function writeGithubSetupResultToStorage(payload: GithubSetupResultPayload) {
+  if (typeof window === "undefined") return
+  try {
+    const connectionId = localStorage.getItem(GITHUB_DRAFT_CONNECTION_KEY)
+    localStorage.setItem(
+      GITHUB_SETUP_RESULT_KEY,
+      JSON.stringify({
+        installationId: payload.installationId,
+        ...(connectionId ? { connectionId } : {}),
+      }),
+    )
+  } catch {
+    // localStorage might be unavailable
+  }
+}
+
+export function readGithubSetupResultFromStorage(): GithubSetupResultPayload | null {
+  if (typeof window === "undefined") return null
+  const raw = localStorage.getItem(GITHUB_SETUP_RESULT_KEY)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as GithubSetupResultPayload
+    if (!parsed.installationId) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+const GITHUB_SETUP_RESULT_POLL_MS = 50
+const GITHUB_SETUP_RESULT_POLL_ATTEMPTS = 20
+
+async function waitForGithubSetupResultInStorage(): Promise<GithubSetupResultPayload | null> {
+  for (let i = 0; i < GITHUB_SETUP_RESULT_POLL_ATTEMPTS; i++) {
+    const hit = readGithubSetupResultFromStorage()
+    if (hit) return hit
+    await new Promise<void>((r) => window.setTimeout(r, GITHUB_SETUP_RESULT_POLL_MS))
+  }
+  return readGithubSetupResultFromStorage()
+}
+
 /**
  * Persist the org context before opening the GitHub install flow so direct
  * callback navigation can resolve the intended org without guessing.
@@ -60,9 +138,11 @@ export function openCenteredPopup(url: string, options?: PopupOptions) {
   const left = Math.max(0, window.screenX + (window.outerWidth - width) / 2)
   const top = Math.max(0, window.screenY + (window.outerHeight - height) / 2)
 
+  markGithubInstallPopupSession()
+
   const popup = window.open(
     url,
-    options?.name ?? "github-connect",
+    options?.name ?? GITHUB_POPUP_NAME,
     [
       "popup=yes",
       `width=${Math.floor(width)}`,
@@ -124,17 +204,18 @@ export async function handleGithubSetupPopupResult(
   orgSlug: string,
   queryClient: QueryClient,
 ): Promise<{ status: GithubSetupRegistrationStatus }> {
-  const raw = localStorage.getItem(GITHUB_SETUP_RESULT_KEY)
+  clearGithubInstallPopupSession()
+
+  let parsed = readGithubSetupResultFromStorage()
+  if (!parsed) {
+    parsed = await waitForGithubSetupResultInStorage()
+  }
   localStorage.removeItem(GITHUB_SETUP_RESULT_KEY)
 
   let status: GithubSetupRegistrationStatus = "no_result"
 
-  if (raw) {
+  if (parsed) {
     try {
-      const parsed = JSON.parse(raw) as {
-        installationId: number
-        connectionId?: string
-      }
       const { installationId, connectionId } = parsed
       if (installationId && orgSlug) {
         const response = await client[":orgSlug"].api.v1.github.installation.$post({

--- a/apps/ui/src/routes/$orgSlug.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.index.tsx
@@ -13,6 +13,7 @@ import { AppShell } from "@/components/AppShell"
 import {
   fetchGithubInstallationSummary,
   githubConnectorKeys,
+  isGithubInstallationLinked,
 } from "@/features/connectors/queries/github-connector"
 import { useGithubConnectFlow } from "@/features/connectors/useGithubConnectFlow"
 import { useSession } from "@/lib/auth-client"
@@ -145,7 +146,7 @@ export function OrgHomePageContent({ orgSlug }: { orgSlug: string }) {
     enabled: !!session,
   })
   const { data: githubInstallation } = githubInstallationQuery
-  const githubConnected = Boolean(githubInstallation)
+  const githubConnected = isGithubInstallationLinked(githubInstallation)
 
   const {
     start,

--- a/apps/ui/src/routes/$orgSlug.setup.tsx
+++ b/apps/ui/src/routes/$orgSlug.setup.tsx
@@ -8,6 +8,7 @@ import { Modal } from "@/components/ui/Modal"
 import {
   fetchGithubInstallationSummary,
   githubConnectorKeys,
+  isGithubInstallationLinked,
 } from "@/features/connectors/queries/github-connector"
 import { useGithubConnectFlow } from "@/features/connectors/useGithubConnectFlow"
 import { client } from "@/lib/api"
@@ -69,7 +70,7 @@ function OrgSetupPage() {
   })
 
   const hasGithubInstallation =
-    Boolean(installation) || githubConnectedOptimistic
+    isGithubInstallationLinked(installation) || githubConnectedOptimistic
 
   const githubButtonBusy = installationPending || ghFlowPending || isSyncing
 

--- a/apps/ui/src/routes/[.]github.setup.tsx
+++ b/apps/ui/src/routes/[.]github.setup.tsx
@@ -5,8 +5,8 @@ import { authClient, useListOrganizations } from "@/lib/auth-client"
 import {
   consumeGithubSetupOrgHint,
   GITHUB_DRAFT_CONNECTION_KEY,
-  GITHUB_POPUP_NAME,
-  GITHUB_SETUP_RESULT_KEY,
+  isGithubInstallPopupWindow,
+  writeGithubSetupResultToStorage,
 } from "@/lib/popup"
 import { Spinner } from "@/components/ui/spinner"
 import { useMutation, useQuery } from "@tanstack/react-query"
@@ -86,16 +86,6 @@ function MissingPreferredOrgView() {
 }
 
 /**
- * `window.opener` is unreliable after cross-origin redirects (Safari/Chrome
- * strip it when navigating github.com → app.ctxpipe.ai). `window.name`
- * survives cross-origin navigations, so we check both.
- */
-function isPopupWindow() {
-  if (typeof window === "undefined") return false
-  return !!window.opener || window.name === GITHUB_POPUP_NAME
-}
-
-/**
  * When running inside a popup, we can't make authenticated API calls (the
  * session cookie is often missing after a cross-origin redirect through
  * github.com). Instead, relay the installation_id back to the opener via
@@ -103,22 +93,10 @@ function isPopupWindow() {
  * API call, and cleans up.
  */
 function RelayAndClose({ installationId }: { installationId: number }) {
+  writeGithubSetupResultToStorage({ installationId })
   useEffect(() => {
-    try {
-      const connectionId = localStorage.getItem(GITHUB_DRAFT_CONNECTION_KEY)
-      localStorage.setItem(
-        GITHUB_SETUP_RESULT_KEY,
-        JSON.stringify({
-          installationId,
-          ...(connectionId ? { connectionId } : {}),
-        }),
-      )
-    } catch {
-      // localStorage might be unavailable; the opener will fall back to
-      // re-querying without an explicit installation_id.
-    }
     window.close()
-  }, [installationId])
+  }, [])
   return null
 }
 
@@ -255,7 +233,7 @@ function DotGitHubSetupPage() {
   // Popup path: relay installation_id via localStorage and close immediately.
   // No API calls — the popup may not have valid auth cookies after the
   // cross-origin redirect through github.com.
-  if (isPopupWindow()) {
+  if (isGithubInstallPopupWindow()) {
     if (search.installation_id) {
       return <RelayAndClose installationId={search.installation_id} />
     }

--- a/apps/ui/src/routes/onboarding.tsx
+++ b/apps/ui/src/routes/onboarding.tsx
@@ -15,6 +15,7 @@ import { useOnboardingCarousel } from "@/components/onboarding/useOnboardingCaro
 import {
   fetchGithubInstallationSummary,
   githubConnectorKeys,
+  isGithubInstallationLinked,
 } from "@/features/connectors/queries/github-connector"
 import { client } from "@/lib/api"
 import { useListOrganizations, useSession } from "@/lib/auth-client"
@@ -67,7 +68,7 @@ export function OnboardingPageContent({
       orgSlug ? fetchGithubInstallationSummary(orgSlug) : Promise.resolve(null),
     enabled: Boolean(orgSlug && session),
   })
-  const hasGithubInstallation = Boolean(installation)
+  const hasGithubInstallation = isGithubInstallationLinked(installation)
 
   const onWelcomeDetailsVisible = useCallback(() => {
     setShowWelcomeDotNav(true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes GitHub App install during onboarding appearing to succeed, but the Connect GitHub step resetting because the app never detected a linked installation.

## Root cause

Two issues compounded:

1. **Ambiguous org resolution** — Self-hosted setup can leave draft/placeholder `connections` rows. After a successful GitHub App install, the org could have both a linked row and draft rows. `resolveGithubInstallationForOrgDetailed` treated any multiple rows as ambiguous, so `GET /github/installation` returned 400 and the UI kept showing “Connect GitHub”.

2. **Popup callback reliability** — The callback page wrote `installation_id` to `localStorage` in `useEffect` before closing. In some browsers/timings the opener could read storage before the write completed, yielding `no_result` and a silent failure.

## Changes

- Prefer linked connections (`installationId != null`) when resolving the default org GitHub installation; only fall back to ambiguous when multiple linked or multiple unlinked rows exist.
- Write GitHub setup results to `localStorage` synchronously in the popup; add `sessionStorage` popup marker; brief poll in the opener before registering.
- Treat GitHub as “connected” in onboarding/UI only when `installationId` is set (`isGithubInstallationLinked`).

## Testing

- `apps/backend/src/models/github-installation.resolve.test.ts` (new)
- `apps/ui/src/features/connectors/githubConnectFlow.test.ts` (updated)

## Manual verification

1. Onboarding → Connect GitHub → complete GitHub App install in popup.
2. Confirm onboarding advances (or shows connected state) without looping.
3. Self-hosted: repeat after partially opening the self-hosted wizard (draft row present).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-101](https://linear.app/ctxpipe/issue/CTX-101/cant-connect-github-during-onboarding-flow)

<div><a href="https://cursor.com/agents/bc-1de10d61-deb6-40f4-a2b7-f197609f5c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1de10d61-deb6-40f4-a2b7-f197609f5c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

