### PR TITLE
fix(ci): recreate broken Railway PR environments on deploy

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -106,19 +106,17 @@ jobs:
 
       - name: Ensure Railway PR environment exists
         # Railway API/CLI calls can be flaky; retry once before failing.
+        # Script recreates broken/incomplete envs and deletes partial state on failure (CTX-125).
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 2
           command: |
             set -euo pipefail
-            railway link --project "${{ vars.RAILWAY_PROJECT_ID }}" --environment production
-            if railway environment config --environment "$PR_ENV" --json >/dev/null 2>&1; then
-              echo "Railway environment $PR_ENV already exists"
-            else
-              railway environment new "$PR_ENV" --duplicate production
-            fi
-            railway link --project "${{ vars.RAILWAY_PROJECT_ID }}" --environment "$PR_ENV"
+            bash scripts/railway-ensure-pr-environment.sh \
+              "${{ vars.RAILWAY_PROJECT_ID }}" \
+              "$PR_ENV" \
+              production
 
       - name: Neon branch expiration (14 days)
         id: neon_expires

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -109,9 +109,9 @@ jobs:
         # Script deletes partial env on create failure so retry can duplicate cleanly (CTX-125).
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 15
           max_attempts: 2
-          retry_wait_seconds: 30
+          retry_wait_seconds: 60
           command: |
             set -euo pipefail
             bash scripts/railway-ensure-pr-environment.sh \

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Ensure Railway PR environment exists
         # Railway API/CLI calls can be flaky; retry once before failing.
-        # Script recreates broken/incomplete envs and deletes partial state on failure (CTX-125).
+        # Script deletes partial env on create failure so retry can duplicate cleanly (CTX-125).
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -109,8 +109,9 @@ jobs:
         # Script deletes partial env on create failure so retry can duplicate cleanly (CTX-125).
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 5
+          timeout_minutes: 10
           max_attempts: 2
+          retry_wait_seconds: 30
           command: |
             set -euo pipefail
             bash scripts/railway-ensure-pr-environment.sh \

--- a/scripts/railway-ensure-pr-environment.sh
+++ b/scripts/railway-ensure-pr-environment.sh
@@ -70,73 +70,58 @@ pr_env_usable() {
   railway environment config --environment "$PR_ENV" --json >/dev/null 2>&1
 }
 
