### PR TITLE
Tighten ingestion extractor prompts to reduce over-exploration.

### DIFF
--- a/.changeset/smart-houses-create.md
+++ b/.changeset/smart-houses-create.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Fine-tune system prompt

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIClients.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIClients.ts
@@ -107,7 +107,7 @@ Search strategy:
 For internal APIs: use consumedApi with the path to the API directory in the repo (e.g. apps/web/src/app/api).
 For external APIs: use consumedApiName (e.g. Stripe, SendGrid) and optionally consumedApiUrl (env var or config).
 
-For each API client found, call submit_api_clients with path, consumedApi OR consumedApiName, and optional evidence. Be thorough. Explore all roots. Prefer submit_api_clients once manifest/SDK evidence is clear.`
+Cover only the listed roots. Call submit_api_clients for each client supported by manifests, SDK imports, or config; batch multiple clients per call. Prefer submitting once manifest/SDK evidence is clear over exhaustive blind search.`
 
 export async function identifyAPIClients(
   state: CodeIngestionState,
@@ -146,7 +146,7 @@ Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots
 ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
   })
 
-  const userMessage = `Explore the repository for API clients. List files in config directories, search for HTTP clients, SDKs, and API config patterns. For each client found, determine if it consumes an internal API (path in repo) or external API (name like Stripe, SendGrid). Call submit_api_clients for each.`
+  const userMessage = `For the listed roots, check package manifests and search for HTTP clients, SDKs, and API config patterns. Call submit_api_clients (batch clients per call) once manifest/SDK evidence is clear; skip uncertain hits.`
 
   await agent.invoke(
     { messages: [new HumanMessage(userMessage)] },

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIs.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIs.ts
@@ -112,7 +112,7 @@ Prefer search and narrow list_files paths first; use get_file in preview by defa
 
 For each API surface without an OpenAPI file, infer operations from route handlers (get_file on route.ts, *.py, etc.) and call submit_apis with path, framework, and operations.
 
-Be thorough. Explore the given roots. Call submit_apis for each distinct API surface you find. Prefer submitting once you have solid evidence for a surface over unbounded exploration.`
+Cover only the given roots. Call submit_apis for each distinct API surface supported by route files or search hits; batch multiple surfaces per call. Prefer submitting once you have solid evidence over exhaustive exploration.`
 
 export async function identifyAPIs(
   state: CodeIngestionState,
@@ -216,7 +216,7 @@ Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots
 ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
     })
 
