### PR TITLE
fix: async repository deletion to prevent 524 timeouts (CTX-117)

### DIFF
--- a/apps/backend/src/domain/repositoryDeletion.ts
+++ b/apps/backend/src/domain/repositoryDeletion.ts
@@ -113,11 +113,26 @@ export async function dropFalkorOrgGraph(orgId: string): Promise<void> {
  * transaction so a crash cannot leave orphaned state. Graph and codesearch
  * calls are best-effort and run after commit.
  */
+function logDeletionPhase(
+  step: string,
+  startedAt: number,
+  fields: Record<string, unknown>,
+): void {
+  log.info({
+    step,
+    message: "repositoryDeletion: phase complete",
+    durationMs: Date.now() - startedAt,
+    ...fields,
+  })
+}
+
 export async function deleteRepositoryWithCleanup(params: {
   orgId: string
   repositoryId: string
 }): Promise<boolean> {
+  const overallStarted = Date.now()
   const db = getOrgDb()
+  const lookupStarted = Date.now()
   const [row] = await db
     .select({
       id: repositories.id,
@@ -141,12 +156,24 @@ export async function deleteRepositoryWithCleanup(params: {
     .limit(1)
 
   if (!row) {
+    log.info({
+      step: "repositoryDeletion.lookup",
+      message: "repositoryDeletion: repository not found",
+      repositoryId: params.repositoryId,
+      durationMs: Date.now() - lookupStarted,
+    })
     return false
   }
+
+  logDeletionPhase("repositoryDeletion.lookup", lookupStarted, {
+    repositoryId: params.repositoryId,
+    zoektRepoId: row.zoektRepoId,
+  })
 
   // Atomic: evidence reconciliation + repo row deletion in one transaction.
   // Deleting the repositories row cascades to repository_checkouts.
   // purgeRepositoryEvidencePg opens a nested savepoint inside this transaction.
+  const pgStarted = Date.now()
   const { stats, graphEffects, deleted } = await db.transaction(async (tx) => {
     const result = await purgeRepositoryEvidencePg(tx, {
       orgId: params.orgId,
@@ -168,29 +195,32 @@ export async function deleteRepositoryWithCleanup(params: {
     }
   })
 
-  if (
-    stats.deletedEvidenceRows > 0 ||
-    stats.claimsUpdated > 0 ||
-    stats.claimsDeleted > 0
-  ) {
-    log.info({
-      step: "repositoryDeletion.evidence_purge",
-      message: "repositoryDeletion: evidence purge",
-      repositoryId: params.repositoryId,
-      ...stats,
-    })
-  }
+  logDeletionPhase("repositoryDeletion.postgres", pgStarted, {
+    repositoryId: params.repositoryId,
+    deleted,
+    ...stats,
+  })
 
-  // Best-effort post-commit: graph sync and codesearch disk cleanup
+  const graphSyncStarted = Date.now()
   await applyIngestionRetractionGraphEffects(graphEffects)
+  logDeletionPhase("repositoryDeletion.graph_sync", graphSyncStarted, {
+    repositoryId: params.repositoryId,
+    deletedClaimIds: graphEffects.deletedClaimIds.length,
+    refreshedClaimIds: graphEffects.refreshedClaimIds.length,
+    deletedObjectIds: graphEffects.deletedObjectIds.length,
+  })
 
   // Remove the Repository node itself from FalkorDB (claim edges were handled
   // above via graphEffects; this catches the node that may remain as an orphan).
   // Caller must have set up withGraphClient context.
+  const falkorRepoStarted = Date.now()
   try {
     const driver = getGraphClient()
     await driver.executeQuery(`MATCH (n { id: $repoId }) DETACH DELETE n`, {
       repoId: params.repositoryId,
+    })
+    logDeletionPhase("repositoryDeletion.falkor_repo_node", falkorRepoStarted, {
+      repositoryId: params.repositoryId,
     })
   } catch (e) {
     log.error({
@@ -201,11 +231,24 @@ export async function deleteRepositoryWithCleanup(params: {
     })
   }
 
+  const codesearchStarted = Date.now()
   await notifyCodesearchRepositoryDeleted({
     orgId: params.orgId,
     repositoryId: row.id,
     repoName: row.name,
     zoektRepoId: row.zoektRepoId,
+  })
+  logDeletionPhase("repositoryDeletion.codesearch", codesearchStarted, {
+    repositoryId: params.repositoryId,
+    zoektRepoId: row.zoektRepoId,
+  })
+
+  log.info({
+    step: "repositoryDeletion.complete",
+    message: "repositoryDeletion: finished",
+    repositoryId: params.repositoryId,
+    deleted,
+    durationMs: Date.now() - overallStarted,
   })
 
   return deleted

--- a/apps/backend/src/models/repositories.ts
+++ b/apps/backend/src/models/repositories.ts
@@ -1,13 +1,14 @@
 import { and, count, eq } from "drizzle-orm"
-import { requireCurrentOrgId, requireCurrentOrgSlug } from "../auth/context.js"
+import { requireCurrentOrgId } from "../auth/context.js"
 import { getOrgDb, withOrgDbContext } from "../db/client.js"
 import { repositories } from "../db/schema/repositories.js"
 import { repositoryCheckouts } from "../db/schema/repository_checkouts.js"
-import { deleteRepositoryWithCleanup } from "../domain/repositoryDeletion.js"
 import { generateObjectId } from "../lib/id.js"
-import { withGraphClient } from "../platform/graph/client.js"
 
 export const DEFAULT_CHECKOUT_KEY = "default"
+
+/** Set on the repository row while async deletion runs (UI + list polling). */
+export const REPOSITORY_DELETING_REASON = "deleting" as const
 
 /** Repository row shape used by API and tools (includes primary Zoekt id from default checkout). */
 export type RepositoryWithSearch = typeof repositories.$inferSelect & {
@@ -160,6 +161,25 @@ export async function markRepositoryIndexingPending(input: {
     .where(eq(repositories.id, input.repositoryId))
 }
 
+/**
+ * Marks a repository as mid-deletion for the UI. Returns false when the row
+ * does not exist. Idempotent when already marked deleting.
+ */
+export async function markRepositoryDeletionQueued(input: {
+  repositoryId: string
+}): Promise<boolean> {
+  const db = getOrgDb()
+  const result = await db
+    .update(repositories)
+    .set({
+      indexReady: false,
+      indexingReason: REPOSITORY_DELETING_REASON,
+      updatedAt: new Date(),
+    })
+    .where(eq(repositories.id, input.repositoryId))
+  return Boolean(result.rowCount && result.rowCount > 0)
+}
+
 /** Match GitHub `full_name` for a specific GitHub connection only.
  *  Assumes caller has established org DB context. */
 export async function findRepositoryByGithubInstallation(
@@ -283,10 +303,3 @@ export const bulkCreateRepositoriesForOrg = async (
   )
 }
 
-export const deleteRepository = async (repositoryId: string) => {
-  const orgId = requireCurrentOrgId()
-  const orgSlug = requireCurrentOrgSlug()
-  return withGraphClient({ orgId, orgSlug }, () =>
-    deleteRepositoryWithCleanup({ orgId, repositoryId }),
-  )
-}

--- a/apps/backend/src/openworkflow/enqueue-repository-deletion.test.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-deletion.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const markDeletionQueuedMock = vi.hoisted(() => vi.fn())
+const runWorkflowMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ workflowRun: { id: "wr_delete_1" } }),
+)
+
+vi.mock("../db/client.js", () => ({
+  withOrgDbContext: (_orgId: string, fn: () => Promise<unknown>) => fn(),
+}))
+
+vi.mock("../models/repositories.js", () => ({
+  markRepositoryDeletionQueued: markDeletionQueuedMock,
+}))
+
+vi.mock("./client.js", () => ({
+  runWorkflowWithWorkerWake: (...args: unknown[]) => runWorkflowMock(...args),
+}))
+
+import {
+  enqueueRepositoryDeletionWorkflow,
+  repositoryDeletionIdempotencyKey,
+} from "./enqueue-repository-deletion.js"
+import { repositoryDeletion } from "./workflows/repository-deletion.js"
+
+describe("enqueueRepositoryDeletionWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    runWorkflowMock.mockResolvedValue({ workflowRun: { id: "wr_delete_1" } })
+  })
+
+  it("returns null when the repository row is missing", async () => {
+    markDeletionQueuedMock.mockResolvedValue(false)
+
+    const result = await enqueueRepositoryDeletionWorkflow(
+      { repositoryId: "repo_missing", orgId: "org_1" },
+      { error: vi.fn() },
+    )
+
+    expect(result).toBeNull()
+    expect(runWorkflowMock).not.toHaveBeenCalled()
+  })
+
+  it("marks deleting and enqueues workflow with idempotency key", async () => {
+    markDeletionQueuedMock.mockResolvedValue(true)
+
+    const result = await enqueueRepositoryDeletionWorkflow(
+      { repositoryId: "repo_1", orgId: "org_1" },
+      { error: vi.fn() },
+    )
+
+    expect(result).toEqual({
+      jobId: "wr_delete_1",
+      status: "queued",
+    })
+    expect(markDeletionQueuedMock).toHaveBeenCalledWith({
+      repositoryId: "repo_1",
+    })
+    expect(runWorkflowMock).toHaveBeenCalledWith(
+      repositoryDeletion.spec,
+      { repositoryId: "repo_1", orgId: "org_1" },
+      {
+        idempotencyKey: repositoryDeletionIdempotencyKey("org_1", "repo_1"),
+      },
+    )
+  })
+})

--- a/apps/backend/src/openworkflow/enqueue-repository-deletion.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-deletion.ts
@@ -1,0 +1,60 @@
+import { withOrgDbContext } from "../db/client.js"
+import { markRepositoryDeletionQueued } from "../models/repositories.js"
+import { runWorkflowWithWorkerWake } from "./client.js"
+import { repositoryDeletion } from "./workflows/repository-deletion.js"
+
+export type RepositoryDeletionEnqueueInput = {
+  repositoryId: string
+  orgId: string
+}
+
+export type RepositoryDeletionEnqueueResult = {
+  jobId: string
+  status: "queued"
+}
+
+export function repositoryDeletionIdempotencyKey(
+  orgId: string,
+  repositoryId: string,
+): string {
+  return `repository-deletion:${orgId}:${repositoryId}`
+}
+
+/**
+ * Marks the repo as deleting for the UI, then enqueues repository-deletion.
+ * Uses an idempotency key so repeated DELETE requests return the same job.
+ */
+export async function enqueueRepositoryDeletionWorkflow(
+  input: RepositoryDeletionEnqueueInput,
+  log: { error: (err: Error) => void },
+): Promise<RepositoryDeletionEnqueueResult | null> {
+  const marked = await withOrgDbContext(input.orgId, () =>
+    markRepositoryDeletionQueued({ repositoryId: input.repositoryId }),
+  )
+
+  if (!marked) {
+    return null
+  }
+
+  const handle = await runWorkflowWithWorkerWake(
+    repositoryDeletion.spec,
+    {
+      repositoryId: input.repositoryId,
+      orgId: input.orgId,
+    },
+    {
+      idempotencyKey: repositoryDeletionIdempotencyKey(
+        input.orgId,
+        input.repositoryId,
+      ),
+    },
+  ).catch((err: unknown) => {
+    log.error(err instanceof Error ? err : new Error(String(err)))
+    throw err
+  })
+
+  return {
+    jobId: handle.workflowRun.id,
+    status: "queued",
+  }
+}

--- a/apps/backend/src/openworkflow/workflows/repository-deletion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-deletion.ts
@@ -1,0 +1,79 @@
+import { defineWorkflow } from "openworkflow"
+import { z } from "zod"
+import { withOrgIdContext } from "../../auth/withAuth.js"
+import { deleteRepositoryWithCleanup } from "../../domain/repositoryDeletion.js"
+import { getSystemDb, withOrgDbContext } from "../../db/client.js"
+import {
+  createLogger,
+  flushWorkflowLog,
+  getLogger,
+  withLogger,
+} from "../../observability/logger.js"
+import { withGraphClient } from "../../platform/graph/client.js"
+
+const repositoryDeletionInputSchema = z.object({
+  repositoryId: z.string().min(1),
+  orgId: z.string().min(1),
+})
+
+function logWorkflowMilestone(
+  step: string,
+  fields: Record<string, unknown>,
+): void {
+  const l = getLogger()
+  l.set({
+    step,
+    component: "openworkflow-worker",
+    at: new Date().toISOString(),
+    pid: process.pid,
+    ...fields,
+  })
+  l.info(step)
+  flushWorkflowLog()
+}
+
+export const repositoryDeletion = defineWorkflow(
+  { name: "repository-deletion", schema: repositoryDeletionInputSchema },
+  async ({ input, step }) =>
+    withLogger(
+      createLogger({
+        workflow: "repository-deletion",
+        repositoryId: input.repositoryId,
+        orgId: input.orgId,
+      }),
+      async () => {
+        logWorkflowMilestone("repository-deletion.workflow-handler-entered", {
+          repositoryId: input.repositoryId,
+          orgId: input.orgId,
+        })
+
+        const org = await getSystemDb().query.organizations.findFirst({
+          where: { id: { eq: input.orgId } },
+        })
+
+        if (!org) {
+          throw new Error(`Organization not found: ${input.orgId}`)
+        }
+
+        return withOrgIdContext({ id: org.id, slug: org.slug }, async () =>
+          withOrgDbContext(input.orgId, async () =>
+            withGraphClient({ orgId: org.id, orgSlug: org.slug }, async () => {
+              const deleted = await step.run({ name: "delete-repository" }, () =>
+                deleteRepositoryWithCleanup({
+                  orgId: input.orgId,
+                  repositoryId: input.repositoryId,
+                }),
+              )
+
+              logWorkflowMilestone("repository-deletion.complete", {
+                repositoryId: input.repositoryId,
+                deleted,
+              })
+
+              return { deleted }
+            }),
+          ),
+        )
+      },
+    ),
+)

--- a/apps/backend/src/routes/v1/repositories.ts
+++ b/apps/backend/src/routes/v1/repositories.ts
@@ -1,11 +1,12 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { AppEnv } from "../../app/env.js"
+import { requireCurrentOrgId } from "../../auth/context.js"
 import {
   createRepository,
-  deleteRepository,
   getRepository,
   listRepositories,
 } from "../../models/repositories.js"
+import { enqueueRepositoryDeletionWorkflow } from "../../openworkflow/enqueue-repository-deletion.js"
 import { enqueueRepositoryIngestionWorkflow } from "../../openworkflow/enqueue-repository-ingestion.js"
 
 const CreateRepositoryRequestSchema = z
@@ -168,6 +169,14 @@ const DeleteRepositoryParamsSchema = z
   .object({ id: z.string() })
   .openapi("DeleteRepositoryParams")
 
+const DeleteRepositoryAcceptedSchema = z
+  .object({
+    jobId: z.string(),
+    status: z.literal("queued"),
+    repositoryId: z.string(),
+  })
+  .openapi("DeleteRepositoryAccepted")
+
 export const deleteRepositoryRoute = createRoute({
   method: "delete",
   path: "/{id}",
@@ -175,8 +184,14 @@ export const deleteRepositoryRoute = createRoute({
     params: DeleteRepositoryParamsSchema,
   },
   responses: {
-    204: {
-      description: "Repository deleted",
+    202: {
+      content: {
+        "application/json": {
+          schema: DeleteRepositoryAcceptedSchema,
+        },
+      },
+      description:
+        "Repository deletion queued (cleanup runs asynchronously in the worker)",
     },
     401: {
       content: {
@@ -283,14 +298,33 @@ export const repositoryRoutes = new OpenAPIHono<AppEnv>()
     if (!user || !session) {
       return c.json({ error: "Unauthorized" }, 401)
     }
+    const orgId = requireCurrentOrgId()
     const id = c.req.param("id")
     try {
-      const repository = await deleteRepository(id)
-      if (!repository) {
+      const result = await enqueueRepositoryDeletionWorkflow(
+        { repositoryId: id, orgId },
+        {
+          error: (err) =>
+            c
+              .get("log")
+              .error(err, { step: "repositories.delete.enqueue-deletion" }),
+        },
+      )
+      if (!result) {
         return c.json({ error: "Not found" }, 404)
       }
-      return c.body(null, 204)
-    } catch {
+      return c.json(
+        {
+          jobId: result.jobId,
+          status: result.status,
+          repositoryId: id,
+        },
+        202,
+      )
+    } catch (e) {
+      c.get("log").error(e instanceof Error ? e : new Error(String(e)), {
+        step: "repositories.delete",
+      })
       return c.json({ error: "Internal server error" }, 500)
     }
   })

--- a/apps/docs/content/docs/(guide)/git-repositories/unindex-reindex.mdx
+++ b/apps/docs/content/docs/(guide)/git-repositories/unindex-reindex.mdx
@@ -21,12 +21,22 @@ knowledge graph.
 3. Choose **Unindex**.
 4. Confirm the destructive action.
 
-The backend deletes the repository row for the organization and runs cleanup for
-associated graph and checkout state. The UI removes the row after the API call
-succeeds.
+The backend queues deletion and returns immediately while a worker removes the
+repository row and cleans up graph, evidence, and codesearch state. The UI shows
+**deleting** and removes the row once cleanup finishes.
 
 ```http
 DELETE /:orgSlug/api/v1/repositories/:id
+```
+
+Response `202 Accepted`:
+
+```json
+{
+  "jobId": "wr_…",
+  "status": "queued",
+  "repositoryId": "repo_…"
+}
 ```
 
 ## Reindex a Repository

--- a/apps/ui/src/features/repositories/components/RepositoryCard.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryCard.tsx
@@ -28,11 +28,12 @@ export function RepositoryCard({
 }: RepositoryCardProps) {
   const webUrl = githubWebUrl(repo.gitUrl)
   const indexed = repo.indexReady
-  const status: RepositoryStatusState = isDeleting
-    ? "deleting"
-    : indexed
-      ? "indexed"
-      : "indexing"
+  const status: RepositoryStatusState =
+    isDeleting || repo.indexingReason === "deleting"
+      ? "deleting"
+      : indexed
+        ? "indexed"
+        : "indexing"
 
   const indexingDetail =
     !indexed && repo.indexingReason === "merge"

--- a/apps/ui/src/routes/$orgSlug.repositories.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.repositories.index.tsx
@@ -93,8 +93,12 @@ function RepositoriesPage() {
     },
     refetchInterval: (query) => {
       const items = (query.state.data as Repository[] | undefined) ?? []
-      const hasIndexingRepos = items.some((repo) => !repo.indexReady)
-      return hasIndexingRepos ? 3000 : false
+      const needsPolling = items.some(
+        (repo) =>
+          !repo.indexReady ||
+          repo.indexingReason === "deleting",
+      )
+      return needsPolling ? 3000 : false
     },
   })
   const { data: githubPreview } = useQuery({
@@ -182,12 +186,26 @@ function RepositoriesPage() {
       const res = await client[":orgSlug"].api.v1.repositories[":id"].$delete({
         param: { id: repoId, orgSlug },
       })
+      if (res.status === 404) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(
+          (err as { error?: string }).error ?? "Repository not found",
+        )
+      }
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
         throw new Error(
           (err as { error?: string }).error ?? "Failed to delete repository",
         )
       }
+      if (res.status !== 202) {
+        throw new Error("Unexpected response while queueing repository deletion")
+      }
+      return res.json() as Promise<{
+        jobId: string
+        status: "queued"
+        repositoryId: string
+      }>
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["repositories", orgSlug] })
@@ -198,12 +216,10 @@ function RepositoriesPage() {
         queryKey: ["github-installation-setup", orgSlug],
       })
       setRepoToDelete(null)
-      toast.success("Repository unindexed")
+      toast.success("Unindexing repository — this may take a minute")
     },
     onError: (err: Error) => {
       toast.error(err.message)
-    },
-    onSettled: () => {
       setDeletingRepoId(null)
     },
   })
@@ -583,7 +599,10 @@ function RepositoriesPage() {
                     <RepositoryCard
                       repo={repo}
                       onDelete={setRepoToDelete}
-                      isDeleting={deletingRepoId === repo.id}
+                      isDeleting={
+                        deletingRepoId === repo.id ||
+                        repo.indexingReason === "deleting"
+                      }
                     />
                   </li>
                 ))}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes production `524` timeouts on `DELETE /api/v1/repositories/:id` by moving heavy cleanup (Postgres evidence purge, FalkorDB graph sync, codesearch purge) off the HTTP request path into an OpenWorkflow job.

## Changes

- **`repository-deletion` workflow** — runs existing `deleteRepositoryWithCleanup` in the worker with structured per-phase timing logs (`lookup`, `postgres`, `graph_sync`, `falkor_repo_node`, `codesearch`).
- **DELETE endpoint** — returns **`202 Accepted`** with `{ jobId, status: "queued", repositoryId }` instead of blocking until cleanup completes.
- **Idempotency** — OpenWorkflow `idempotencyKey` per org/repo so retries are safe.
- **UI** — treats `202` as success, shows **deleting** via `indexingReason === "deleting"`, polls repository list every 3s until the row disappears.
- **Docs** — updated unindex guide for async behaviour.

## Acceptance criteria (CTX-117)

| Criterion | Status |
|-----------|--------|
| Delete no longer depends on a single long-lived HTTP request | ✅ 202 + worker |
| No 524 on normal delete (request returns quickly) | ✅ |
| UI shows deterministic status | ✅ deleting + poll |
| Idempotent / safe to retry | ✅ idempotency key |
| Logs expose per-phase timing | ✅ evlog steps |

## Testing

- `pnpm exec vitest run src/openworkflow/enqueue-repository-deletion.test.ts`
- `pnpm --filter @ctxpipe/backend lint`

Fixes CTX-117
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-117](https://linear.app/ctxpipe/issue/CTX-117/repository-delete-endpoint-times-out-with-524-in-production-delete)

<div><a href="https://cursor.com/agents/bc-31bf718c-84da-4afd-bf27-2d54a640254f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31bf718c-84da-4afd-bf27-2d54a640254f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