-pr_env_linkable() {
-  link_environment "$PR_ENV"
+delete_pr_env_by_id() {
+  local env_id="$1"
+  railway_graphql \
+    'mutation($id: String!) { environmentDelete(id: $id) }' \
+    "$(jq -nc --arg id "$env_id" '{id:$id}')" >/dev/null
+  echo "Deleted Railway environment $PR_ENV via GraphQL ($env_id)"
 }
 
 delete_pr_env_best_effort() {
-  local attempt env_id deleted=false
+  local env_id deleted=false
 
-  for attempt in $(seq 1 10); do
-    deleted=false
-    env_id="$(lookup_env_id "$PR_ENV" || true)"
-    if [[ -n "$env_id" ]]; then
-      railway_graphql \
-        'mutation($id: String!) { environmentDelete(id: $id) }' \
-        "$(jq -nc --arg id "$env_id" '{id:$id}')" >/dev/null
-      echo "Deleted Railway environment $PR_ENV via GraphQL ($env_id)"
+  env_id="$(lookup_env_id "$PR_ENV" || true)"
+  if [[ -n "$env_id" ]]; then
+    delete_pr_env_by_id "$env_id"
+    deleted=true
+  fi
+
+  if link_environment "$PR_ENV"; then
+    if railway environment delete "$PR_ENV" --yes; then
+      echo "Deleted Railway environment $PR_ENV via CLI (linked)"
       deleted=true
     fi
+    link_environment "$SOURCE_ENV" || true
+  elif railway environment delete "$PR_ENV" --yes 2>/dev/null; then
+    echo "Deleted Railway environment $PR_ENV via CLI"
+    deleted=true
+  fi
 
-    if pr_env_linkable; then
-      if railway environment delete "$PR_ENV" --yes; then
-        echo "Deleted Railway environment $PR_ENV via CLI (linked)"
-        deleted=true
-      fi
-      link_environment "$SOURCE_ENV" || true
-    elif railway environment delete "$PR_ENV" --yes 2>/dev/null; then
-      echo "Deleted Railway environment $PR_ENV via CLI"
-      deleted=true
-    fi
+  if [[ "$deleted" == "false" ]]; then
+    echo "Could not find Railway environment $PR_ENV to delete; waiting for name release" >&2
+    return 1
+  fi
 
-    if [[ "$deleted" == "true" ]]; then
-      return 0
-    fi
-
-    if ! pr_env_usable && ! pr_env_linkable && [[ -z "$(lookup_env_id "$PR_ENV" || true)" ]]; then
-      return 0
-    fi
-
-    echo "Retrying delete for Railway environment $PR_ENV (attempt $attempt/10)..."
-    sleep 2
-  done
-
-  echo "Warning: could not delete Railway environment $PR_ENV" >&2
-  return 1
+  return 0
 }
 
-wait_for_pr_env_gone() {
+create_duplicated_env_with_cleanup() {
   local attempt
-  for attempt in $(seq 1 30); do
-    if pr_env_usable; then
-      echo "Waiting for Railway environment $PR_ENV to finish deleting (attempt $attempt/30)..."
-      sleep 2
-      continue
+  for attempt in $(seq 1 5); do
+    if railway environment new "$PR_ENV" --duplicate "$SOURCE_ENV"; then
+      return 0
     fi
-    if pr_env_linkable; then
-      link_environment "$SOURCE_ENV" || true
-      echo "Waiting for Railway environment $PR_ENV to finish deleting (attempt $attempt/30)..."
-      sleep 2
-      continue
+
+    echo "railway environment new failed (attempt $attempt/5); cleaning up before retry" >&2
+    if delete_pr_env_best_effort; then
+      sleep 10
+    else
+      # Name may be reserved without a deletable env object after manual deletes.
+      sleep 30
     fi
-    if [[ -n "$(lookup_env_id "$PR_ENV" || true)" ]]; then
-      echo "Waiting for Railway environment $PR_ENV to finish deleting (attempt $attempt/30)..."
-      sleep 2
-      continue
-    fi
-    return 0
   done
-  echo "Warning: Railway environment $PR_ENV may still be deleting" >&2
+
   return 1
 }
 
@@ -144,23 +129,17 @@ link_environment "$SOURCE_ENV"
 
 if pr_env_usable; then
   echo "Railway environment $PR_ENV already exists"
-elif pr_env_linkable; then
-  echo "Railway environment $PR_ENV exists but is not usable; deleting before recreate"
-  railway environment delete "$PR_ENV" --yes
-  link_environment "$SOURCE_ENV"
-  wait_for_pr_env_gone || true
-  if ! railway environment new "$PR_ENV" --duplicate "$SOURCE_ENV"; then
-    echo "railway environment new failed; deleting partial environment so retry can succeed" >&2
-    delete_pr_env_best_effort || true
-    wait_for_pr_env_gone || true
-    exit 1
-  fi
 else
-  link_environment "$SOURCE_ENV"
-  if ! railway environment new "$PR_ENV" --duplicate "$SOURCE_ENV"; then
-    echo "railway environment new failed; deleting partial environment so retry can succeed" >&2
-    delete_pr_env_best_effort || true
-    wait_for_pr_env_gone || true
+  env_id="$(lookup_env_id "$PR_ENV" || true)"
+  if [[ -n "$env_id" ]]; then
+    echo "Railway environment $PR_ENV exists but is not usable; deleting before recreate"
+    delete_pr_env_by_id "$env_id"
+    link_environment "$SOURCE_ENV"
+    sleep 10
+  fi
+
+  if ! create_duplicated_env_with_cleanup; then
+    echo "Failed to create Railway environment $PR_ENV after retries" >&2
     exit 1
   fi
 fi

--- a/scripts/railway-ensure-pr-environment.sh
+++ b/scripts/railway-ensure-pr-environment.sh
@@ -43,10 +43,13 @@ lookup_env_id() {
           }
         }
       }' \
-      "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" --arg after "$after" '{projectId:$project, first:100, after:($after | if . == "" then null else . end)}')")"
+      "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" --arg after "$after" \
+        '{projectId:$project, first:100, after:($after | if . == "" then null else . end)}')")"
 
     local env_id
