### PR TITLE
Document local memory CLI release

### DIFF
--- a/.changeset/memory-docs.md
+++ b/.changeset/memory-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document local memory as an early CLI release.

--- a/README.md
+++ b/README.md
@@ -60,11 +60,17 @@ managed SaaS at [ctxpipe.ai](https://ctxpipe.ai/early-access).
 | One MCP for engineering knowledge | Give Cursor, Claude Code, Codex, and custom tools the same [MCP](https://docs.ctxpipe.ai/docs/mcp/mcp-docs) endpoint for ctx\| context. |
 | Chat/MCP UI | Give new team members a place to ask questions about code, systems, and decisions without hunting through repos and docs. See agent interactions via MCP filter. |
 | Human-readable context surfaces | Use Chat, repository management, and the [knowledge graph](https://docs.ctxpipe.ai/docs/knowledge-graph) to see what agents can use before they act. |
+| CLI setup and local memory | Install ctx\| MCP with `npx ctxpipe init`, or add early repo-local memory with `npx ctxpipe memory init`. |
+
+## Early CLI releases
+
+These workflows are available through the `ctxpipe` CLI:
+
+- MCP setup from the terminal. Install ctx\| MCP config for Cursor, Claude Code, Codex, OpenCode, and VS Code with `npx ctxpipe init`; the interactive wizard can also add local memory.
+- Local memory. Add a `ctxpipe-memory` MCP server backed by `.ai/memory` from the `npx ctxpipe init` wizard, or use `npx ctxpipe memory init` for memory-only setup; local save/search works without a ctx\| account, and sign-in enables hosted summaries.
 
 ## Coming soon
 
-- Git-backed instructions and memory. Keep AGENTS files, ADRs, skills, and synced docs versioned, reviewable, and close to the repos they affect.
-- MCP CLI for easy installation across supported coding agents.
 - Dashboard to see agent activity, patterns, and insights.
 - Proactive insights that surface stale context, missing instructions, and useful
   patterns from agent usage.
@@ -123,7 +129,8 @@ For backend API, OpenAPI, MCP, and package scripts, see
 ## Documentation
 
 - [Product docs](https://docs.ctxpipe.ai)
-- **MCP setup from the terminal:** `npx ctxpipe init` (see [packages/cli/README.md](packages/cli/README.md) and `npx ctxpipe init --help`)
+- **MCP setup from the terminal:** `npx ctxpipe init` (includes optional local memory; see [packages/cli/README.md](packages/cli/README.md) and `npx ctxpipe init --help`)
+- **Local memory from the terminal:** select local memory in `npx ctxpipe init`, or run `npx ctxpipe memory init` for memory-only setup (see [packages/cli/README.md](packages/cli/README.md))
 - [Getting started](https://docs.ctxpipe.ai/docs/getting-started)
 - [Connections](https://docs.ctxpipe.ai/docs/connections)
 - [Git repositories](https://docs.ctxpipe.ai/docs/git-repositories)

--- a/apps/docs/content/docs/(guide)/chat/index.mdx
+++ b/apps/docs/content/docs/(guide)/chat/index.mdx
@@ -107,4 +107,4 @@ threads created by MCP clients.
 
 - [Knowledge graph overview](/docs/knowledge-graph)
 - [Exploring the knowledge graph](/docs/knowledge-graph/exploring)
-- [MCP docs](/docs/mcp/mcp-docs)
+- [Remote MCP](/docs/mcp/mcp-docs)

--- a/apps/docs/content/docs/(guide)/git-repositories/index.mdx
+++ b/apps/docs/content/docs/(guide)/git-repositories/index.mdx
@@ -66,4 +66,4 @@ The versioned REST API is scoped the same way:
 
 - [Ingestion explanation](/docs/connections/ingestion)
 - [Knowledge graph overview](/docs/knowledge-graph)
-- [MCP docs](/docs/mcp/mcp-docs)
+- [Remote MCP](/docs/mcp/mcp-docs)

--- a/apps/docs/content/docs/(guide)/git-repositories/install-mcps-via-pr.mdx
+++ b/apps/docs/content/docs/(guide)/git-repositories/install-mcps-via-pr.mdx
@@ -135,5 +135,5 @@ context they can access.
 
 ## Related
 
-- [MCP docs](/docs/mcp/mcp-docs)
+- [Remote MCP](/docs/mcp/mcp-docs)
 - [Manage repositories](/docs/git-repositories/manage-repositories)

--- a/apps/docs/content/docs/(guide)/managing-organization/index.mdx
+++ b/apps/docs/content/docs/(guide)/managing-organization/index.mdx
@@ -37,5 +37,5 @@ exposed). The authenticated user becomes **owner** of the new org.
 <Cards>
   <Card title="Team members" href="/docs/managing-organization/team-members" description="Invites, roles, and membership." />
   <Card title="Verified domains" href="/docs/managing-organization/verified-domains" description="Email domain trust - current status." />
-  <Card title="MCP docs" href="/docs/mcp/mcp-docs" description="OAuth sign-in flow for MCP client access." />
+  <Card title="Remote MCP" href="/docs/mcp/mcp-docs" description="OAuth sign-in flow for MCP client access." />
 </Cards>

--- a/apps/docs/content/docs/(guide)/mcp/local-memory.mdx
+++ b/apps/docs/content/docs/(guide)/mcp/local-memory.mdx
@@ -1,0 +1,187 @@
+---
+title: Local memory
+description: Configure the early ctxpipe-memory MCP release for durable repo-local agent memory.
+---
+
+Local memory gives coding agents a durable, repo-local memory surface through a
+second MCP server named `ctxpipe-memory`.
+
+Use it when you want agents to remember architecture decisions, working
+patterns, lessons, and curated session summaries across chats, compactions,
+branch switches, and tools. The source of truth is Markdown in your repository,
+so useful memory stays reviewable in Git instead of disappearing into a private
+agent cache.
+
+<Callout title="Early release">
+  Local memory is available today through the `ctxpipe` CLI. The stable user
+  entry point is `npx ctxpipe memory init`; the internal runtime can change
+  without changing the MCP config written into your agent clients.
+</Callout>
+
+## How It Fits With ctx| MCP
+
+ctx| has two complementary MCP surfaces:
+
+| MCP server | What it does |
+| --- | --- |
+| `ctxpipe` | Remote, organization-scoped context from repositories, connected sources, the knowledge graph, and `ctx_advisor`. |
+| `ctxpipe-memory` | Local, repo-scoped durable memory backed by `.ai/memory` and a ctxpipe-managed AgentMemory cache. |
+
+You can use local memory by itself, or install it next to the remote ctx| MCP
+server.
+
+## Install Local Memory
+
+For normal first-time setup, use the main MCP install wizard:
+
+```bash
+npx ctxpipe init
+```
+
+That wizard includes local memory setup. It lets you choose:
+
+- your ctx| organization for remote MCP,
+- whether to sign in for hosted memory summaries,
+- where to write agent config: this repo, your user profile, or both,
+- which agent clients should get `ctxpipe-memory`,
+- and the planned file changes before anything is written.
+
+Use the memory-only command when you do not want to install the remote
+organization-scoped `ctxpipe` MCP server, or when remote MCP is already
+configured and you are adding memory later:
+
+```bash
+npx ctxpipe memory init
+```
+
+For scripts or headless setup, use explicit flags. Non-interactive `init` does
+not enable memory unless you pass `--memory`:
+
+```bash
+npx ctxpipe memory init --agents cursor --scope repo --non-interactive
+```
+
+To install both remote ctx| MCP and local memory in one run:
+
+```bash
+npx ctxpipe init --org acme --agents cursor,claude --scope repo --memory --non-interactive
+```
+
+## Local-Only And Signed-In Modes
+
+Local memory works without a ctx| account.
+
+| Mode | What works |
+| --- | --- |
+| Continue without login | Local `memory_save`, `memory_recall`, and `memory_smart_search` over repo memory. |
+| Sign in to ctx| | Local save/search plus hosted-model features such as summaries and consolidation. |
+
+Signing in is optional for local save/search. When signed in, ctxpipe forwards
+your existing setup auth to the ctx| model proxy for enhanced memory features;
+you do not need to add model API keys or edit AgentMemory config.
+
+## What Gets Written
+
+The CLI writes portable config and a committed memory root:
+
+| Path | Purpose |
+| --- | --- |
+| `.ai/memory/README.md` | Seed instructions for the canonical memory tree. Existing files are preserved. |
+| `.ctxpipe/config.json` | Non-secret ctx| setup metadata, including the organization when one is selected. |
+| Agent MCP config | A `ctxpipe-memory` entry that runs `npx -y ctxpipe memory mcp`. |
+
+For Cursor and Claude Code project config, the entry looks like:
+
+```json
+{
+  "mcpServers": {
+    "ctxpipe-memory": {
+      "command": "npx",
+      "args": ["-y", "ctxpipe", "memory", "mcp"]
+    }
+  }
+}
+```
+
+For VS Code project config, the entry uses `type: "stdio"`:
+
+```json
+{
+  "servers": {
+    "ctxpipe-memory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "ctxpipe", "memory", "mcp"]
+    }
+  }
+}
+```
+
+Do not commit secrets, raw transcripts, tool logs, or private customer data
+under `.ai/memory`. Commit only durable project knowledge your team wants agents
+to reuse.
+
+## What Agents See
+
+`ctxpipe-memory` exposes a small policy-controlled tool surface:
+
+| Tool | Purpose |
+| --- | --- |
+| `memory_save` | Write a durable Markdown memory record, then hydrate the local cache. |
+| `memory_recall` | Search repo memory. Uses AgentMemory when available and falls back to Markdown search. |
+| `memory_smart_search` | Search repo memory with richer ranking when the local runtime is available. |
+| `memory_status` | Report signed-in state, runtime state, and hosted model availability. |
+| `memory_summarize_session` | Summarize a session when hosted-model access is available. |
+| `memory_consolidate` | Consolidate memory when hosted-model access is available. |
+
+Export and destructive delete-style AgentMemory tools are not exposed in this
+early release.
+
+## Runtime Behavior
+
+`ctxpipe-memory` starts lazily when an agent first calls the MCP server. ctxpipe
+manages a pinned AgentMemory runtime behind the scenes and hydrates it from
+`.ai/memory`.
+
+The AgentMemory cache is disposable. If it is missing, stale, or incompatible
+with the pinned runtime, ctxpipe can rebuild it from the Markdown files in the
+repo.
+
+Local runtime state lives outside the repo under `~/.config/ctxpipe/memory/`.
+The repo contains only the canonical memory files and portable MCP config.
+
+## Operate And Debug
+
+Use these commands from the repository root:
+
+```bash
+npx ctxpipe memory status
+npx ctxpipe memory doctor
+npx ctxpipe memory stop
+```
+
+`memory status` reports the current mode, memory root, runtime URL when one is
+running, hosted-model availability, and hydration manifest state.
+
+`memory doctor` adds setup checks for the memory root, setup auth, runtime, and
+hydration manifest.
+
+`memory stop` stops the per-repo AgentMemory runtime managed by ctxpipe.
+
+You normally do not run `npx ctxpipe memory mcp` by hand. Agent clients launch
+that command from their MCP config.
+
+## Current Limits
+
+- First use may download the pinned AgentMemory package through `npx`.
+- Hosted summaries and consolidation require ctx| sign-in.
+- Local save/search is the stable early-release path; richer memory behavior is
+  still evolving.
+- Raw session logs and tool observations are local cache only. Curated memory
+  belongs in `.ai/memory` and should be reviewed like any other Git change.
+
+## Related
+
+- [Remote MCP](/docs/mcp/mcp-docs)
+- [Connected sources](/docs/connections/connected-sources)
+- [Open source](/docs/resources/open-source)

--- a/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
+++ b/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
@@ -1,6 +1,6 @@
 ---
-title: MCP docs
-description: Choose the right ctx| MCP install path for individuals, teams, and clients that need manual configuration.
+title: Remote MCP
+description: Choose the right remote ctx| MCP install path for individuals, teams, and clients that need manual configuration.
 ---
 
 ctx| exposes an organization-scoped remote MCP server at:
@@ -44,6 +44,7 @@ That runs an interactive wizard for:
 - selecting your organization,
 - choosing repo, user, or both scopes,
 - selecting agent clients,
+- optionally enabling local memory through `ctxpipe-memory`,
 - reviewing the planned file changes before writing.
 
 For MCP-only setup, use:
@@ -55,12 +56,12 @@ npx ctxpipe mcp add
 For scripts and CI, use explicit flags:
 
 ```bash
-npx ctxpipe init --org acme --agents cursor,claude --scope repo --yes
-npx ctxpipe mcp add --org acme --client opencode --scope user --yes
+npx ctxpipe init --org acme --agents cursor,claude --scope repo --non-interactive
+npx ctxpipe mcp add --org acme --client opencode --scope user --non-interactive
 npx ctxpipe doctor --json
 ```
 
-Use `npx ctxpipe init --help` and `npx ctxpipe mcp add --help` for the full flag list, including `--base-url`, `--org`, `--scope`, `--agents`, `--client`, `--yes`, `--json`, and `--dry-run`.
+Use `npx ctxpipe init --help` and `npx ctxpipe mcp add --help` for the full flag list, including `--base-url`, `--org`, `--scope`, `--agents`, `--client`, `--non-interactive`, `--json`, and `--dry-run`.
 
 Setup sign-in is separate from MCP authorization. The CLI signs you in so it can list organizations and write correct config. It stores setup credentials in the OS keychain when available, with a file fallback under `~/.config/ctxpipe/` when keyring access is not possible.
 
@@ -71,6 +72,29 @@ Supported CLI clients:
 - **OpenCode** - repo config in `opencode.json`, user config in `~/.config/opencode/opencode.json`.
 - **VS Code / Copilot** - repo config in `.vscode/mcp.json`; user setup provides the VS Code install link.
 - **Codex** - user setup uses `codex mcp add` when available; otherwise the CLI prints the command to run.
+
+## Local Memory MCP
+
+The CLI can also install `ctxpipe-memory`, an early local-memory MCP server
+backed by `.ai/memory` in your repo. Use it when you want agents to save and
+recall durable project memory across sessions without making the remote ctx| MCP
+responsible for local working notes.
+
+Local memory can run without a ctx| account for save/search. Signing in enables
+hosted-model features such as summaries and consolidation.
+
+```bash
+npx ctxpipe init
+npx ctxpipe memory init
+npx ctxpipe init --org acme --agents cursor --scope repo --memory --non-interactive
+```
+
+The interactive `npx ctxpipe init` wizard includes local memory setup, so you do
+not need to run `memory init` separately for the normal first-time setup flow.
+Use `npx ctxpipe memory init` when you want local memory only, or when remote
+ctx| MCP is already configured and you are adding memory later.
+
+Read the full guide: [Local memory](/docs/mcp/local-memory).
 
 ## Team Setup Via Pull Requests
 
@@ -214,3 +238,4 @@ If your client's docs only mention `http` or SSE, check the current client docum
 
 - [Managing your organization](/docs/managing-organization) - org slug and membership
 - [Install MCPs via PR](/docs/git-repositories/install-mcps-via-pr) - team rollout through GitHub pull requests
+- [Local memory](/docs/mcp/local-memory) - repo-local memory through `ctxpipe-memory`

--- a/apps/docs/content/docs/(guide)/mcp/meta.json
+++ b/apps/docs/content/docs/(guide)/mcp/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "ctx| MCP",
-  "pages": ["mcp-docs"]
+  "pages": ["mcp-docs", "local-memory"]
 }


### PR DESCRIPTION
Updated docs to explain the local memory harness, and removed 'coming soon' reference in the README.md