### PR TITLE
Avoid having a single transaction across all steps in a workflow

### DIFF
--- a/.changeset/old-pianos-act.md
+++ b/.changeset/old-pianos-act.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Fix transaction behaviour for workflow

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -81,87 +81,81 @@ export const repositoryIngestion = defineWorkflow(
         return withOrgIdContext({ id: org.id, slug: org.slug }, async () => {
           let ingestOutputState: CodeIngestionState | undefined
 
-          const result = await withOrgDbContext(input.orgId, async () => {
-            const db = getOrgDb()
+          logWorkflowMilestone(
+            "repository-ingestion.step.get-repository.start",
+            {
+              repositoryId: input.repositoryId,
+              orgId: input.orgId,
+            },
+          )
 
-            logWorkflowMilestone(
-              "repository-ingestion.step.get-repository.start",
-              {
-                repositoryId: input.repositoryId,
-                orgId: input.orgId,
-              },
-            )
-
-            const repository = await step.run({ name: "get-repository" }, () =>
+          const repository = await step.run({ name: "get-repository" }, () =>
+            withOrgDbContext(input.orgId, (db) =>
               db.query.repositories.findFirst({
                 where: {
                   id: { eq: input.repositoryId },
                   orgId: { eq: input.orgId },
                 },
               }),
+            ),
+          )
+
+          logWorkflowMilestone("repository-ingestion.step.get-repository.done", {
+            repositoryId: input.repositoryId,
+            found: Boolean(repository),
+          })
+
+          if (!repository) {
+            throw new Error(
+              `repository-ingestion: no repository row for id=${input.repositoryId} orgId=${input.orgId} (skipping codesearch resolve-ref)`,
             )
+          }
 
-            logWorkflowMilestone(
-              "repository-ingestion.step.get-repository.done",
-              {
-                repositoryId: input.repositoryId,
-                found: Boolean(repository),
-              },
-            )
+          const githubConnectionId = repository.githubConnectionId
+          log.set({
+            step: "repository-ingestion.repository-loaded",
+            repositoryId: input.repositoryId,
+            lastIngestedHash: repository.lastIngestedHash,
+            githubConnectionId,
+          })
+          log.info("repository row loaded")
+          flushWorkflowLog()
 
-            if (!repository) {
-              throw new Error(
-                `repository-ingestion: no repository row for id=${input.repositoryId} orgId=${input.orgId} (skipping codesearch resolve-ref)`,
-              )
-            }
+          logWorkflowMilestone("repository-ingestion.step.resolve-ref.start", {
+            repositoryId: input.repositoryId,
+            branch: input.targetBranch ?? null,
+          })
 
-            const githubConnectionId = repository.githubConnectionId
-            log.set({
-              step: "repository-ingestion.repository-loaded",
+          const resolved = await step.run({ name: "resolve-ref" }, () =>
+            resolveRepositoryRef({
               repositoryId: input.repositoryId,
-              lastIngestedHash: repository.lastIngestedHash,
+              orgId: input.orgId,
+              branch: input.targetBranch ?? undefined,
               githubConnectionId,
-            })
-            log.info("repository row loaded")
-            flushWorkflowLog()
+            }),
+          )
 
-            logWorkflowMilestone(
-              "repository-ingestion.step.resolve-ref.start",
-              {
-                repositoryId: input.repositoryId,
-                branch: input.targetBranch ?? null,
-              },
-            )
+          logWorkflowMilestone("repository-ingestion.step.resolve-ref.done", {
+            repositoryId: input.repositoryId,
+            targetHash: resolved.hash,
+            branch: resolved.branch,
+          })
 
-            const resolved = await step.run({ name: "resolve-ref" }, () =>
-              resolveRepositoryRef({
-                repositoryId: input.repositoryId,
-                orgId: input.orgId,
-                branch: input.targetBranch ?? undefined,
-                githubConnectionId,
-              }),
-            )
+          log.set({
+            step: "repository-ingestion.ref-resolved",
+            targetHash: resolved.hash,
+            sourceBranch: resolved.branch,
+          })
+          log.info("repository ref resolved for ingestion")
+          flushWorkflowLog()
 
-            logWorkflowMilestone("repository-ingestion.step.resolve-ref.done", {
-              repositoryId: input.repositoryId,
-              targetHash: resolved.hash,
-              branch: resolved.branch,
-            })
+          logWorkflowMilestone("repository-ingestion.step.ingest.start", {
+            repositoryId: input.repositoryId,
+            targetHash: resolved.hash,
+          })
 
-            log.set({
-              step: "repository-ingestion.ref-resolved",
-              targetHash: resolved.hash,
-              sourceBranch: resolved.branch,
-            })
-            log.info("repository ref resolved for ingestion")
-            flushWorkflowLog()
-
-            logWorkflowMilestone("repository-ingestion.step.ingest.start", {
-              repositoryId: input.repositoryId,
-              targetHash: resolved.hash,
-            })
-
-            ingestOutputState = await step.run({ name: "ingest" }, () =>
+          ingestOutputState = await step.run({ name: "ingest" }, () =>
+            withOrgDbContext(input.orgId, () =>
               runWithLangfuseContext(
                 {
                   sessionId: input.repositoryId,
@@ -181,7 +175,7 @@ export const repositoryIngestion = defineWorkflow(
                     },
                   )
 
-                  const result = await codeIngestionGraph.invoke(
+                  const graphResult = await codeIngestionGraph.invoke(
                     {
                       repositoryId: input.repositoryId,
                       orgId: input.orgId,
@@ -204,7 +198,7 @@ export const repositoryIngestion = defineWorkflow(
                   )
 
                   const logIngest = getLogger()
-                  const state = result as CodeIngestionState
+                  const state = graphResult as CodeIngestionState
                   logIngest.set({
                     step: "repository-ingestion.graph.complete",
                     repositoryId: input.repositoryId,
@@ -221,17 +215,17 @@ export const repositoryIngestion = defineWorkflow(
                   })
                   logIngest.info("repository ingestion graph completed")
                   flushWorkflowLog()
-                  return result
+                  return graphResult as CodeIngestionState
                 },
               ),
-            )
+            ),
+          )
 
-            return {
-              repositoryId: input.repositoryId,
-              targetHash: resolved.hash,
-              sourceBranch: resolved.branch,
-            }
-          })
+          const result = {
+            repositoryId: input.repositoryId,
+            targetHash: resolved.hash,
+            sourceBranch: resolved.branch,
+          }
 
           const effects = ingestOutputState?.retractionGraphEffects
           if (


### PR DESCRIPTION
This is one of the fixes as our [repo-ingestion workflow is failing due to transaction being idle for a long time](https://railway.com/project/119e3cc3-ef73-43aa-895a-8c8ccff73ff8/logs?environmentId=9337f109-511a-4c5a-8e57-e9a45cc9a412&timeFrame=15m&context=2026-06-15T07%3A38%3A03.574068649Z&permalink=2026-06-15T07%3A38%3A03.574068649Z)

Steps in the same workflow dont need to be in the same transaction either as due to the nature of a workflow, if a step is already successful, it won't be re-run again - only the successful result is returned

This approach aligns with other workflows too