-    const userMessage = `Explore the repository for HTTP APIs for these roots only: ${rootsNeedingLlm.join(", ")}. List and search route patterns; infer operations from route files where there is no OpenAPI spec. Call submit_apis for each API surface.`
+    const userMessage = `For these roots only: ${rootsNeedingLlm.join(", ")}. Check likely API directories, search route patterns, and infer operations from route files where there is no OpenAPI spec. Call submit_apis (batch surfaces per call) once you have solid evidence; stop after targeted checks rather than scanning the whole tree.`
 
     await agent.invoke(
       { messages: [new HumanMessage(userMessage)] },

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
@@ -117,7 +117,7 @@ Search strategy:
 2. search for connection strings, ORM config, driver imports (postgresql, create_engine, SessionLocal, DATABASES, jdbc:, mongodb://, redis://)
 3. get_file on schema files, package manifests, env examples to confirm
 
-For each database found, call submit_databases with dbType, path (root or directory), and optional evidence. Be thorough. Explore all roots. Prefer submit_databases once connection/ORM evidence is clear.`
+Cover only the listed roots. Call submit_databases for each database supported by ORM config, connection strings, or manifests; batch multiple databases per call. Prefer submitting once connection/ORM evidence is clear over exhaustive blind search.`
 
 export async function identifyDatabases(
   state: CodeIngestionState,
@@ -156,7 +156,7 @@ Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots
 ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
   })
 
-  const userMessage = `Explore the repository for databases. List files in config directories, search for database connection patterns across all languages. For each database found, read the relevant config/schema to confirm, then call submit_databases.`
+  const userMessage = `For the listed roots, check config directories and search for database/ORM patterns. Call submit_databases (batch per call) once connection or schema evidence is clear; skip uncertain hits.`
 
   await agent.invoke(
     { messages: [new HumanMessage(userMessage)] },

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructure.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructure.ts
@@ -90,7 +90,7 @@ Search strategy:
 2. search for apiVersion: apps/v1, kind: Deployment, FROM in Dockerfile, serverless framework, terraform, pulumi
 3. get_file on Dockerfile, docker-compose.yml, k8s manifests, serverless.yml to confirm
 
-For each infrastructure found, call submit_infrastructure with infraType, path (root or directory), and optional evidence. Be thorough. Explore all roots. Terraform/Pulumi: focus on compute-related resources; lighter scan is acceptable. Prefer submit_infrastructure once Dockerfile/manifest evidence is clear.`
+Cover only the listed roots. Call submit_infrastructure for each deployment target supported by Dockerfiles, manifests, or IaC; batch multiple items per call. Terraform/Pulumi: focus on compute-related resources; lighter scan is acceptable. Prefer submitting once Dockerfile/manifest evidence is clear over exhaustive blind search.`
 
 export async function identifyInfrastructure(
   state: CodeIngestionState,
@@ -126,7 +126,7 @@ Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots
 ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
   })
 
-  const userMessage = `Explore the repository for infrastructure and deployment targets. List files at roots, search for Dockerfile, docker-compose, Kubernetes manifests, serverless config, Terraform/Pulumi. For each infrastructure found, read the relevant config to confirm, then call submit_infrastructure.`
+  const userMessage = `For the listed roots, check for Dockerfile, docker-compose, k8s manifests, serverless config, and Terraform/Pulumi. Call submit_infrastructure (batch per call) once manifest evidence is clear; skip uncertain hits.`
 
   await agent.invoke(
     { messages: [new HumanMessage(userMessage)] },

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
@@ -150,7 +150,7 @@ Search strategy:
 3. get_file on package.json, requirements.txt, etc. to confirm dependencies
 4. Focus on architectural deps — skip lodash, date-fns, uuid, etc. unless central to architecture
 
-For each library found, call submit_libraries with name, path (root or directory), optional category, and optional evidence. Be thorough. Explore all roots. Prefer calling submit_libraries once you have enough manifest/import evidence rather than exhaustive blind search.`
+Cover only the listed roots. Call submit_libraries for each architectural library supported by manifests or imports; batch multiple libraries per call. Focus on architectural deps — skip utilities unless central. Prefer submitting once you have enough manifest/import evidence over exhaustive blind search.`
 
 export async function identifyLibraries(
   state: CodeIngestionState,
@@ -186,7 +186,7 @@ Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots
 ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
   })
 
-  const userMessage = `Explore the repository for architectural libraries (ORM, HTTP, auth, validation, cache). List package manifests, search for import patterns across all languages. For each library found, read the relevant config to confirm, then call submit_libraries.`
+  const userMessage = `For the listed roots, check package manifests and search for architectural library imports (ORM, HTTP, auth, validation, cache). Call submit_libraries (batch per call) once manifest/import evidence is clear; skip utilities and uncertain hits.`
 
   await agent.invoke(
     { messages: [new HumanMessage(userMessage)] },

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyServiceDependencies.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyServiceDependencies.ts
@@ -95,7 +95,7 @@ Files to inspect:
 - .env.example, config files with service URLs
 - Source code: fetch(API_URL), axios.get(internalUrl), import from workspace packages
 
-For each dependency found, call submit_service_dependencies with consumerPath (root of consumer, e.g. apps/web), providerPath (root of provider, e.g. apps/api or packages/shared), and optional evidence. Only report dependencies within this repository — not external npm packages. Be thorough. Explore all roots. Prefer submit_service_dependencies once workspace/import evidence is clear.`
+Cover only the listed roots. Call submit_service_dependencies for each in-repo dependency supported by workspace config or imports; batch multiple dependencies per call. Only report dependencies within this repository — not external npm packages. Prefer submitting once workspace/import evidence is clear over exhaustive blind search.`
 
 export async function identifyServiceDependencies(
   state: CodeIngestionState,
@@ -131,7 +131,7 @@ Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots
 ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
   })
 
-  const userMessage = `Explore the repository for cross-service dependencies. List package manifests, workspace configs, search for workspace:* refs, internal HTTP calls, and imports from workspace packages. For each dependency found, call submit_service_dependencies with consumerPath, providerPath, and optional evidence.`
+  const userMessage = `For the listed roots, check workspace configs and search for workspace refs, internal HTTP calls, and imports from in-repo packages. Call submit_service_dependencies (batch per call) once evidence is clear; skip external npm packages and uncertain hits.`
 
   await agent.invoke(
     { messages: [new HumanMessage(userMessage)] },

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreams.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreams.ts
@@ -95,7 +95,7 @@ Search strategy:
 4. For producer: look for send, publish, produce, put
 5. For consumer: look for subscribe, consume, receive, get
 
-For each stream found, call submit_streams with streamType, path (root or directory), role (producer/consumer/both), and optional evidence. Be thorough. Explore all roots. Prefer submit_streams once dependency/import evidence is clear.`
+Cover only the listed roots. Call submit_streams for each messaging system supported by dependencies or imports; batch multiple streams per call. Prefer submitting once dependency/import evidence is clear over exhaustive blind search.`
 
 export async function identifyStreams(
   state: CodeIngestionState,
@@ -131,7 +131,7 @@ Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots
 ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
   })
 
-  const userMessage = `Explore the repository for message/event streams. List files in config directories, search for Kafka, RabbitMQ, SQS, SNS, Redis Pub/Sub, NATS, Pulsar and similar patterns across all languages. For each stream found, determine if the service produces to, consumes from, or both. Call submit_streams with streamType, path, role, and optional evidence.`
+  const userMessage = `For the listed roots, check manifests and search for Kafka, RabbitMQ, SQS, SNS, Redis Pub/Sub, NATS, Pulsar, and similar patterns. Call submit_streams (batch per call) with role once dependency/import evidence is clear; skip uncertain hits.`
 
   await agent.invoke(
     { messages: [new HumanMessage(userMessage)] },


### PR DESCRIPTION
Replace "be thorough" guidance with bounded, evidence-first instructions so ReAct agents submit earlier and hit recursion limits less often.