### PR TITLE
Fix GitHub manage scope popup flow

### DIFF
--- a/.changeset/olive-zebras-wave.md
+++ b/.changeset/olive-zebras-wave.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Fix GitHub repository Manage flow so connected organisations open the correct GitHub App scope popup.

--- a/apps/ui/src/components/onboarding/OnboardingGithubSlide.tsx
+++ b/apps/ui/src/components/onboarding/OnboardingGithubSlide.tsx
@@ -125,7 +125,7 @@ export function OnboardingGithubSlide({
                 return
               }
               setGithubSetupError(null)
-              start()
+              start("connect")
             }}
           >
             {isGithubSyncing

--- a/apps/ui/src/features/connectors/components/AddGithubConnectorButton.tsx
+++ b/apps/ui/src/features/connectors/components/AddGithubConnectorButton.tsx
@@ -59,7 +59,7 @@ export function AddGithubConnectorButton({
         type="button"
         disabled={busy}
         className="group flex w-full items-start gap-4 rounded-none border border-border bg-card/40 p-4 text-left outline-none transition-colors hover:border-teal-400/40 hover:bg-foreground/[0.03] focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-wait disabled:opacity-60"
-        onClick={() => start()}
+        onClick={() => start("connect")}
       >
         <span className="ctx-node size-12 transition-colors group-hover:border-teal-400/60 group-hover:bg-teal-400/5">
           <IconBrandGithub className="size-5 text-foreground" aria-hidden />

--- a/apps/ui/src/features/connectors/components/GithubSelfHostedWizardModal.tsx
+++ b/apps/ui/src/features/connectors/components/GithubSelfHostedWizardModal.tsx
@@ -14,6 +14,8 @@ import { orgConnectionsKeys } from "@/features/connectors/queries/org-connection
 import { githubAppInstallSelectTargetUrl } from "@/lib/github-app-url"
 import { generateGithubWebhookSecret } from "@/lib/github-webhook-secret"
 import {
+  beginGithubPopupFlow,
+  clearGithubPopupFlow,
   GITHUB_DRAFT_CONNECTION_KEY,
   GITHUB_POPUP_NAME,
   type GithubSetupRegistrationStatus,
@@ -130,6 +132,7 @@ export function GithubSelfHostedWizardModal({
       const url = githubAppInstallSelectTargetUrl(slug)
       localStorage.setItem(GITHUB_DRAFT_CONNECTION_KEY, connectionId ?? "")
       setGithubSetupOrgHint(orgSlug)
+      beginGithubPopupFlow()
       if (onHandoffClose) {
         onHandoffClose()
       } else {
@@ -155,6 +158,8 @@ export function GithubSelfHostedWizardModal({
             reset()
           })()
         })
+      } else {
+        clearGithubPopupFlow()
       }
     } catch {
       toast.error("Invalid GitHub App slug")

--- a/apps/ui/src/features/connectors/githubConnectFlow.test.ts
+++ b/apps/ui/src/features/connectors/githubConnectFlow.test.ts
@@ -9,6 +9,7 @@ describe("getGithubConnectStartBranch", () => {
         installationPending: false,
         installation: null,
         hostedDefaultAppInstallUrl: null,
+        intent: "connect",
       }),
     ).toBe("noop_bootstrap_pending")
   })
@@ -20,6 +21,7 @@ describe("getGithubConnectStartBranch", () => {
         installationPending: false,
         installation: { id: "con_1" },
         hostedDefaultAppInstallUrl: null,
+        intent: "connect",
       }),
     ).toBe("already_installed")
   })
@@ -32,6 +34,7 @@ describe("getGithubConnectStartBranch", () => {
         installation: { id: "con_1" },
         hostedDefaultAppInstallUrl:
           "https://github.com/apps/ctxpipe-agent/installations/select_target",
+        intent: "connect",
       }),
     ).toBe("already_installed")
   })
@@ -44,6 +47,7 @@ describe("getGithubConnectStartBranch", () => {
         installation: undefined,
         hostedDefaultAppInstallUrl:
           "https://github.com/apps/foo/installations/select_target",
+        intent: "connect",
       }),
     ).toBe("noop_installation_pending")
   })
