### PR TITLE
fix(backend): Anthropic Claude MCP connector compatibility (CTX-108)

### DIFF
--- a/apps/backend/src/app/app.ts
+++ b/apps/backend/src/app/app.ts
@@ -56,10 +56,17 @@ export function createApp() {
 
   const app = new OpenAPIHono<AppEnv>()
 
-  const corsOrigins = (env.AUTH_ALLOWED_ORIGINS ?? "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean)
+  const corsOrigins = [
+    ...new Set(
+      [
+        ...(env.AUTH_ALLOWED_ORIGINS ?? "")
+          .split(",")
+          .map((value) => value.trim())
+          .filter(Boolean),
+        "https://claude.ai",
+      ].filter(Boolean),
+    ),
+  ]
 
   app.use(
     "*",

--- a/apps/backend/src/auth/config.ts
+++ b/apps/backend/src/auth/config.ts
@@ -45,10 +45,18 @@ export function createBetterAuth() {
   const env = parseEnv(process.env as Record<string, string | undefined>)
   const db = initDb(env.DATABASE_URL)
   const issuer = env.AUTH_ISSUER ?? env.AUTH_BASE_URL
-  const trustedOrigins = (env.AUTH_ALLOWED_ORIGINS ?? "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean)
+  const trustedOrigins = [
+    ...new Set(
+      [
+        ...(env.AUTH_ALLOWED_ORIGINS ?? "")
+          .split(",")
+          .map((value) => value.trim())
+          .filter(Boolean),
+        // Claude workspace / claude.ai custom MCP connectors (OAuth callback host).
+        "https://claude.ai",
+      ].filter(Boolean),
+    ),
+  ]
 
   return betterAuth({
     appName: "ctx|",

--- a/apps/backend/src/routes/auth.test.ts
+++ b/apps/backend/src/routes/auth.test.ts
@@ -123,12 +123,20 @@ describe("auth metadata routes", () => {
     const oidcAppended = await app.request(
       "/mcp/.well-known/openid-configuration",
     )
+    const prmAppended = await app.request(
+      "/mcp/.well-known/oauth-protected-resource",
+    )
     expect(oidcRoot.status).toBe(200)
     expect(oidcInserted.status).toBe(200)
     expect(oidcAppended.status).toBe(200)
+    expect(prmAppended.status).toBe(200)
     const oidcRootBody = await oidcRoot.text()
+    const prmMcpBody = await app.request(
+      "/.well-known/oauth-protected-resource/mcp",
+    )
     expect(await oidcInserted.text()).toBe(oidcRootBody)
     expect(await oidcAppended.text()).toBe(oidcRootBody)
+    expect(await prmAppended.text()).toBe(await prmMcpBody.text())
 
     const oauthIssuerPath = await app.request(
       "/.well-known/oauth-authorization-server/.auth/api/v1/auth",

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -187,5 +187,11 @@ export function registerAuthRoutes(app: Hono<AppEnv>) {
     "/.well-known/oauth-protected-resource/mcp",
     serveMcpProtectedResourceMetadata,
   )
+
+  // RFC 9728 path-appended PRM when the resource identifier is …/mcp (before UI catch-all).
+  app.get(
+    "/mcp/.well-known/oauth-protected-resource",
+    serveMcpProtectedResourceMetadata,
+  )
   return app
 }

--- a/apps/backend/src/routes/mcp.test.ts
+++ b/apps/backend/src/routes/mcp.test.ts
@@ -78,7 +78,18 @@ describe("MCP route auth and org validation", () => {
     expect(registerMcpToolsMock).not.toHaveBeenCalled()
   })
 
-  it("returns 400 JSON-RPC error for missing orgSlug query", async () => {
+  it("returns 401 for missing orgSlug when unauthenticated (OAuth discovery)", async () => {
+    requireAuthMock.mockImplementationOnce(async (c) =>
+      c.json({ error: "Unauthorized" }, 401),
+    )
+
+    const app = createTestApp()
+    const response = await app.request("/mcp", { method: "POST" })
+    expect(response.status).toBe(401)
+    expect(registerMcpToolsMock).not.toHaveBeenCalled()
+  })
+
+  it("returns 400 JSON-RPC error for missing orgSlug when authenticated", async () => {
     const app = createTestApp()
     const response = await app.request("/mcp", { method: "POST" })
     expect(response.status).toBe(400)

--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -13,6 +13,8 @@ import { registerMcpTools } from "../mcp/tools.js"
 export function registerMcpRoutes(app: Hono<AppEnv>) {
   app.all(
     "/mcp",
+    withBearerAuth,
+    requireAuth,
     (c, next) => {
       if (c.req.query("orgSlug")) return next()
       return c.json(
@@ -28,8 +30,6 @@ export function registerMcpRoutes(app: Hono<AppEnv>) {
         400,
       )
     },
-    withBearerAuth,
-    requireAuth,
     withNetworkOrgContext,
     async (c) => {
       const server = new McpServer(

--- a/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
+++ b/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
@@ -195,9 +195,26 @@ The CLI prints this for you when it cannot run it directly.
 
 If your client's docs only mention `http` or SSE, check the current client documentation. New remote MCP integrations generally use Streamable HTTP, but client config keys still vary.
 
+## Claude / Anthropic workspace connectors
+
+Claude Team and Enterprise can add ctx| as a **custom Web connector** in [Organization settings → Connectors](https://claude.ai/admin-settings/connectors). Anthropic connects from **their cloud** (not your laptop), so the server must be on the public internet at a stable HTTPS URL.
+
+Use the same Streamable HTTP URL as other clients, including your org slug:
+
+```text
+https://app.ctxpipe.ai/mcp?orgSlug=your-org
+```
+
+After an owner adds the connector, each member must open **Customize → Connectors**, find the custom connector, and click **Connect** to complete OAuth (sign in to ctx|, approve access). Tools will not load in chat until that per-user connection is active.
+
+Anthropic supports **Streamable HTTP** (what ctx| serves at `/mcp`) and legacy SSE; ctx| does not expose a separate SSE endpoint. OAuth uses Dynamic Client Registration — leave Advanced settings OAuth fields empty unless Anthropic support asks you to register a fixed client.
+
+If the admin UI shows **"Couldn't reach the MCP server"** while adding the connector, the host often probed `/mcp` before OAuth and received a non-discovery response. Ensure the URL includes `?orgSlug=…`, then retry after deploy. If the connector saves but tools never appear, complete **Connect** on the member side and enable the connector for the conversation.
+
 ## Troubleshooting
 
 - **CLI sign-in worked, but the MCP client still asks for authorization** - expected. CLI setup auth and MCP client OAuth are separate flows.
+- **Claude workspace: connector listed but tools missing in chat** - complete per-user **Connect** under Customize → Connectors and enable the connector for that chat.
 - **Connection fails after pasting URL only** - add the client-specific `type` field. Most clients do not infer the transport reliably.
 - **OpenCode shows the server but it never connects** - use the top-level `mcp.ctxpipe` shape with `type: "remote"` and `enabled: true`.
 - **`streamable-http` is not recognized** - upgrade the client, or check whether that client expects `http` for its config key while still using a Streamable HTTP remote server.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation of **CTX-108** shows ctx| is already compatible with Anthropic’s remote MCP requirements (**Streamable HTTP** at `/mcp`, OAuth/DCR, public HTTPS). The failures reported in Claude workspace settings are primarily **integration and discovery** issues, not a missing SSE transport.

This PR hardens three server-side gaps that can cause Anthropic’s proxy (`mcp-proxy.anthropic.com`) to show **“Couldn’t reach the MCP server”** or leave tools unloaded after a connector is saved.

## Root cause analysis

| Area | Finding |
|------|---------|
| Transport | ctx| uses **Streamable HTTP** via `@hono/mcp` — supported by [Claude MCP connector docs](https://platform.claude.com/docs/en/agents-and-tools/mcp-connector) and [Claude building guide](https://claude.com/docs/connectors/building). SSE is not required. |
| Reachability | Production `https://app.ctxpipe.ai/mcp?orgSlug=…` is reachable from the public internet (401 + `WWW-Authenticate` with `resource_metadata` when unauthenticated). |
| Prior bug | `/mcp` returned **400 JSON-RPC** for missing `orgSlug` *before* auth middleware. Anthropic’s pre-OAuth probe to `/mcp` (without query) likely interpreted that as unreachable rather than OAuth-protected. |
| OAuth discovery | `/mcp/.well-known/oauth-protected-resource` returned **SPA HTML** (UI catch-all). Some MCP clients use RFC 9728 path-appended metadata URLs. |
| Claude OAuth | `https://claude.ai` was not in Better Auth `trustedOrigins` / CORS allowlist. |

## Changes

1. **Middleware order on `/mcp`**: run `withBearerAuth` + `requireAuth` before `orgSlug` validation so unauthenticated probes get **401 + OAuth discovery** instead of 400.
2. **RFC 9728 path-appended PRM**: serve protected-resource metadata at `/mcp/.well-known/oauth-protected-resource`.
3. **Trust `https://claude.ai`** for Better Auth and CORS (no new env vars).
4. **Docs**: Claude Team/Enterprise workspace connector setup and troubleshooting in `apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx`.

## Operator / user steps (post-deploy)

1. Org owner adds connector URL: `https://app.ctxpipe.ai/mcp?orgSlug=<slug>` (must include `orgSlug`).
2. Each member: **Customize → Connectors → Connect** and complete ctx| OAuth.
3. Enable the connector for the conversation.

## Known Anthropic-side limitations (not fixed here)

- [HTTP/2 lowercase `WWW-Authenticate`](https://github.com/anthropics/claude-ai-mcp/issues/219) on Cloudflare may affect OAuth discovery in edge cases.
- [Streamable HTTP tool execution bugs](https://github.com/anthropics/claude-ai-mcp/issues/123) in claude.ai web UI (discovery works, calls may not).
- Connector must be **connected per user**; admin “add connector” alone does not load tools in chat.

## Testing

- `pnpm --filter @ctxpipe/backend test` — `src/routes/mcp.test.ts`, `src/routes/auth.test.ts` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-108](https://linear.app/ctxpipe/issue/CTX-108/mcp-connection-issue-with-anthropic-workspace)

<div><a href="https://cursor.com/agents/bc-8a2714fd-165d-40a9-a845-81803e2e59d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a2714fd-165d-40a9-a845-81803e2e59d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

