### PR TITLE
fix(backend): harden Postgres pool for auth session lookups (CTX-116)

### DIFF
--- a/apps/backend/src/app/app.ts
+++ b/apps/backend/src/app/app.ts
@@ -11,6 +11,7 @@ import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { getAuth } from "../auth/config.js"
 import { parseEnv } from "../config/env.js"
 import { initDb } from "../db/client.js"
+import { sanitizeDbError } from "../db/sanitize-db-error.js"
 import { initAmplitudeFromEnv } from "../observability/amplitude.js"
 import { backfillGithubAppSecretsFromEnv } from "../scripts/backfillGithubConnectionSecrets.js"
 import { createEvlogDrain, log } from "../observability/logger.js"
@@ -93,7 +94,7 @@ export function createApp() {
       return new Response(null, { status: 499 })
     }
 
-    c.get("log").error(error)
+    c.get("log").error(sanitizeDbError(error))
     const parsed = parseError(error)
 
     return c.json(

--- a/apps/backend/src/db/client.ts
+++ b/apps/backend/src/db/client.ts
@@ -1,14 +1,15 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 import { sql } from "drizzle-orm"
 import { drizzle } from "drizzle-orm/node-postgres"
-import { Pool } from "pg"
 import { log } from "../observability/logger.js"
+import { createPgPool } from "./pg-pool.js"
+import { sanitizeDbError } from "./sanitize-db-error.js"
 import { relations, schema } from "./schema.js"
 
 function createDrizzleDb(connectionString: string) {
-  const client = new Pool({
+  const client = createPgPool({
     connectionString,
-    idleTimeoutMillis: 300000,
+    applicationName: "ctxpipe-backend",
   })
   return drizzle({ client, schema, relations })
 }
@@ -62,12 +63,11 @@ export async function withOrgDbContext<T>(
       // drop AsyncLocalStorage across `() => handler(tx)` when `handler` is async.
       return await orgDbStorage.run(tx, async () => handler(tx))
     } catch (err) {
-      log.error({
+      const safe = sanitizeDbError(err)
+      log.error(safe instanceof Error ? safe : new Error(String(safe)), {
         step: "withOrgDbContext.rollback",
         message: "withOrgDbContext: transaction rollback",
         orgId,
-        error: err instanceof Error ? err.message : String(err),
-        cause: err instanceof Error ? err.cause : undefined,
       })
       throw err
     }

--- a/apps/backend/src/db/migrate.ts
+++ b/apps/backend/src/db/migrate.ts
@@ -4,14 +4,17 @@
 // ones already run.
 import { drizzle } from "drizzle-orm/node-postgres"
 import { migrate } from "drizzle-orm/node-postgres/migrator"
-import { Pool } from "pg"
+import { createPgPool } from "./pg-pool.js"
 import { initEvlog, log } from "../observability/logger.js"
 
 initEvlog()
 
 const connectionString = process.env.DATABASE_URL ?? "[REDACTED]"
 
-const pool = new Pool({ connectionString })
+const pool = createPgPool({
+  connectionString,
+  applicationName: "ctxpipe-migrate",
+})
 const db = drizzle({ client: pool })
 
 log.info({ step: "migrate", message: "[migrate] running migrations…" })

--- a/apps/backend/src/db/pg-pool.test.ts
+++ b/apps/backend/src/db/pg-pool.test.ts
@@ -1,0 +1,73 @@
+import { Pool } from "pg"
+import { describe, expect, it, vi } from "vitest"
+import {
+  buildPgPoolConfig,
+  isTransientPgConnectionError,
+  RetryingPgPool,
+} from "./pg-pool.js"
+
+describe("buildPgPoolConfig", () => {
+  it("sets keepalive, idle timeout, maxUses, and strips sslmode from URL", () => {
+    const config = buildPgPoolConfig({
+      connectionString:
+        "postgresql://user:pass@db.example.com:5432/ctxpipe?sslmode=require",
+      applicationName: "ctxpipe-test",
+    })
+
+    expect(config.keepAlive).toBe(true)
+    expect(config.idleTimeoutMillis).toBe(30_000)
+    expect(config.maxUses).toBe(5_000)
+    expect(config.application_name).toBe("ctxpipe-test")
+    expect(config.connectionString).not.toContain("sslmode=")
+    expect(config.ssl).toEqual({ rejectUnauthorized: false })
+  })
+
+  it("leaves local URLs without sslmode unchanged", () => {
+    const config = buildPgPoolConfig({
+      connectionString: "postgresql://ctxpipe:ctxpipe@localhost:5433/ctxpipe",
+    })
+    expect(config.ssl).toBeUndefined()
+    expect(config.connectionString).toBe(
+      "postgresql://ctxpipe:ctxpipe@localhost:5433/ctxpipe",
+    )
+  })
+
+  it("maps verify-full to strict TLS", () => {
+    const config = buildPgPoolConfig({
+      connectionString:
+        "postgresql://u:p@host/db?sslmode=verify-full",
+    })
+    expect(config.ssl).toEqual({ rejectUnauthorized: true })
+  })
+})
+
+describe("isTransientPgConnectionError", () => {
+  it("detects connection terminated unexpectedly", () => {
+    expect(
+      isTransientPgConnectionError(
+        new Error("Connection terminated unexpectedly"),
+      ),
+    ).toBe(true)
+  })
+
+  it("ignores unrelated errors", () => {
+    expect(isTransientPgConnectionError(new Error("syntax error"))).toBe(false)
+  })
+})
+
+describe("RetryingPgPool", () => {
+  it("retries once on transient connection errors", async () => {
+    const spy = vi
+      .spyOn(Pool.prototype, "query")
+      .mockRejectedValueOnce(new Error("Connection terminated unexpectedly"))
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+
+    const pool = new RetryingPgPool({
+      connectionString: "postgresql://u:p@localhost:5433/ctxpipe",
+    })
+    await pool.query("select 1")
+    expect(spy).toHaveBeenCalledTimes(2)
+    spy.mockRestore()
+    await pool.end()
+  })
+})

--- a/apps/backend/src/db/pg-pool.ts
+++ b/apps/backend/src/db/pg-pool.ts
@@ -1,0 +1,157 @@
+import type { PoolConfig } from "pg"
+import { Pool } from "pg"
+import { log } from "../observability/logger.js"
+
+/** Recycle pooled connections before typical proxy/LB idle cuts (~60s). */
+const POOL_IDLE_TIMEOUT_MS = 30_000
+
+/** Cap connection lifetime to avoid long-lived sockets that infra may reset. */
+const POOL_MAX_USES = 5_000
+
+type PgSslConfig = boolean | { rejectUnauthorized: boolean }
+
+function resolveSslFromConnectionUrl(connectionString: string): {
+  ssl?: PgSslConfig
+  /** Connection string with sslmode stripped so pg does not re-parse ambiguously. */
+  connectionString: string
+} {
+  let url: URL
+  try {
+    url = new URL(connectionString)
+  } catch {
+    return { connectionString }
+  }
+
+  const sslmode = url.searchParams.get("sslmode")
+  if (!sslmode) {
+    return { connectionString }
+  }
+
+  url.searchParams.delete("sslmode")
+  const cleaned = url.toString()
+
+  const ssl = sslConfigForMode(sslmode)
+  return ssl === undefined ? { connectionString: cleaned } : { ssl, connectionString: cleaned }
+}
+
+function sslConfigForMode(sslmode: string): PgSslConfig | undefined {
+  switch (sslmode) {
+    case "disable":
+      return false
+    case "no-verify":
+      return { rejectUnauthorized: false }
+    case "prefer":
+    case "require":
+      // libpq-compatible: TLS without strict hostname verification (Neon/RDS poolers).
+      return { rejectUnauthorized: false }
+    case "verify-ca":
+    case "verify-full":
+      return { rejectUnauthorized: true }
+    default:
+      return { rejectUnauthorized: true }
+  }
+}
+
+export type CreatePgPoolOptions = {
+  connectionString: string
+  /** Shown in pg_stat_activity; defaults to `ctxpipe-backend`. */
+  applicationName?: string
+  max?: number
+}
+
+/**
+ * Shared pg.Pool defaults for API, auth (Better Auth), and workers.
+ * Mitigates stale connections dropped by poolers/LBs and clarifies SSL from DATABASE_URL.
+ */
+function hostPortUserFromUrl(connectionString: string): Pick<
+  PoolConfig,
+  "host" | "port" | "user" | "password" | "database"
+> {
+  try {
+    const url = new URL(connectionString)
+    const database = url.pathname.replace(/^\//, "") || undefined
+    return {
+      host: url.hostname || undefined,
+      port: url.port ? Number.parseInt(url.port, 10) : undefined,
+      user: url.username ? decodeURIComponent(url.username) : undefined,
+      password: url.password ? decodeURIComponent(url.password) : undefined,
+      database: database ? decodeURIComponent(database) : undefined,
+    }
+  } catch {
+    return {}
+  }
+}
+
+export function buildPgPoolConfig(options: CreatePgPoolOptions): PoolConfig {
+  const { ssl, connectionString } = resolveSslFromConnectionUrl(
+    options.connectionString,
+  )
+
+  const config: PoolConfig = {
+    connectionString,
+    ...hostPortUserFromUrl(connectionString),
+    ssl,
+    keepAlive: true,
+    idleTimeoutMillis: POOL_IDLE_TIMEOUT_MS,
+    connectionTimeoutMillis: 10_000,
+    maxUses: POOL_MAX_USES,
+    application_name: options.applicationName ?? "ctxpipe-backend",
+    max: options.max,
+  }
+
+  return config
+}
+
+/**
+ * One immediate retry on transient socket drops (common behind poolers during session lookup).
+ */
+export class RetryingPgPool extends Pool {
+  // biome-ignore lint/suspicious/noExplicitAny: pg query overloads
+  override query(...args: any[]): any {
+    const run = () => super.query(...args)
+    return run().catch((err: unknown) => {
+      if (!isTransientPgConnectionError(err)) throw err
+      return run()
+    })
+  }
+}
+
+export function createPgPool(options: CreatePgPoolOptions): Pool {
+  const pool = new RetryingPgPool(buildPgPoolConfig(options))
+
+  pool.on("error", (err) => {
+    log.error({
+      step: "db.pool",
+      message: "Postgres pool idle client error",
+      applicationName: options.applicationName ?? "ctxpipe-backend",
+      error: err instanceof Error ? err.message : String(err),
+      code:
+        err && typeof err === "object" && "code" in err
+          ? String((err as { code?: string }).code)
+          : undefined,
+    })
+  })
+
+  return pool
+}
+
+/** True when pg/pg-pool reports a dropped or reset connection (retry-safe). */
+export function isTransientPgConnectionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  const message = err.message.toLowerCase()
+  if (
+    message.includes("connection terminated") ||
+    message.includes("connection terminated unexpectedly") ||
+    message.includes("connection reset") ||
+    message.includes("econnreset") ||
+    message.includes("socket hang up") ||
+    message.includes("client has encountered a connection error")
+  ) {
+    return true
+  }
+  const code =
+    err && typeof err === "object" && "code" in err
+      ? (err as { code?: string }).code
+      : undefined
+  return code === "ECONNRESET" || code === "57P01" || code === "08006" || code === "08003"
+}

--- a/apps/backend/src/db/sanitize-db-error.test.ts
+++ b/apps/backend/src/db/sanitize-db-error.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { DrizzleQueryError } from "drizzle-orm"
+import { redactQueryParams, sanitizeDbError } from "./sanitize-db-error.js"
+
+describe("redactQueryParams", () => {
+  it("redacts params when query selects sessions by token", () => {
+    const query =
+      'select ... from "sessions" where "sessions"."token" = $1'
+    const redacted = redactQueryParams(["sess_secret_token_value"], query)
+    expect(redacted).toEqual(["<redacted len=23>"])
+  })
+
+  it("leaves params unchanged for non-sensitive queries", () => {
+    expect(redactQueryParams(["org_abc"], 'select "id" from "organizations"')).toEqual([
+      "org_abc",
+    ])
+  })
+})
+
+describe("sanitizeDbError", () => {
+  it("strips session token from DrizzleQueryError message", () => {
+    const cause = new Error("Connection terminated unexpectedly")
+    const err = new DrizzleQueryError(
+      'select "id" from "sessions" where "sessions"."token" = $1',
+      ["super_secret_session_token"],
+      cause,
+    )
+
+    const sanitized = sanitizeDbError(err) as Error
+    expect(sanitized.message).toContain("<redacted len=")
+    expect(sanitized.message).not.toContain("super_secret_session_token")
+  })
+
+  it("returns non-drizzle errors unchanged", () => {
+    const err = new Error("other")
+    expect(sanitizeDbError(err)).toBe(err)
+  })
+})

--- a/apps/backend/src/db/sanitize-db-error.ts
+++ b/apps/backend/src/db/sanitize-db-error.ts
@@ -1,0 +1,57 @@
+import { DrizzleQueryError } from "drizzle-orm"
+
+/** SQL fragments that indicate bound params may contain secrets (session tokens, etc.). */
+const SENSITIVE_QUERY_MARKERS = [
+  /"sessions"\."token"/i,
+  /"token"\s*=\s*\$/,
+  /refresh_token/i,
+  /"password"/i,
+  /client_secret/i,
+] as const
+
+function queryMayContainSecrets(query: string): boolean {
+  return SENSITIVE_QUERY_MARKERS.some((pattern) => pattern.test(query))
+}
+
+/** Redact string query parameters for safe logging (presence + length only). */
+export function redactQueryParams(
+  params: unknown,
+  query?: string,
+): unknown {
+  const redactAll =
+    typeof query === "string" && queryMayContainSecrets(query)
+
+  if (!Array.isArray(params)) {
+    return redactAll ? "[redacted]" : params
+  }
+
+  return params.map((value) => {
+    if (typeof value !== "string" || value.length === 0) return value
+    if (!redactAll) return value
+    return `<redacted len=${value.length}>`
+  })
+}
+
+function isDrizzleQueryError(err: unknown): err is DrizzleQueryError {
+  return err instanceof DrizzleQueryError
+}
+
+/**
+ * Returns an error safe to pass to evlog / OTLP: Drizzle query failures no longer
+ * embed raw session tokens in `message` when the SQL touches sensitive columns.
+ */
+export function sanitizeDbError(err: unknown): unknown {
+  if (!isDrizzleQueryError(err)) return err
+
+  const redactedParams = redactQueryParams(err.params, err.query)
+  const sanitized = new Error(
+    `Failed query: ${err.query}\nparams: ${JSON.stringify(redactedParams)}`,
+  )
+  sanitized.name = err.name
+  if (err.cause !== undefined) {
+    ;(sanitized as Error & { cause?: unknown }).cause = sanitizeDbError(
+      err.cause,
+    )
+  }
+  return sanitized
+}

--- a/apps/backend/src/graphs/conversationGraph/graph.ts
+++ b/apps/backend/src/graphs/conversationGraph/graph.ts
@@ -1,8 +1,7 @@
 import { END, START, StateGraph } from "@langchain/langgraph"
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres"
 import "@langchain/langgraph/zod"
-import { Pool } from "pg"
-import { log } from "../../observability/logger.js"
+import { createPgPool } from "../../db/pg-pool.js"
 import { agentNode } from "./nodes/agent.js"
 import { assembleNode } from "./nodes/assemble.js"
 import { conversationNaming } from "./nodes/conversationNaming.js"
@@ -43,20 +42,10 @@ const workflow = new StateGraph(ConversationGraphStateSchema)
 
 let checkpointer: PostgresSaver | undefined
 if (process.env.DATABASE_URL) {
-  const checkpointPool = new Pool({
+  const checkpointPool = createPgPool({
     connectionString: process.env.DATABASE_URL,
+    applicationName: "ctxpipe-checkpointer",
     max: 10,
-    keepAlive: true,
-    idleTimeoutMillis: 30_000,
-    connectionTimeoutMillis: 5_000,
-    application_name: "ctxpipe-checkpointer",
-  })
-  checkpointPool.on("error", (err) => {
-    log.error({
-      step: "conversation.checkpointer_pool",
-      message: "Checkpointer pg pool error",
-      error: err instanceof Error ? err.message : String(err),
-    })
   })
   checkpointer = new PostgresSaver(checkpointPool)
   await checkpointer.setup()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses intermittent Better Auth `INTERNAL_SERVER_ERROR` during session token validation when `pg-pool` reports **Connection terminated unexpectedly** on routine `sessions` lookups.

## Root cause (evidence-based)

The failure chain matches **stale or reset TCP connections** in the app pool, not bad SQL:

1. The main API pool used a **5 minute** `idleTimeoutMillis` with **no TCP keepalive**, while the LangGraph checkpointer pool already used **30s idle + keepalive**.
2. Managed Postgres / poolers (Neon, RDS Proxy, Railway, etc.) commonly recycle idle connections around **30–60s**. The client can hand out a socket the server has already closed → `Connection terminated unexpectedly` mid-query.
3. `pg-connection-string` warns that `sslmode=require` semantics are in flux; leaving `sslmode` only in the URL delegates ambiguous TLS behaviour to the driver.

## Changes

- **`createPgPool` / `RetryingPgPool`**: shared pool defaults — `keepAlive`, 30s idle timeout, `maxUses`, 10s connect timeout, explicit `ssl` derived from `sslmode` (stripped from URL to avoid double-parse), idle pool `error` logging.
- **One-shot retry** on transient connection errors (covers auth session lookup without app-level changes).
- **`sanitizeDbError`**: redacts bound params for sensitive SQL (e.g. `sessions.token`) in Drizzle error messages before evlog / `onError` logging.

## Validation

- New unit tests: `pg-pool.test.ts`, `sanitize-db-error.test.ts` (10 tests, all passing).
- Full backend suite: same pre-existing failures on `main` (e.g. `app.test.ts` UI proxy auth expectations); no new regressions attributable to this diff.

## Operator notes

- For hosted Postgres, prefer an explicit `sslmode` in `DATABASE_URL` (`require` → TLS without strict hostname verify; `verify-full` → strict). Local Compose (`localhost`) unchanged when `sslmode` is omitted.
- After deploy, correlate auth 500 rate with pool `db.pool` wide events; expect drop once stale sockets are recycled faster.

Fixes CTX-116
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-116](https://linear.app/ctxpipe/issue/CTX-116/auth-session-lookups-failing-with-intermittent-postgres-connection)

<div><a href="https://cursor.com/agents/bc-6c4d248e-49ca-4054-9026-9cb29628628d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c4d248e-49ca-4054-9026-9cb29628628d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

