### PR TITLE
Graph UI fixes

### DIFF
--- a/.changeset/smart-signs-crash.md
+++ b/.changeset/smart-signs-crash.md
@@ -1,5 +1,5 @@
 ---
-"@ctxpipe/aws-cdk": minor
+"@ctxpipe/aws-cdk": patch
 ---
 
 Interaction fixes to the knowledge-graph UI

--- a/.changeset/smart-signs-crash.md
+++ b/.changeset/smart-signs-crash.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": minor
+---
+
+Interaction fixes to the knowledge-graph UI

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphCosmographCanvas.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphCosmographCanvas.tsx
@@ -100,7 +100,7 @@ const REVEAL_AFTER_REBUILD_MS = 250
 const FOCUS_FIT_PADDING = 0.12
 const INITIAL_EXTENTS_FIT_PADDING = 0.1
 const GRAPH_SIMULATION_RESTART_ALPHA = 0.35
-const INITIAL_SIMULATION_AUTO_SETTLE_MS = 9000
+const INITIAL_SIMULATION_AUTO_SETTLE_MS = 7000
 const GRAPH_SIMULATION_PRESET = {
   simulationDecay: 1800,
   simulationGravity: 0.46,
@@ -140,6 +140,7 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
   const [prepError, setPrepError] = useState<string | null>(null)
   const hasInitialFitRef = useRef(false)
   const manualSimulationControlRef = useRef(false)
+  const initialAutoSettleArmedRef = useRef(false)
   const pointIdsRef = useRef<string[]>([])
   const pointIndexByIdRef = useRef<Map<string, number>>(new Map())
   const isLassoActiveRef = useRef(false)
@@ -207,6 +208,10 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
     setIsLassoActive(false)
     cosmographRef.current?.unselectAllPoints?.()
     timelineRef.current?.setSelection?.()
+    if (!manualSimulationControlRef.current) {
+      cosmographRef.current?.pause?.()
+      setIsSimulationRunning(false)
+    }
     onSelectionChangeRef.current(null)
   }, [])
 
@@ -379,6 +384,7 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
 
     hasInitialFitRef.current = false
     manualSimulationControlRef.current = false
+    initialAutoSettleArmedRef.current = true
     setIsSimulationRunning(false)
     isLassoActiveRef.current = false
     setIsLassoActive(false)
@@ -461,8 +467,14 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
         autoSettleTimer = null
       }
       const autoSettleInitialSimulation = () => {
+        if (
+          manualSimulationControlRef.current ||
+          !initialAutoSettleArmedRef.current
+        ) {
+          return
+        }
+        initialAutoSettleArmedRef.current = false
         clearAutoSettleTimer()
-        if (manualSimulationControlRef.current) return
         autoSettleTimer = setTimeout(() => {
           if (cancelled || manualSimulationControlRef.current) return
           cosmographRef.current?.pause?.()
@@ -514,7 +526,11 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
         fitViewPadding: 0.15,
         onSimulationStart: () => {
           setIsSimulationRunning(true)
-          if (!hasInitialFitRef.current) autoSettleInitialSimulation()
+          autoSettleInitialSimulation()
+        },
+        onSimulationRestart: () => {
+          setIsSimulationRunning(true)
+          autoSettleInitialSimulation()
         },
         onSimulationEnd: () => {
           clearAutoSettleTimer()
@@ -535,13 +551,14 @@ export const KnowledgeGraphCosmographCanvas = forwardRef<
           }, REVEAL_AFTER_REBUILD_MS)
         },
         onClick: (index: number | undefined) => {
-          if (index !== undefined) handleCanvasPointIndex(index)
+          if (index !== undefined) {
+            handleCanvasPointIndex(index)
+            return
+          }
+          onBackgroundClickRef.current()
         },
         onLabelClick: (_index: number, id: string) => {
           onPointClickRef.current(id)
-        },
-        onBackgroundClick: () => {
-          onBackgroundClickRef.current()
         },
         onPointsFiltered: (_filteredPoints, selectedPointIndices) => {
           if (

--- a/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
+++ b/apps/ui/src/features/knowledge-graph/KnowledgeGraphExplorer.tsx
@@ -335,15 +335,23 @@ export function KnowledgeGraphExplorer({ orgSlug }: { orgSlug: string }) {
     setSelectedId(id)
   }, [])
 
-  const clearGraphSelection = useCallback(() => {
-    setSelectedId(null)
-    setKgFocusIds([])
-    setGraphSelection(null)
-    cgRef.current?.clearSelectionFilters()
-  }, [])
+  const clearGraphSelection = useCallback(
+    (options?: { resetCanvas?: boolean }) => {
+      const shouldResetCanvas = options?.resetCanvas ?? true
+      setSelectedId(null)
+      setKgFocusIds([])
+      setGraphSelection(null)
+      if (shouldResetCanvas) {
+        cgRef.current?.clearSelectionFilters()
+      }
+    },
+    [],
+  )
 
   const onBackgroundClick = useCallback(() => {
-    clearGraphSelection()
+    // Cosmograph already handles its own "empty click" reset flow; only clear
+    // product chrome here to avoid re-entering graph state updates mid-event.
+    clearGraphSelection({ resetCanvas: false })
   }, [clearGraphSelection])
 
   const onGraphSelectionChange = useCallback(


### PR DESCRIPTION
Interactions in the knowledge graph was buggy. This PR fixes the following bugs:

1. When the graph loads, the simulation never comes to a halt. This needs to be verified and fixed. The simulation does decellerate, but it needs to rest after 5-8 seconds. Examples in the Cosmograph website show this simulation behaviour is possible.

2. Interacting with an edge will change the background colour to a lighter grey, and then freezes the node and community labels - yet activates the simulation again. So the nodes and edges move away from the now fixed labels. Verify and fix, and note the graph visual is then no longer interactive - nothing is clickable. I need to refresh to fix.

3. Interacting with the background (black/dark grey space) does the same as bug 2. The graph simulation accelerates, the background becomes lighter grey, and the labels freeze in position. 