@@ -56,11 +60,25 @@ describe("getGithubConnectStartBranch", () => {
         installation: null,
         hostedDefaultAppInstallUrl:
           "https://github.com/apps/ctxpipe-agent/installations/select_target",
+        intent: "connect",
       }),
     ).toBe("managed_install")
   })
 
-  it("returns managed_install for manage_scope intent", () => {
+  it("returns managed_install for manage_scope intent without installation", () => {
+    expect(
+      getGithubConnectStartBranch({
+        bootstrapPending: false,
+        installationPending: false,
+        installation: null,
+        hostedDefaultAppInstallUrl:
+          "https://github.com/apps/ctxpipe-agent/installations/select_target",
+        intent: "manage_scope",
+      }),
+    ).toBe("managed_install")
+  })
+
+  it("returns already_installed for manage_scope when installation exists", () => {
     expect(
       getGithubConnectStartBranch({
         bootstrapPending: false,
@@ -70,7 +88,7 @@ describe("getGithubConnectStartBranch", () => {
           "https://github.com/apps/ctxpipe-agent/installations/select_target",
         intent: "manage_scope",
       }),
-    ).toBe("managed_install")
+    ).toBe("already_installed")
   })
 
   it("returns self_hosted_wizard when hosted URL is null (no public-app fallback)", () => {
@@ -80,6 +98,7 @@ describe("getGithubConnectStartBranch", () => {
         installationPending: false,
         installation: null,
         hostedDefaultAppInstallUrl: null,
+        intent: "connect",
       }),
     ).toBe("self_hosted_wizard")
   })

--- a/apps/ui/src/features/connectors/githubConnectFlow.test.ts
+++ b/apps/ui/src/features/connectors/githubConnectFlow.test.ts
@@ -24,6 +24,18 @@ describe("getGithubConnectStartBranch", () => {
     ).toBe("already_installed")
   })
 
+  it("keeps already_installed precedence over installation pending", () => {
+    expect(
+      getGithubConnectStartBranch({
+        bootstrapPending: false,
+        installationPending: true,
+        installation: { id: "con_1" },
+        hostedDefaultAppInstallUrl:
+          "https://github.com/apps/ctxpipe-agent/installations/select_target",
+      }),
+    ).toBe("already_installed")
+  })
+
   it("returns noop when installation query is still pending", () => {
     expect(
       getGithubConnectStartBranch({
@@ -44,6 +56,19 @@ describe("getGithubConnectStartBranch", () => {
         installation: null,
         hostedDefaultAppInstallUrl:
           "https://github.com/apps/ctxpipe-agent/installations/select_target",
+      }),
+    ).toBe("managed_install")
+  })
+
+  it("returns managed_install for manage_scope intent", () => {
+    expect(
+      getGithubConnectStartBranch({
+        bootstrapPending: false,
+        installationPending: false,
+        installation: { id: "con_1" },
+        hostedDefaultAppInstallUrl:
+          "https://github.com/apps/ctxpipe-agent/installations/select_target",
+        intent: "manage_scope",
       }),
     ).toBe("managed_install")
   })

--- a/apps/ui/src/features/connectors/githubConnectFlow.ts
+++ b/apps/ui/src/features/connectors/githubConnectFlow.ts
@@ -14,11 +14,15 @@ export function getGithubConnectStartBranch(args: {
   installation: unknown
   bootstrapPending: boolean
   hostedDefaultAppInstallUrl: string | null | undefined
+  intent?: "connect" | "manage_scope"
 }): GithubConnectStartBranch {
   if (args.bootstrapPending) return "noop_bootstrap_pending"
+  const hosted = args.hostedDefaultAppInstallUrl
+  if (args.intent === "manage_scope" && hosted != null && hosted !== "") {
+    return "managed_install"
+  }
   if (args.installation) return "already_installed"
   if (args.installationPending) return "noop_installation_pending"
-  const hosted = args.hostedDefaultAppInstallUrl
   if (hosted != null && hosted !== "") return "managed_install"
   return "self_hosted_wizard"
 }

--- a/apps/ui/src/features/connectors/githubConnectFlow.ts
+++ b/apps/ui/src/features/connectors/githubConnectFlow.ts
@@ -14,11 +14,16 @@ export function getGithubConnectStartBranch(args: {
   installation: unknown
   bootstrapPending: boolean
   hostedDefaultAppInstallUrl: string | null | undefined
-  intent?: "connect" | "manage_scope"
+  intent: "connect" | "manage_scope"
 }): GithubConnectStartBranch {
   if (args.bootstrapPending) return "noop_bootstrap_pending"
   const hosted = args.hostedDefaultAppInstallUrl
-  if (args.intent === "manage_scope" && hosted != null && hosted !== "") {
+  if (
+    args.intent === "manage_scope" &&
+    !args.installation &&
+    hosted != null &&
+    hosted !== ""
+  ) {
     return "managed_install"
   }
   if (args.installation) return "already_installed"

--- a/apps/ui/src/features/connectors/queries/github-connector.ts
+++ b/apps/ui/src/features/connectors/queries/github-connector.ts
@@ -40,11 +40,7 @@ export type GithubConnectorBootstrap = Awaited<
 
 export async function fetchGithubInstallationSummary(
   orgSlug: string,
-): Promise<{
-  id: string
-  appSlug: string | null
-  installationId: number | null
-} | null> {
+): Promise<{ id: string; appSlug: string | null } | null> {
   const res = await client[":orgSlug"].api.v1.github.installation.$get({
     param: { orgSlug },
   })

--- a/apps/ui/src/features/connectors/queries/github-connector.ts
+++ b/apps/ui/src/features/connectors/queries/github-connector.ts
@@ -40,7 +40,7 @@ export type GithubConnectorBootstrap = Awaited<
 
 export async function fetchGithubInstallationSummary(
   orgSlug: string,
-): Promise<{ id: string } | null> {
+): Promise<{ id: string; appSlug: string | null } | null> {
   const res = await client[":orgSlug"].api.v1.github.installation.$get({
     param: { orgSlug },
   })

--- a/apps/ui/src/features/connectors/queries/github-connector.ts
+++ b/apps/ui/src/features/connectors/queries/github-connector.ts
@@ -40,7 +40,11 @@ export type GithubConnectorBootstrap = Awaited<
 
 export async function fetchGithubInstallationSummary(
   orgSlug: string,
-): Promise<{ id: string; appSlug: string | null } | null> {
+): Promise<{
+  id: string
+  appSlug: string | null
+  installationId: number | null
+} | null> {
   const res = await client[":orgSlug"].api.v1.github.installation.$get({
     param: { orgSlug },
   })

--- a/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
+++ b/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
@@ -18,6 +18,10 @@ import {
   useWatchPopupClose,
 } from "@/lib/popup"
 import { useGithubConnectorBootstrap } from "@/lib/useGithubConnectorBootstrap"
+import {
+  githubAppInstallationSettingsUrl,
+  githubAppInstallSelectTargetUrl,
+} from "@/lib/github-app-url"
 
 export type UseGithubConnectFlowOptions = {
   orgSlug: string
@@ -144,12 +148,19 @@ export function useGithubConnectFlow({
 
   const start = useCallback((intent: "connect" | "manage_scope") => {
     if (!orgSlug.trim()) return
-    if (intent === "manage_scope" && installation?.appSlug?.trim()) {
-      openManagedInstallPopup(
-        `https://github.com/apps/${encodeURIComponent(
-          installation.appSlug.trim(),
-        )}/installations/select_target`,
-      )
+    if (intent === "manage_scope" && installation) {
+      if (installation.installationId != null) {
+        openManagedInstallPopup(
+          githubAppInstallationSettingsUrl(installation.installationId),
+        )
+        return
+      }
+      if (installation.appSlug?.trim()) {
+        openManagedInstallPopup(
+          githubAppInstallSelectTargetUrl(installation.appSlug),
+        )
+        return
+      }
       return
     }
     const branch = getGithubConnectStartBranch({

--- a/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
+++ b/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
@@ -84,6 +84,10 @@ export function useGithubConnectFlow({
         onRegistrationFailed?.(
           "Could not complete GitHub connection. Please try again.",
         )
+      else if (status === "no_result")
+        onRegistrationFailed?.(
+          "GitHub setup finished but no callback result was received. Please verify callback URLs and try again.",
+        )
     },
     [onRegistered, onRegistrationFailed],
   )

--- a/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
+++ b/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
@@ -35,6 +35,14 @@ export type UseGithubConnectFlowOptions = {
   minFinalizeAfterRegistrationMs?: number
 }
 
+type StartGithubConnectFlowOptions = {
+  /**
+   * Prefer opening the hosted GitHub install popup even when a connection is
+   * already linked. Used by "Manage" actions to adjust repository scope.
+   */
+  intent?: "connect" | "manage_scope"
+}
+
 export function useGithubConnectFlow({
   orgSlug,
   onAlreadyInstalled,
@@ -99,13 +107,14 @@ export function useGithubConnectFlow({
     [minFinalizeAfterRegistrationMs],
   )
 
-  const start = useCallback(() => {
+  const start = useCallback((options?: StartGithubConnectFlowOptions) => {
     if (!orgSlug.trim()) return
     const branch = getGithubConnectStartBranch({
       installationPending,
       installation,
       bootstrapPending,
       hostedDefaultAppInstallUrl: bootstrap?.hostedDefaultAppInstallUrl,
+      intent: options?.intent,
     })
 
     if (branch === "already_installed") {

--- a/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
+++ b/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
@@ -9,6 +9,8 @@ import {
   githubConnectorKeys,
 } from "@/features/connectors/queries/github-connector"
 import {
+  beginGithubPopupFlow,
+  clearGithubPopupFlow,
   GITHUB_DRAFT_CONNECTION_KEY,
   GITHUB_POPUP_NAME,
   type GithubSetupRegistrationStatus,
@@ -113,12 +115,14 @@ export function useGithubConnectFlow({
       }
       setGithubSetupOrgHint(orgSlug)
       setInstallStarting(true)
+      beginGithubPopupFlow()
       const popup = openCenteredPopup(url, {
         name: GITHUB_POPUP_NAME,
         width: 1120,
         height: 780,
       })
       if (!popup) {
+        clearGithubPopupFlow()
         setInstallStarting(false)
         return
       }

--- a/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
+++ b/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
@@ -35,14 +35,6 @@ export type UseGithubConnectFlowOptions = {
   minFinalizeAfterRegistrationMs?: number
 }
 
-type StartGithubConnectFlowOptions = {
-  /**
-   * Prefer opening the hosted GitHub install popup even when a connection is
-   * already linked. Used by "Manage" actions to adjust repository scope.
-   */
-  intent?: "connect" | "manage_scope"
-}
-
 export function useGithubConnectFlow({
   orgSlug,
   onAlreadyInstalled,
@@ -107,29 +99,8 @@ export function useGithubConnectFlow({
     [minFinalizeAfterRegistrationMs],
   )
 
-  const start = useCallback((options?: StartGithubConnectFlowOptions) => {
-    if (!orgSlug.trim()) return
-    const branch = getGithubConnectStartBranch({
-      installationPending,
-      installation,
-      bootstrapPending,
-      hostedDefaultAppInstallUrl: bootstrap?.hostedDefaultAppInstallUrl,
-      intent: options?.intent,
-    })
-
-    if (branch === "already_installed") {
-      onAlreadyInstalled?.()
-      return
-    }
-    if (
-      branch === "noop_bootstrap_pending" ||
-      branch === "noop_installation_pending"
-    ) {
-      return
-    }
-    if (branch === "managed_install") {
-      const hostedUrl = bootstrap?.hostedDefaultAppInstallUrl
-      if (!hostedUrl) return
+  const openManagedInstallPopup = useCallback(
+    (url: string) => {
       onFlowStarted?.()
       try {
         localStorage.removeItem(GITHUB_DRAFT_CONNECTION_KEY)
@@ -138,7 +109,7 @@ export function useGithubConnectFlow({
       }
       setGithubSetupOrgHint(orgSlug)
       setInstallStarting(true)
-      const popup = openCenteredPopup(hostedUrl, {
+      const popup = openCenteredPopup(url, {
         name: GITHUB_POPUP_NAME,
         width: 1120,
         height: 780,
@@ -160,6 +131,49 @@ export function useGithubConnectFlow({
           handleInstallSettled(status)
         })()
       })
+    },
+    [
+      onFlowStarted,
+      orgSlug,
+      watchPopupClose,
+      queryClient,
+      applyFinalizeDelay,
+      handleInstallSettled,
+    ],
+  )
+
+  const start = useCallback((intent: "connect" | "manage_scope" = "connect") => {
+    if (!orgSlug.trim()) return
+    if (intent === "manage_scope" && installation?.appSlug?.trim()) {
+      openManagedInstallPopup(
+        `https://github.com/apps/${encodeURIComponent(
+          installation.appSlug.trim(),
+        )}/installations/select_target`,
+      )
+      return
+    }
+    const branch = getGithubConnectStartBranch({
+      installationPending,
+      installation,
+      bootstrapPending,
+      hostedDefaultAppInstallUrl: bootstrap?.hostedDefaultAppInstallUrl,
+      intent,
+    })
+
+    if (branch === "already_installed") {
+      onAlreadyInstalled?.()
+      return
+    }
+    if (
+      branch === "noop_bootstrap_pending" ||
+      branch === "noop_installation_pending"
+    ) {
+      return
+    }
+    if (branch === "managed_install") {
+      const hostedUrl = bootstrap?.hostedDefaultAppInstallUrl
+      if (!hostedUrl) return
+      openManagedInstallPopup(hostedUrl)
       return
     }
 
@@ -183,6 +197,7 @@ export function useGithubConnectFlow({
     delegateSelfHostedWizard,
     handleInstallSettled,
     applyFinalizeDelay,
+    openManagedInstallPopup,
   ])
 
   const showInlineSelfHostedWizard = delegateSelfHostedWizard == null

--- a/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
+++ b/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
@@ -142,7 +142,7 @@ export function useGithubConnectFlow({
     ],
   )
 
-  const start = useCallback((intent: "connect" | "manage_scope" = "connect") => {
+  const start = useCallback((intent: "connect" | "manage_scope") => {
     if (!orgSlug.trim()) return
     if (intent === "manage_scope" && installation?.appSlug?.trim()) {
       openManagedInstallPopup(

--- a/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
+++ b/apps/ui/src/features/connectors/useGithubConnectFlow.tsx
@@ -18,10 +18,6 @@ import {
   useWatchPopupClose,
 } from "@/lib/popup"
 import { useGithubConnectorBootstrap } from "@/lib/useGithubConnectorBootstrap"
-import {
-  githubAppInstallationSettingsUrl,
-  githubAppInstallSelectTargetUrl,
-} from "@/lib/github-app-url"
 
 export type UseGithubConnectFlowOptions = {
   orgSlug: string
@@ -148,19 +144,12 @@ export function useGithubConnectFlow({
 
   const start = useCallback((intent: "connect" | "manage_scope") => {
     if (!orgSlug.trim()) return
-    if (intent === "manage_scope" && installation) {
-      if (installation.installationId != null) {
-        openManagedInstallPopup(
-          githubAppInstallationSettingsUrl(installation.installationId),
-        )
-        return
-      }
-      if (installation.appSlug?.trim()) {
-        openManagedInstallPopup(
-          githubAppInstallSelectTargetUrl(installation.appSlug),
-        )
-        return
-      }
+    if (intent === "manage_scope" && installation?.appSlug?.trim()) {
+      openManagedInstallPopup(
+        `https://github.com/apps/${encodeURIComponent(
+          installation.appSlug.trim(),
+        )}/installations/select_target`,
+      )
       return
     }
     const branch = getGithubConnectStartBranch({

--- a/apps/ui/src/lib/github-app-url.ts
+++ b/apps/ui/src/lib/github-app-url.ts
@@ -11,16 +11,6 @@ export function githubAppInstallSelectTargetUrl(appSlug: string): string {
 }
 
 /**
- * GitHub App installation settings for an already-linked installation.
- * This opens the repository access settings directly for scope management.
- */
-export function githubAppInstallationSettingsUrl(
-  installationId: number,
-): string {
-  return `https://github.com/settings/installations/${installationId}`
-}
-
-/**
  * Dev-only convenience: when the API omits `hostedDefaultAppInstallUrl`, Storybook
  * and local runs can still open the public ctxpipe GitHub App. **Production**
  * self-hosted installs must use {@link useGithubConnectFlow} / the self-hosted

--- a/apps/ui/src/lib/github-app-url.ts
+++ b/apps/ui/src/lib/github-app-url.ts
@@ -11,6 +11,16 @@ export function githubAppInstallSelectTargetUrl(appSlug: string): string {
 }
 
 /**
+ * GitHub App installation settings for an already-linked installation.
+ * This opens the repository access settings directly for scope management.
+ */
+export function githubAppInstallationSettingsUrl(
+  installationId: number,
+): string {
+  return `https://github.com/settings/installations/${installationId}`
+}
+
+/**
  * Dev-only convenience: when the API omits `hostedDefaultAppInstallUrl`, Storybook
  * and local runs can still open the public ctxpipe GitHub App. **Production**
  * self-hosted installs must use {@link useGithubConnectFlow} / the self-hosted

--- a/apps/ui/src/lib/popup.ts
+++ b/apps/ui/src/lib/popup.ts
@@ -12,6 +12,14 @@ export const GITHUB_SETUP_RESULT_KEY = "github-setup-result"
 export const GITHUB_SETUP_ORG_HINT_KEY = "github-setup-org-hint"
 /** Draft `con_*` id for wizard: popup callback merges install with this row. */
 export const GITHUB_DRAFT_CONNECTION_KEY = "github-draft-connection-id"
+export const GITHUB_POPUP_FLOW_KEY = "github-popup-flow"
+
+const GITHUB_POPUP_FLOW_TTL_MS = 15 * 60 * 1000
+
+type GithubPopupFlowState = {
+  nonce: string
+  startedAtMs: number
+}
 
 export type GithubSetupRegistrationStatus =
   | "no_result"
@@ -20,6 +28,57 @@ export type GithubSetupRegistrationStatus =
 
 /** Window name used when opening the GitHub app install popup. */
 export const GITHUB_POPUP_NAME = "github-app-install"
+
+function safeNowMs() {
+  return Date.now()
+}
+
+function parsePopupFlowState(raw: string | null): GithubPopupFlowState | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<GithubPopupFlowState>
+    if (
+      typeof parsed.nonce !== "string" ||
+      parsed.nonce.length === 0 ||
+      typeof parsed.startedAtMs !== "number"
+    ) {
+      return null
+    }
+    if (safeNowMs() - parsed.startedAtMs > GITHUB_POPUP_FLOW_TTL_MS) return null
+    return { nonce: parsed.nonce, startedAtMs: parsed.startedAtMs }
+  } catch {
+    return null
+  }
+}
+
+function createPopupFlowNonce() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return `${safeNowMs()}-${Math.random().toString(36).slice(2)}`
+}
+
+export function beginGithubPopupFlow() {
+  if (typeof window === "undefined") return null
+  const state: GithubPopupFlowState = {
+    nonce: createPopupFlowNonce(),
+    startedAtMs: safeNowMs(),
+  }
+  localStorage.setItem(GITHUB_POPUP_FLOW_KEY, JSON.stringify(state))
+  return state.nonce
+}
+
+export function getActiveGithubPopupFlowState() {
+  if (typeof window === "undefined") return null
+  const parsed = parsePopupFlowState(localStorage.getItem(GITHUB_POPUP_FLOW_KEY))
+  if (!parsed) localStorage.removeItem(GITHUB_POPUP_FLOW_KEY)
+  return parsed
+}
+
+export function clearGithubPopupFlow() {
+  if (typeof window === "undefined") return
+  localStorage.removeItem(GITHUB_POPUP_FLOW_KEY)
+}
 
 /**
  * Persist the org context before opening the GitHub install flow so direct
@@ -126,6 +185,7 @@ export async function handleGithubSetupPopupResult(
 ): Promise<{ status: GithubSetupRegistrationStatus }> {
   const raw = localStorage.getItem(GITHUB_SETUP_RESULT_KEY)
   localStorage.removeItem(GITHUB_SETUP_RESULT_KEY)
+  const activePopupFlow = getActiveGithubPopupFlowState()
 
   let status: GithubSetupRegistrationStatus = "no_result"
 
@@ -134,17 +194,25 @@ export async function handleGithubSetupPopupResult(
       const parsed = JSON.parse(raw) as {
         installationId: number
         connectionId?: string
+        popupFlowNonce?: string
       }
-      const { installationId, connectionId } = parsed
+      const { installationId, connectionId, popupFlowNonce } = parsed
+      const nonceMatches =
+        !activePopupFlow ||
+        (typeof popupFlowNonce === "string" &&
+          popupFlowNonce.length > 0 &&
+          popupFlowNonce === activePopupFlow.nonce)
       if (installationId && orgSlug) {
-        const response = await client[":orgSlug"].api.v1.github.installation.$post({
-          param: { orgSlug },
-          json: {
-            installationId,
-            ...(connectionId ? { connectionId } : {}),
-          },
-        })
-        status = response.ok ? "registered" : "registration_failed"
+        if (nonceMatches) {
+          const response = await client[":orgSlug"].api.v1.github.installation.$post({
+            param: { orgSlug },
+            json: {
+              installationId,
+              ...(connectionId ? { connectionId } : {}),
+            },
+          })
+          status = response.ok ? "registered" : "registration_failed"
+        }
       }
     } catch {
       // Registration may fail — query invalidation below will reflect
@@ -197,6 +265,8 @@ export async function handleGithubSetupPopupResult(
       // Keep "no_result" and let caller decide UX.
     }
   }
+
+  clearGithubPopupFlow()
 
   return { status }
 }

--- a/apps/ui/src/lib/popup.ts
+++ b/apps/ui/src/lib/popup.ts
@@ -184,5 +184,19 @@ export async function handleGithubSetupPopupResult(
     }),
   ])
 
+  if (status === "no_result") {
+    try {
+      const response = await client[":orgSlug"].api.v1.github.installation.$get({
+        param: { orgSlug },
+      })
+      if (response.ok) {
+        const linked = (await response.json()) as { id: string } | null
+        if (linked) status = "registered"
+      }
+    } catch {
+      // Keep "no_result" and let caller decide UX.
+    }
+  }
+
   return { status }
 }

--- a/apps/ui/src/routes/$orgSlug.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.index.tsx
@@ -189,7 +189,7 @@ export function OrgHomePageContent({ orgSlug }: { orgSlug: string }) {
 
   const handleGithubConnect = () => {
     if (githubConnected) return
-    start()
+    start("connect")
   }
 
   const githubRowBusy = ghBusy || isSyncing

--- a/apps/ui/src/routes/$orgSlug.repositories.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.repositories.index.tsx
@@ -214,11 +214,11 @@ function RepositoriesPage() {
     deleteMutation.mutate(repoToDelete.id)
   }
 
-  const handleConnectGithubInstall = (options?: {
-    intent?: "connect" | "manage_scope"
-  }) => {
+  const handleConnectGithubInstall = (
+    intent: "connect" | "manage_scope" = "connect",
+  ) => {
     postRegisterNavigateToSetup.current = false
-    start(options)
+    start(intent)
   }
 
   const handleConnectGithubFromEmptyState = () => {
@@ -330,11 +330,7 @@ function RepositoriesPage() {
                         Install MCP via PRs
                       </MenuItem>
                       <MenuItem
-                        onAction={() =>
-                          handleConnectGithubInstall({
-                            intent: "manage_scope",
-                          })
-                        }
+                        onAction={() => handleConnectGithubInstall("manage_scope")}
                         textValue="Manage"
                         className="rounded-none px-3 py-2 text-zinc-100"
                       >

--- a/apps/ui/src/routes/$orgSlug.repositories.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.repositories.index.tsx
@@ -214,9 +214,11 @@ function RepositoriesPage() {
     deleteMutation.mutate(repoToDelete.id)
   }
 
-  const handleConnectGithubInstall = () => {
+  const handleConnectGithubInstall = (options?: {
+    intent?: "connect" | "manage_scope"
+  }) => {
     postRegisterNavigateToSetup.current = false
-    start()
+    start(options)
   }
 
   const handleConnectGithubFromEmptyState = () => {
@@ -328,7 +330,11 @@ function RepositoriesPage() {
                         Install MCP via PRs
                       </MenuItem>
                       <MenuItem
-                        onAction={handleConnectGithubInstall}
+                        onAction={() =>
+                          handleConnectGithubInstall({
+                            intent: "manage_scope",
+                          })
+                        }
                         textValue="Manage"
                         className="rounded-none px-3 py-2 text-zinc-100"
                       >

--- a/apps/ui/src/routes/$orgSlug.repositories.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.repositories.index.tsx
@@ -228,7 +228,7 @@ function RepositoriesPage() {
       return
     }
     postRegisterNavigateToSetup.current = true
-    start()
+    start("connect")
   }
 
   const githubConnectBusy = installationPending || ghFlowPending || isSyncing

--- a/apps/ui/src/routes/$orgSlug.setup.tsx
+++ b/apps/ui/src/routes/$orgSlug.setup.tsx
@@ -106,7 +106,7 @@ function OrgSetupPage() {
   const handleConnectGitHub = () => {
     if (githubButtonBusy) return
     setGithubSetupError(null)
-    start()
+    start("connect")
   }
 
   const parseInviteEmails = (value: string) =>

--- a/apps/ui/src/routes/[.]github.setup.tsx
+++ b/apps/ui/src/routes/[.]github.setup.tsx
@@ -5,6 +5,7 @@ import { authClient, useListOrganizations } from "@/lib/auth-client"
 import {
   consumeGithubSetupOrgHint,
   GITHUB_DRAFT_CONNECTION_KEY,
+  getActiveGithubPopupFlowState,
   GITHUB_POPUP_NAME,
   GITHUB_SETUP_RESULT_KEY,
 } from "@/lib/popup"
@@ -102,7 +103,13 @@ function isPopupWindow() {
  * localStorage and close immediately. The opener reads the value, makes the
  * API call, and cleans up.
  */
-function RelayAndClose({ installationId }: { installationId: number }) {
+function RelayAndClose({
+  installationId,
+  popupFlowNonce,
+}: {
+  installationId: number
+  popupFlowNonce?: string
+}) {
   useEffect(() => {
     try {
       const connectionId = localStorage.getItem(GITHUB_DRAFT_CONNECTION_KEY)
@@ -111,6 +118,7 @@ function RelayAndClose({ installationId }: { installationId: number }) {
         JSON.stringify({
           installationId,
           ...(connectionId ? { connectionId } : {}),
+          ...(popupFlowNonce ? { popupFlowNonce } : {}),
         }),
       )
     } catch {
@@ -251,13 +259,19 @@ function ConnectGithubView({
 
 function DotGitHubSetupPage() {
   const search = Route.useSearch()
+  const popupFlow = useMemo(() => getActiveGithubPopupFlowState(), [])
 
   // Popup path: relay installation_id via localStorage and close immediately.
   // No API calls — the popup may not have valid auth cookies after the
   // cross-origin redirect through github.com.
-  if (isPopupWindow()) {
+  if (popupFlow || isPopupWindow()) {
     if (search.installation_id) {
-      return <RelayAndClose installationId={search.installation_id} />
+      return (
+        <RelayAndClose
+          installationId={search.installation_id}
+          popupFlowNonce={popupFlow?.nonce}
+        />
+      )
     }
     return <CloseOnly />
   }


### PR DESCRIPTION
An earlier fix to the onboarding flow caused a bug in the repo page where clicking 'manage' would take the user to the 'select repos' page. This prevents users from adjusting the scope of the repos via the Github app.

This fix scopes a minimal change to decouple the onboarding and repo page Github logic, so that the onboarding fixes remain intact (popup churn fixes) while re-enabling users to adjust the repo scope.