### PR TITLE
Clarify Grafana storage-decision Harbor task repo context

### DIFF
--- a/benchmarks/tasks/ctxpipe/storage-decision-ctxpipe/README.md
+++ b/benchmarks/tasks/ctxpipe/storage-decision-ctxpipe/README.md
@@ -4,7 +4,8 @@ Harbor benchmark task for the **ctxpipe arm**: no repository checkout and
 verifier guardrails that reject a local primary-repo tree.
 
 The agent must use the configured hosted ctxpipe MCP server to gather org-wide
-context and produce `/app/answer.json`.
+context for `grafana/loki` (primary), `grafana/tempo`, and `grafana/mimir`, then
+produce `/app/answer.json`.
 
 `allow_internet = true` is required because Cursor CLI runs inside the trial
 container and must reach `CTXPIPE_MCP_URL`.

--- a/benchmarks/tasks/ctxpipe/storage-decision-ctxpipe/environment/Dockerfile
+++ b/benchmarks/tasks/ctxpipe/storage-decision-ctxpipe/environment/Dockerfile
@@ -13,6 +13,12 @@ RUN apt-get update && \
 RUN python3 -m pip install --no-cache-dir --break-system-packages uv && \
     uv pip install --system --break-system-packages 'harbor-rewardkit==0.1.*'
 
-# No repository checkout in this arm.
+# No repository checkout — agents must use hosted ctxpipe MCP for org context.
+RUN printf '%s\n' \
+  '# Grafana storage decision (ctxpipe arm)' \
+  '' \
+  'This workspace has no ingested repository files on disk.' \
+  'Use the ctxpipe MCP server configured for your trial to read org code context for grafana/loki, grafana/tempo, and grafana/mimir.' \
+  > /app/README.md
 
 ENV BENCHMARK_ARM=ctxpipe

--- a/benchmarks/tasks/ctxpipe/storage-decision-ctxpipe/instruction.md
+++ b/benchmarks/tasks/ctxpipe/storage-decision-ctxpipe/instruction.md
@@ -1,10 +1,16 @@
-# Storage Architecture Decision (ctxpipe MCP)
+# Grafana Storage Architecture Decision (ctxpipe MCP)
 
-You are designing storage for a new observability subsystem in a large engineering organization.
+You are designing storage for a new observability subsystem at Grafana.
 
-There is no repository checkout in this workspace. Use the configured ctxpipe MCP server for org-wide code context.
+**There is no repository checkout in this workspace.** Use the **ctxpipe** MCP
+server (already configured for your trial) to read org code context for:
 
-Choose the best storage option and justify the decision with concrete code evidence.
+- `grafana/loki` (primary)
+- `grafana/tempo` (sibling)
+- `grafana/mimir` (sibling)
+
+Choose the best storage option and justify the decision with concrete code evidence
+from these repositories.
 
 Write `/app/answer.json` with exactly these keys:
 - `selected_option`
@@ -17,7 +23,7 @@ Rules:
 - `alternatives_considered` must be an array of at least two options from the same set, excluding `selected_option`.
 - `evidence` must be an array with at least 4 entries.
 - Each `evidence` entry must be an object with keys:
-  - `repo` (string)
+  - `repo` (string — use `owner/repo` form, e.g. `grafana/loki`)
   - `path` (string, repository-relative)
   - `claim` (string)
   - `supports_option` (boolean)

--- a/benchmarks/tasks/ctxpipe/storage-decision-ctxpipe/task.toml
+++ b/benchmarks/tasks/ctxpipe/storage-decision-ctxpipe/task.toml
@@ -2,7 +2,7 @@ schema_version = "1.0"
 
 [task]
 name = "ctxpipe/storage-decision-ctxpipe"
-description = "Cross-repo storage architecture decision benchmark via hosted ctxpipe MCP."
+description = "Grafana cross-repo storage decision benchmark (grafana/loki, tempo, mimir) via hosted ctxpipe MCP."
 keywords = ["grafana", "storage", "decision", "rewardkit", "org-context", "ctxpipe", "mcp"]
 
 [metadata]

--- a/benchmarks/tasks/ctxpipe/storage-decision/README.md
+++ b/benchmarks/tasks/ctxpipe/storage-decision/README.md
@@ -1,7 +1,8 @@
 # ctxpipe/storage-decision
 