-    env_id="$(jq -r --arg name "$env_name" '.data.project.environments.edges[] | select(.node.name == $name) | .node.id' <<<"$response" | head -1)"
+    env_id="$(jq -r --arg name "$env_name" \
+      '.data.project.environments.edges[]? | select(.node.name == $name) | .node.id' \
+      <<<"$response" | head -1)"
     if [[ -n "$env_id" ]]; then
       echo "$env_id"
       return 0
@@ -59,28 +62,107 @@ lookup_env_id() {
   done
 }
 
-delete_pr_env_if_present() {
-  local env_id
-  env_id="$(lookup_env_id "$PR_ENV" || true)"
-  if [[ -n "$env_id" ]]; then
-    railway_graphql \
-      'mutation($id: String!) { environmentDelete(id: $id) }' \
-      "$(jq -nc --arg id "$env_id" '{id:$id}')" >/dev/null
-    echo "Deleted Railway environment $PR_ENV ($env_id)"
-  fi
-  railway environment delete "$PR_ENV" --yes 2>/dev/null || true
+link_environment() {
+  railway link --project "$RAILWAY_PROJECT_ID" --environment "$1" >/dev/null 2>&1
 }
 
-railway link --project "$RAILWAY_PROJECT_ID" --environment "$SOURCE_ENV"
+pr_env_usable() {
+  railway environment config --environment "$PR_ENV" --json >/dev/null 2>&1
+}
 
-if railway environment config --environment "$PR_ENV" --json >/dev/null 2>&1; then
+pr_env_linkable() {
+  link_environment "$PR_ENV"
+}
+
+delete_pr_env_best_effort() {
+  local attempt env_id deleted=false
+
+  for attempt in $(seq 1 10); do
+    deleted=false
+    env_id="$(lookup_env_id "$PR_ENV" || true)"
+    if [[ -n "$env_id" ]]; then
+      railway_graphql \
+        'mutation($id: String!) { environmentDelete(id: $id) }' \
+        "$(jq -nc --arg id "$env_id" '{id:$id}')" >/dev/null
+      echo "Deleted Railway environment $PR_ENV via GraphQL ($env_id)"
+      deleted=true
+    fi
+
+    if pr_env_linkable; then
+      if railway environment delete "$PR_ENV" --yes; then
+        echo "Deleted Railway environment $PR_ENV via CLI (linked)"
+        deleted=true
+      fi
+      link_environment "$SOURCE_ENV" || true
+    elif railway environment delete "$PR_ENV" --yes 2>/dev/null; then
+      echo "Deleted Railway environment $PR_ENV via CLI"
+      deleted=true
+    fi
+
+    if [[ "$deleted" == "true" ]]; then
+      return 0
+    fi
+
+    if ! pr_env_usable && ! pr_env_linkable && [[ -z "$(lookup_env_id "$PR_ENV" || true)" ]]; then
+      return 0
+    fi
+
+    echo "Retrying delete for Railway environment $PR_ENV (attempt $attempt/10)..."
+    sleep 2
+  done
+
+  echo "Warning: could not delete Railway environment $PR_ENV" >&2
+  return 1
+}
+
+wait_for_pr_env_gone() {
+  local attempt
+  for attempt in $(seq 1 30); do
+    if pr_env_usable; then
+      echo "Waiting for Railway environment $PR_ENV to finish deleting (attempt $attempt/30)..."
+      sleep 2
+      continue
+    fi
+    if pr_env_linkable; then
+      link_environment "$SOURCE_ENV" || true
+      echo "Waiting for Railway environment $PR_ENV to finish deleting (attempt $attempt/30)..."
+      sleep 2
+      continue
+    fi
+    if [[ -n "$(lookup_env_id "$PR_ENV" || true)" ]]; then
+      echo "Waiting for Railway environment $PR_ENV to finish deleting (attempt $attempt/30)..."
+      sleep 2
+      continue
+    fi
+    return 0
+  done
+  echo "Warning: Railway environment $PR_ENV may still be deleting" >&2
+  return 1
+}
+
+link_environment "$SOURCE_ENV"
+
+if pr_env_usable; then
   echo "Railway environment $PR_ENV already exists"
-else
+elif pr_env_linkable; then
+  echo "Railway environment $PR_ENV exists but is not usable; deleting before recreate"
+  railway environment delete "$PR_ENV" --yes
+  link_environment "$SOURCE_ENV"
+  wait_for_pr_env_gone || true
   if ! railway environment new "$PR_ENV" --duplicate "$SOURCE_ENV"; then
     echo "railway environment new failed; deleting partial environment so retry can succeed" >&2
-    delete_pr_env_if_present || true
+    delete_pr_env_best_effort || true
+    wait_for_pr_env_gone || true
+    exit 1
+  fi
+else
+  link_environment "$SOURCE_ENV"
+  if ! railway environment new "$PR_ENV" --duplicate "$SOURCE_ENV"; then
+    echo "railway environment new failed; deleting partial environment so retry can succeed" >&2
+    delete_pr_env_best_effort || true
+    wait_for_pr_env_gone || true
     exit 1
   fi
 fi
 
-railway link --project "$RAILWAY_PROJECT_ID" --environment "$PR_ENV"
+link_environment "$PR_ENV"

--- a/scripts/railway-ensure-pr-environment.sh
+++ b/scripts/railway-ensure-pr-environment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Ensure a Railway PR preview environment exists and is duplicated from production.
-# GraphQL lookup/delete handles broken envs where CLI delete by name fails (CTX-125).
+# Ensure a Railway PR preview environment exists, duplicated from production.
+# On create failure, delete any partial environment so nick-fields/retry can succeed (CTX-125).
 
 set -euo pipefail
 
@@ -32,103 +32,53 @@ railway_graphql() {
 
 lookup_env_id() {
   local env_name="$1"
-  railway_graphql \
-    'query($projectId: String!) { project(id: $projectId) { environments { edges { node { id name } } } } }' \
-    "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" '{projectId:$project}')" \
-    | jq -r --arg name "$env_name" '.data.project.environments.edges[] | select(.node.name == $name) | .node.id' \
-    | head -1
-}
+  local after="" response
+  while true; do
+    response="$(railway_graphql \
+      'query($projectId: String!, $first: Int!, $after: String) {
+        project(id: $projectId) {
+          environments(first: $first, after: $after) {
+            edges { node { id name } }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }' \
+      "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" --arg after "$after" '{projectId:$project, first:100, after:($after | if . == "" then null else . end)}')")"
 
-delete_env_by_id() {
-  local env_id="$1"
-  railway_graphql \
-    'mutation($id: String!) { environmentDelete(id: $id) }' \
-    "$(jq -nc --arg id "$env_id" '{id:$id}')" >/dev/null
-  echo "Deleted Railway environment $env_id"
+    local env_id
+    env_id="$(jq -r --arg name "$env_name" '.data.project.environments.edges[] | select(.node.name == $name) | .node.id' <<<"$response" | head -1)"
+    if [[ -n "$env_id" ]]; then
+      echo "$env_id"
+      return 0
+    fi
+
+    if [[ "$(jq -r '.data.project.environments.pageInfo.hasNextPage' <<<"$response")" != "true" ]]; then
+      return 1
+    fi
+    after="$(jq -r '.data.project.environments.pageInfo.endCursor' <<<"$response")"
+  done
 }
 
 delete_pr_env_if_present() {
   local env_id
   env_id="$(lookup_env_id "$PR_ENV" || true)"
   if [[ -n "$env_id" ]]; then
-    delete_env_by_id "$env_id"
+    railway_graphql \
+      'mutation($id: String!) { environmentDelete(id: $id) }' \
+      "$(jq -nc --arg id "$env_id" '{id:$id}')" >/dev/null
+    echo "Deleted Railway environment $PR_ENV ($env_id)"
   fi
   railway environment delete "$PR_ENV" --yes 2>/dev/null || true
 }
 
-wait_for_pr_env_absent() {
-  local attempt
-  for attempt in $(seq 1 30); do
-    if [[ -z "$(lookup_env_id "$PR_ENV" || true)" ]] \
-      && ! env_config_readable "$PR_ENV"; then
-      return 0
-    fi
-    echo "Waiting for Railway environment $PR_ENV to finish deleting (attempt $attempt/30)..."
-    sleep 2
-  done
-  echo "Warning: Railway environment $PR_ENV may still be deleting" >&2
-  return 1
-}
-
-env_config_readable() {
-  railway environment config --environment "$1" --json >/dev/null 2>&1
-}
-
-count_active_services() {
-  local env_name="$1"
-  local config
-  config="$(railway environment config --environment "$env_name" --json 2>/dev/null)" || return 1
-  jq '[(.services // {}) | to_entries[] | select(.value.is_deleted != true)] | length' <<<"$config"
-}
-
-env_needs_recreate() {
-  if ! env_config_readable "$PR_ENV"; then
-    echo "Railway environment $PR_ENV exists but config is not readable"
-    return 0
-  fi
-
-  local prod_count pr_count
-  if ! prod_count="$(count_active_services "$SOURCE_ENV")"; then
-    echo "Warning: could not count $SOURCE_ENV services; treating readable $PR_ENV as complete" >&2
-    return 1
-  fi
-
-  if ! pr_count="$(count_active_services "$PR_ENV")"; then
-    echo "Railway environment $PR_ENV config is readable but service list is unavailable"
-    return 0
-  fi
-
-  if [[ "$pr_count" -lt "$prod_count" ]]; then
-    echo "Railway environment $PR_ENV is incomplete ($pr_count < $prod_count active services)"
-    return 0
-  fi
-
-  return 1
-}
-
-create_duplicated_env() {
-  railway environment new "$PR_ENV" --duplicate "$SOURCE_ENV"
-}
-
 railway link --project "$RAILWAY_PROJECT_ID" --environment "$SOURCE_ENV"
 
-ENV_ID="$(lookup_env_id "$PR_ENV" || true)"
-
-if [[ -n "$ENV_ID" ]] && ! env_needs_recreate; then
-  echo "Railway environment $PR_ENV already exists and is duplicated from $SOURCE_ENV"
+if railway environment config --environment "$PR_ENV" --json >/dev/null 2>&1; then
+  echo "Railway environment $PR_ENV already exists"
 else
-  if [[ -n "$ENV_ID" ]]; then
-    echo "Recreating Railway environment $PR_ENV from $SOURCE_ENV"
-    delete_pr_env_if_present
-    wait_for_pr_env_absent || true
-  else
-    echo "Creating Railway environment $PR_ENV duplicated from $SOURCE_ENV"
-  fi
-
-  if ! create_duplicated_env; then
-    echo "railway environment new failed; cleaning up so retry can succeed" >&2
+  if ! railway environment new "$PR_ENV" --duplicate "$SOURCE_ENV"; then
+    echo "railway environment new failed; deleting partial environment so retry can succeed" >&2
     delete_pr_env_if_present || true
-    wait_for_pr_env_absent || true
     exit 1
   fi
 fi

--- a/scripts/railway-ensure-pr-environment.sh
+++ b/scripts/railway-ensure-pr-environment.sh
@@ -53,6 +53,21 @@ delete_pr_env_if_present() {
   if [[ -n "$env_id" ]]; then
     delete_env_by_id "$env_id"
   fi
+  railway environment delete "$PR_ENV" --yes 2>/dev/null || true
+}
+
+wait_for_pr_env_absent() {
+  local attempt
+  for attempt in $(seq 1 30); do
+    if [[ -z "$(lookup_env_id "$PR_ENV" || true)" ]] \
+      && ! env_config_readable "$PR_ENV"; then
+      return 0
+    fi
+    echo "Waiting for Railway environment $PR_ENV to finish deleting (attempt $attempt/30)..."
+    sleep 2
+  done
+  echo "Warning: Railway environment $PR_ENV may still be deleting" >&2
+  return 1
 }
 
 env_config_readable() {
@@ -104,7 +119,8 @@ if [[ -n "$ENV_ID" ]] && ! env_needs_recreate; then
 else
   if [[ -n "$ENV_ID" ]]; then
     echo "Recreating Railway environment $PR_ENV from $SOURCE_ENV"
-    delete_env_by_id "$ENV_ID"
+    delete_pr_env_if_present
+    wait_for_pr_env_absent || true
   else
     echo "Creating Railway environment $PR_ENV duplicated from $SOURCE_ENV"
   fi
@@ -112,18 +128,8 @@ else
   if ! create_duplicated_env; then
     echo "railway environment new failed; cleaning up so retry can succeed" >&2
     delete_pr_env_if_present || true
+    wait_for_pr_env_absent || true
     exit 1
-  fi
-
-  if env_config_readable "$PR_ENV" && env_config_readable "$SOURCE_ENV"; then
-    prod_count="$(count_active_services "$SOURCE_ENV")"
-    pr_count="$(count_active_services "$PR_ENV")"
-    if [[ "$pr_count" -lt "$prod_count" ]]; then
-      echo "Railway environment $PR_ENV is still incomplete after duplicate ($pr_count < $prod_count)" >&2
-      delete_pr_env_if_present || true
-      exit 1
-    fi
-    echo "Railway environment $PR_ENV ready with $pr_count active service(s)"
   fi
 fi
 

--- a/scripts/railway-ensure-pr-environment.sh
+++ b/scripts/railway-ensure-pr-environment.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Ensure a Railway PR preview environment exists and is duplicated from production.
+# GraphQL lookup/delete handles broken envs where CLI delete by name fails (CTX-125).
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <railway_project_id> <pr_environment_name> [source_environment=production]" >&2
+  exit 1
+}
+
+[[ $# -ge 2 && $# -le 3 ]] || usage
+
+RAILWAY_PROJECT_ID="$1"
+PR_ENV="$2"
+SOURCE_ENV="${3:-production}"
+
+if [[ -z "${RAILWAY_API_TOKEN:-}" ]]; then
+  echo "RAILWAY_API_TOKEN must be set" >&2
+  exit 1
+fi
+
+railway_graphql() {
+  local query="$1"
+  local variables="$2"
+  curl -fsS -X POST \
+    -H "Authorization: Bearer ${RAILWAY_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -nc --arg q "$query" --argjson v "$variables" '{query:$q,variables:$v}')" \
+    https://backboard.railway.com/graphql/v2
+}
+
+lookup_env_id() {
+  local env_name="$1"
+  railway_graphql \
+    'query($projectId: String!) { project(id: $projectId) { environments { edges { node { id name } } } } }' \
+    "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" '{projectId:$project}')" \
+    | jq -r --arg name "$env_name" '.data.project.environments.edges[] | select(.node.name == $name) | .node.id' \
+    | head -1
+}
+
+delete_env_by_id() {
+  local env_id="$1"
+  railway_graphql \
+    'mutation($id: String!) { environmentDelete(id: $id) }' \
+    "$(jq -nc --arg id "$env_id" '{id:$id}')" >/dev/null
+  echo "Deleted Railway environment $env_id"
+}
+
+delete_pr_env_if_present() {
+  local env_id
+  env_id="$(lookup_env_id "$PR_ENV" || true)"
+  if [[ -n "$env_id" ]]; then
+    delete_env_by_id "$env_id"
+  fi
+}
+
+env_config_readable() {
+  railway environment config --environment "$1" --json >/dev/null 2>&1
+}
+
+count_active_services() {
+  local env_name="$1"
+  local config
+  config="$(railway environment config --environment "$env_name" --json 2>/dev/null)" || return 1
+  jq '[(.services // {}) | to_entries[] | select(.value.is_deleted != true)] | length' <<<"$config"
+}
+
+env_needs_recreate() {
+  if ! env_config_readable "$PR_ENV"; then
+    echo "Railway environment $PR_ENV exists but config is not readable"
+    return 0
+  fi
+
+  local prod_count pr_count
+  if ! prod_count="$(count_active_services "$SOURCE_ENV")"; then
+    echo "Warning: could not count $SOURCE_ENV services; treating readable $PR_ENV as complete" >&2
+    return 1
+  fi
+
+  if ! pr_count="$(count_active_services "$PR_ENV")"; then
+    echo "Railway environment $PR_ENV config is readable but service list is unavailable"
+    return 0
+  fi
+
+  if [[ "$pr_count" -lt "$prod_count" ]]; then
+    echo "Railway environment $PR_ENV is incomplete ($pr_count < $prod_count active services)"
+    return 0
+  fi
+
+  return 1
+}
+
+create_duplicated_env() {
+  railway environment new "$PR_ENV" --duplicate "$SOURCE_ENV"
+}
+
+railway link --project "$RAILWAY_PROJECT_ID" --environment "$SOURCE_ENV"
+
+ENV_ID="$(lookup_env_id "$PR_ENV" || true)"
+
+if [[ -n "$ENV_ID" ]] && ! env_needs_recreate; then
+  echo "Railway environment $PR_ENV already exists and is duplicated from $SOURCE_ENV"
+else
+  if [[ -n "$ENV_ID" ]]; then
+    echo "Recreating Railway environment $PR_ENV from $SOURCE_ENV"
+    delete_env_by_id "$ENV_ID"
+  else
+    echo "Creating Railway environment $PR_ENV duplicated from $SOURCE_ENV"
+  fi
+
+  if ! create_duplicated_env; then
+    echo "railway environment new failed; cleaning up so retry can succeed" >&2
+    delete_pr_env_if_present || true
+    exit 1
+  fi
+
+  if env_config_readable "$PR_ENV" && env_config_readable "$SOURCE_ENV"; then
+    prod_count="$(count_active_services "$SOURCE_ENV")"
+    pr_count="$(count_active_services "$PR_ENV")"
+    if [[ "$pr_count" -lt "$prod_count" ]]; then
+      echo "Railway environment $PR_ENV is still incomplete after duplicate ($pr_count < $prod_count)" >&2
+      delete_pr_env_if_present || true
+      exit 1
+    fi
+    echo "Railway environment $PR_ENV ready with $pr_count active service(s)"
+  fi
+fi
+
+railway link --project "$RAILWAY_PROJECT_ID" --environment "$PR_ENV"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When `railway environment new --duplicate production` fails partway through, the retry step sees the PR environment as already existing and skips duplication, leaving preview environments broken.

After manual deletes, Railway can also leave a reserved environment name that blocks `environment new` with "already exists" while the env is not visible to GraphQL or CLI delete.

## Solution

Simplified `scripts/railway-ensure-pr-environment.sh`:

1. If `railway environment config` succeeds → env exists, skip create
2. Otherwise → `railway environment new --duplicate production` with up to 5 in-script retries
3. On each create failure → delete via paginated GraphQL + linked CLI delete; if not found, wait 30s for Railway name release
4. Outer `nick-fields/retry` (2 attempts, 60s wait) as a final safety net

## Verification

PR Deploy workflow succeeded after manual env delete scenario: https://github.com/ctxpipe-ai/ctxpipe/actions/runs/27261782750
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CTX-125](https://linear.app/ctxpipe/issue/CTX-125/railway-is-not-duplicating-production-environment-on-pr-deployment)

<div><a href="https://cursor.com/agents/bc-ff33cc59-3899-4c4b-82bd-afcf152e0e0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff33cc59-3899-4c4b-82bd-afcf152e0e0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