-Harbor benchmark task for the **baseline arm**: sparse pinned checkout of the
-primary repository in `/app`, without ctxpipe MCP.
+Harbor benchmark task for the **baseline arm**: sparse pinned checkout of
+`grafana/loki` (primary) in `/app`, without ctxpipe MCP. Agents should also
+reference sibling repos `grafana/tempo` and `grafana/mimir` for cross-repo evidence.
 
 The agent must produce `/app/answer.json` with a storage decision, alternatives,
 and evidence records grounded in code.

--- a/benchmarks/tasks/ctxpipe/storage-decision/instruction.md
+++ b/benchmarks/tasks/ctxpipe/storage-decision/instruction.md
@@ -1,10 +1,19 @@
-# Storage Architecture Decision
+# Grafana Storage Architecture Decision
 
-You are designing storage for a new observability subsystem in a large engineering organization.
+You are designing storage for a new observability subsystem at Grafana.
 
-This workspace contains a pinned checkout of one repository at `/app`.
+The workspace contains a sparse, pinned checkout of the **primary repository**
+`grafana/loki` at `/app`. It includes only a subset of files from that repo.
 
-Choose the best storage option and justify the decision with concrete code evidence.
+Your decision should also draw on patterns from related Grafana observability
+repositories in the same organization:
+
+- `grafana/loki` (primary — local checkout at `/app`)
+- `grafana/tempo` (sibling)
+- `grafana/mimir` (sibling)
+
+Choose the best storage option and justify the decision with concrete code evidence
+across these repositories.
 
 Write `/app/answer.json` with exactly these keys:
 - `selected_option`
@@ -17,7 +26,7 @@ Rules:
 - `alternatives_considered` must be an array of at least two options from the same set, excluding `selected_option`.
 - `evidence` must be an array with at least 4 entries.
 - Each `evidence` entry must be an object with keys:
-  - `repo` (string)
+  - `repo` (string — use `owner/repo` form, e.g. `grafana/loki`)
   - `path` (string, repository-relative)
   - `claim` (string)
   - `supports_option` (boolean)

--- a/benchmarks/tasks/ctxpipe/storage-decision/task.toml
+++ b/benchmarks/tasks/ctxpipe/storage-decision/task.toml
@@ -2,7 +2,7 @@ schema_version = "1.0"
 
 [task]
 name = "ctxpipe/storage-decision"
-description = "Cross-repo storage architecture decision benchmark with local-only baseline context."
+description = "Grafana cross-repo storage decision benchmark (grafana/loki primary checkout) with local-only baseline context."
 keywords = ["grafana", "storage", "decision", "rewardkit", "org-context", "ctxpipe"]
 
 [metadata]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `storage-decision` Harbor benchmark tasks had generic instructions that never named which repositories the agent should investigate. The Dockerfile and verifier already assume `grafana/loki` (primary) plus `grafana/tempo` and `grafana/mimir` (siblings), but `instruction.md` only said "one repository at `/app`" — inviting hallucinated repos and missed cross-repo evidence.

This aligns both arms with the clearer pattern used by `grafana-codeowners-discovery`.

## Changes

- **Baseline** (`storage-decision/instruction.md`): Frame as a Grafana observability storage decision; name `grafana/loki` as the primary repo checked out at `/app`; list `grafana/tempo` and `grafana/mimir` as sibling repos for cross-repo evidence.
- **Ctxpipe** (`storage-decision-ctxpipe/instruction.md`): Same repo list, with explicit MCP guidance (no local checkout).
- **Ctxpipe Dockerfile**: Add `/app/README.md` reminder (matches `grafana-codeowners-discovery-ctxpipe`).
- **task.toml / README**: Update descriptions to name the repos.

## Review notes (pre-change)

| What existed | Problem |
|---|---|
| "designing storage for a new observability subsystem in a large engineering organization" | No org/repo anchor — agent could invent any codebase |
| "pinned checkout of one repository at `/app`" | Never names `grafana/loki` despite sparse checkout in Dockerfile |
| No sibling repo mention | Verifier requires primary + sibling evidence (`evidence_has_primary_and_sibling`) |
| Ctxpipe arm | No MCP repo list (unlike `grafana-codeowners-discovery-ctxpipe`) |

Oracle answers and scoring are unchanged — only agent-facing context is clarified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-247f3236-99dc-49e1-97f9-c74f1bcfd506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-247f3236-99dc-49e1-97f9-c74f1bcfd506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

