### PR TITLE
Replace LLM extractors with deterministic manifest scanning

### DIFF
--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/README.md
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/README.md
@@ -75,17 +75,16 @@ Runs in parallel with identifyAPIs; internal refs match api: keys from identifyA
 
 ## identifyServiceDependencies
 
-Extracts DEPENDS_ON claims (Service → Service) for cross-service dependencies within a monorepo. Uses an LLM agent with `list_files`, `search`, `get_file`, and `submit_service_dependencies` tools. Produces no new objects — Service nodes come from extractKind.
+Extracts DEPENDS_ON claims (Service → Service) for cross-service dependencies within a monorepo. **Deterministic**: scans `package.json` for `workspace:*`, `link:`, and `file:` references and resolves them via package name index. Produces no new objects — Service nodes come from extractKind.
 
-- **Internal package refs** – "@repo/api": "workspace:*", from "@repo/shared"
-- **HTTP calls to internal URLs** – localhost, internal hostnames, service discovery
-- **Workspace config** – pnpm-workspace.yaml, package.json workspaces, yarn workspaces
+- **Internal package refs** – `"@repo/api": "workspace:*"`, `"@repo/shared": "file:../../packages/shared"`
+- **Workspace config** – resolved via package `name` fields across the repo
 
 Claim path: subjectRef = `svc:${repositoryId}:${consumerRoot}`, objectRef = `svc:${repositoryId}:${providerRoot}`, predicate = DEPENDS_ON
 
 ## identifyLibraries
 
-Extracts Library objects and USES_LIBRARY claims (Service → Library) from repository code. Uses an LLM agent with `list_files`, `search`, `get_file`, and `submit_libraries` tools to detect architectural dependencies:
+Extracts Library objects and USES_LIBRARY claims (Service → Library) from repository code. **Deterministic**: scans package manifests (`package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, etc.) for known architectural dependencies.
 
 - **ORM** – Prisma, Drizzle, TypeORM, Sequelize, Mongoose, SQLAlchemy, GORM
 - **HTTP** – Express, Hono, Fastify, Next.js, FastAPI, Flask, Django
@@ -96,29 +95,36 @@ Extracts Library objects and USES_LIBRARY claims (Service → Library) from repo
 Deduplication: `lib:${repositoryId}:${root}:${libraryName}`  
 Claim path: subjectRef = `svc:${repositoryId}:${root}`, objectRef = lib key, predicate = USES_LIBRARY
 
+## identifyDatabases
+
+Extracts Database objects and DEPENDS_ON claims (Service → Database). **Deterministic**: scans Prisma schemas (`provider`), `docker-compose*.yml` service images, and manifest database drivers (`pg`, `mongoose`, `ioredis`, etc.).
+
+Deduplication: `db:${repositoryId}:${root}:${dbType}`  
+Claim path: subjectRef = `svc:${repositoryId}:${root}`, objectRef = db key, predicate = DEPENDS_ON
+
 ## identifyStreams
 
-Extracts Stream objects and PRODUCES_TO / CONSUMES_FROM claims (Service → Stream) from repository code. Uses an LLM agent with `list_files`, `search`, `get_file`, and `submit_streams` tools to detect message/event streams:
+Extracts Stream objects and PRODUCES_TO / CONSUMES_FROM claims (Service → Stream) from repository code. **Deterministic**: scans manifest dependencies for Kafka, RabbitMQ, SQS, SNS, Redis Pub/Sub, NATS, Pulsar, and similar SDKs. Role defaults to `both` when only manifest evidence is available.
 
-- **Kafka** – kafka-python, confluent-kafka, @nestjs/microservices, sarama, kafkajs
-- **RabbitMQ** – amqp, pika, amqplib
-- **AWS** – @aws-sdk/client-sqs, @aws-sdk/client-sns, boto3 sqs/sns
-- **Redis Pub/Sub** – ioredis publish/subscribe, redis-py pubsub
-- **NATS, Pulsar, Google Pub/Sub, Azure Event Hubs, ActiveMQ**
+- **Kafka** – kafkajs, confluent-kafka, @nestjs/microservices, sarama
+- **RabbitMQ** – amqplib, pika
+- **AWS** – @aws-sdk/client-sqs, @aws-sdk/client-sns
+- **Redis Pub/Sub** – ioredis, redis
+- **NATS, Pulsar, Google Pub/Sub, Azure Event Hubs**
 
 Deduplication: `stream:${repositoryId}:${root}:${streamType}` (submissions are attributed to the **most specific** matching root when `roots` lists both `./` and package paths).  
-Stream object payload: `path` is the resolved service root; `submittedPath` is the path(s) from the agent (single string, or `; `-joined if merged).  
+Stream object payload: `path` is the resolved service root; `submittedPath` is the path(s) from the scan (single string, or `; `-joined if merged).  
 Claim path: subjectRef = `svc:${repositoryId}:${root}`, objectRef = stream key, predicate = PRODUCES_TO or CONSUMES_FROM (based on role: producer/consumer/both)
 
 ## identifyInfrastructure
 
-Extracts Infrastructure objects and RUNS_ON claims (Service → Infrastructure) from repository code. Uses an LLM agent with `list_files`, `search`, `get_file`, and `submit_infrastructure` tools to detect deployment targets:
+Extracts Infrastructure objects and RUNS_ON claims (Service → Infrastructure) from repository code. **Deterministic**: scans for Dockerfiles, compose files, k8s manifests, and platform config files.
 
 - **Docker** – Dockerfile, .dockerignore
 - **Docker Compose** – docker-compose*.yml
 - **Kubernetes** – k8s/, manifests/, *.yaml with apiVersion: apps/v1, Helm charts
 - **Serverless** – serverless.yml, sam.yaml, Cloud Run, Lambda config
-- **Terraform / Pulumi** – *.tf, Pulumi.yaml referencing compute (lighter scan)
+- **Terraform / Pulumi** – *.tf, Pulumi.yaml
 - **Platforms** – Vercel, Fly.io, Railway, Render, Cloudflare Workers
 
 Deduplication: `inf:${repositoryId}:${root}:${infraType}` (same **most specific root** rule as streams when `./` and package roots coexist). Duplicate submissions for the same key merge **evidence** and collect distinct **paths** in payload `paths` when needed.  

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/deterministicRepoScan.test.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/deterministicRepoScan.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildPackageNameIndex,
+  collectDeterministicScanPaths,
+  dirOf,
+  resolveRelativePath,
+  scanDatabases,
+  scanInfrastructure,
+  scanLibraries,
+  scanStreams,
+  scanWorkspaceDependencies,
+} from "./deterministicRepoScan.js"
+
+describe("deterministicRepoScan", () => {
+  describe("scanWorkspaceDependencies", () => {
+    it("detects workspace:* dependencies between monorepo packages", () => {
+      const paths = ["apps/web/package.json", "packages/shared/package.json"]
+      const contents = {
+        "apps/web/package.json": JSON.stringify({
+          name: "@repo/web",
+          dependencies: { "@repo/shared": "workspace:*" },
+        }),
+        "packages/shared/package.json": JSON.stringify({
+          name: "@repo/shared",
+        }),
+      }
+      const index = buildPackageNameIndex(paths, contents)
+      const deps = scanWorkspaceDependencies(paths, contents, index)
+
+      expect(deps).toHaveLength(1)
+      expect(deps[0]).toMatchObject({
+        consumerPath: "apps/web",
+        providerPath: "packages/shared",
+        evidence: "apps/web/package.json: @repo/shared@workspace:*",
+      })
+    })
+
+    it("detects file: workspace references", () => {
+      const paths = ["apps/api/package.json"]
+      const contents = {
+        "apps/api/package.json": JSON.stringify({
+          dependencies: { shared: "file:../../packages/shared" },
+        }),
+      }
+      const index = buildPackageNameIndex(paths, contents)
+      const deps = scanWorkspaceDependencies(paths, contents, index)
+
+      expect(deps).toHaveLength(1)
+      expect(deps[0].providerPath).toBe("packages/shared")
+    })
+
+    it("deduplicates identical consumer→provider pairs", () => {
+      const paths = ["apps/web/package.json"]
+      const contents = {
+        "apps/web/package.json": JSON.stringify({
+          dependencies: { "@repo/shared": "workspace:*" },
+          devDependencies: { "@repo/shared": "workspace:^" },
+        }),
+      }
+      const index = new Map([["@repo/shared", "packages/shared"]])
+      const deps = scanWorkspaceDependencies(paths, contents, index)
+      expect(deps).toHaveLength(1)
+    })
+  })
+
+  describe("scanLibraries", () => {
+    it("detects architectural libraries from package.json", () => {
+      const paths = ["apps/backend/package.json"]
+      const contents = {
+        "apps/backend/package.json": JSON.stringify({
+          dependencies: {
+            hono: "^4.0.0",
+            zod: "^3.0.0",
+            "better-auth": "^1.0.0",
+            lodash: "^4.0.0",
+          },
+        }),
+      }
+      const libs = scanLibraries(paths, contents)
+      const names = libs.map((l) => l.name).sort()
+      expect(names).toEqual(["Better Auth", "Hono", "Zod"])
+      expect(libs.find((l) => l.name === "Hono")).toMatchObject({
+        category: "HTTP",
+        path: "apps/backend",
+      })
+    })
+  })
+
+  describe("scanDatabases", () => {
+    it("detects Postgres from Prisma schema", () => {
+      const paths = ["apps/backend/prisma/schema.prisma"]
+      const contents = {
+        "apps/backend/prisma/schema.prisma": `
+          datasource db {
+            provider = "postgresql"
+            url      = env("DATABASE_URL")
+          }
+        `,
+      }
+      const dbs = scanDatabases(paths, contents)
+      expect(dbs).toHaveLength(1)
+      expect(dbs[0]).toMatchObject({
+        dbType: "Postgres",
+        path: "apps/backend/prisma",
+      })
+    })
+
+    it("detects databases from docker-compose services", () => {
+      const paths = ["docker-compose.yml"]
+      const contents = {
+        "docker-compose.yml": `
+          services:
+            postgres:
+              image: postgres:16
+            redis:
+              image: redis:7
+        `,
+      }
+      const dbs = scanDatabases(paths, contents)
+      const types = dbs.map((d) => d.dbType).sort()
+      expect(types).toEqual(["Postgres", "Redis"])
+    })
+
+    it("detects databases from package.json drivers", () => {
+      const paths = ["package.json"]
+      const contents = {
+        "package.json": JSON.stringify({
+          dependencies: { pg: "^8.0.0", mongoose: "^8.0.0" },
+        }),
+      }
+      const dbs = scanDatabases(paths, contents)
+      const types = dbs.map((d) => d.dbType).sort()
+      expect(types).toEqual(["Mongo", "Postgres"])
+    })
+  })
+
+  describe("scanInfrastructure", () => {
+    it("detects Docker and Docker Compose from file names", () => {
+      const paths = ["apps/api/Dockerfile", "docker-compose.yml"]
+      const contents = { "apps/api/Dockerfile": "", "docker-compose.yml": "" }
+      const infra = scanInfrastructure(paths, contents)
+      const types = infra.map((i) => i.infraType).sort()
+      expect(types).toEqual(["Docker", "Docker Compose"])
+    })
+
+    it("detects Kubernetes from manifest content", () => {
+      const paths = ["k8s/deployment.yaml"]
+      const contents = {
+        "k8s/deployment.yaml": `
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: api
+        `,
+      }
+      const infra = scanInfrastructure(paths, contents)
+      expect(infra).toHaveLength(1)
+      expect(infra[0].infraType).toBe("Kubernetes")
+    })
+  })
+
+  describe("scanStreams", () => {
+    it("detects Kafka from package.json dependencies", () => {
+      const paths = ["apps/worker/package.json"]
+      const contents = {
+        "apps/worker/package.json": JSON.stringify({
+          dependencies: { kafkajs: "^2.0.0" },
+        }),
+      }
+      const streams = scanStreams(paths, contents)
+      expect(streams).toHaveLength(1)
+      expect(streams[0]).toMatchObject({
+        streamType: "Kafka",
+        path: "apps/worker",
+        role: "both",
+      })
+    })
+  })
+
+  describe("path helpers", () => {
+    it("resolves relative paths", () => {
+      expect(resolveRelativePath("apps/web", "../packages/shared")).toBe(
+        "apps/packages/shared",
+      )
+      expect(dirOf("apps/web/package.json")).toBe("apps/web")
+      expect(dirOf("package.json")).toBe("./")
+    })
+
+    it("collects scan paths for partial ingestion scope", () => {
+      const all = [
+        "apps/web/package.json",
+        "apps/api/package.json",
+        "apps/web/src/index.ts",
+      ]
+      const collected = collectDeterministicScanPaths(all, ["apps/web"])
+      expect(collected).toContain("apps/web/package.json")
+      expect(collected).not.toContain("apps/api/package.json")
+    })
+  })
+})

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/deterministicRepoScan.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/deterministicRepoScan.ts
@@ -1,0 +1,706 @@
+/**
+ * Deterministic repository scanning for code-ingestion extractors.
+ * Parses manifests, config files, and well-known paths without LLM agents.
+ */
+
+import { parse as parseYaml } from "yaml"
+import { filterPathsByPartialScan } from "./partialIngestionScope.js"
+
+export type WorkspaceDependency = {
+  consumerPath: string
+  providerPath: string
+  evidence: string
+}
+
+export type ManifestLibrary = {
+  name: string
+  path: string
+  category?: string
+  evidence: string
+}
+
+export type ManifestDatabase = {
+  dbType: string
+  path: string
+  evidence: string
+}
+
+export type ManifestInfrastructure = {
+  infraType: string
+  path: string
+  evidence: string
+}
+
+export type ManifestStream = {
+  streamType: string
+  path: string
+  role: "producer" | "consumer" | "both"
+  evidence: string
+}
+
+const PACKAGE_JSON = "package.json"
+const MANIFEST_FILES = new Set([
+  PACKAGE_JSON,
+  "requirements.txt",
+  "pyproject.toml",
+  "Pipfile",
+  "go.mod",
+  "Cargo.toml",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "Gemfile",
+  "composer.json",
+  "mix.exs",
+])
+
+const PRISMA_SCHEMA_SUFFIX = "schema.prisma"
+const DOCKER_COMPOSE_RE = /(^|\/)docker-compose[^/]*\.ya?ml$/i
+const K8S_MANIFEST_RE = /(^|\/)(k8s|manifests|kubernetes)\/.*\.ya?ml$/i
+
+type LibraryRule = {
+  canonical: string
+  category: string
+  packages: string[]
+}
+
+const LIBRARY_RULES: LibraryRule[] = [
+  {
+    canonical: "Prisma",
+    category: "ORM",
+    packages: ["prisma", "@prisma/client"],
+  },
+  {
+    canonical: "Drizzle",
+    category: "ORM",
+    packages: ["drizzle-orm", "drizzle-kit"],
+  },
+  { canonical: "TypeORM", category: "ORM", packages: ["typeorm"] },
+  { canonical: "Sequelize", category: "ORM", packages: ["sequelize"] },
+  { canonical: "Mongoose", category: "ORM", packages: ["mongoose"] },
+  { canonical: "SQLAlchemy", category: "ORM", packages: ["sqlalchemy"] },
+  { canonical: "GORM", category: "ORM", packages: ["gorm.io/gorm"] },
+  { canonical: "Express", category: "HTTP", packages: ["express"] },
+  { canonical: "Hono", category: "HTTP", packages: ["hono"] },
+  { canonical: "Fastify", category: "HTTP", packages: ["fastify"] },
+  { canonical: "Next.js", category: "HTTP", packages: ["next"] },
+  { canonical: "FastAPI", category: "HTTP", packages: ["fastapi"] },
+  { canonical: "Flask", category: "HTTP", packages: ["flask"] },
+  { canonical: "Django", category: "HTTP", packages: ["django"] },
+  { canonical: "Axum", category: "HTTP", packages: ["axum"] },
+  {
+    canonical: "Better Auth",
+    category: "auth",
+    packages: ["better-auth"],
+  },
+  { canonical: "NextAuth", category: "auth", packages: ["next-auth"] },
+  { canonical: "Passport", category: "auth", packages: ["passport"] },
+  { canonical: "Zod", category: "validation", packages: ["zod"] },
+  { canonical: "Yup", category: "validation", packages: ["yup"] },
+  { canonical: "Joi", category: "validation", packages: ["joi"] },
+  { canonical: "Pydantic", category: "validation", packages: ["pydantic"] },
+  { canonical: "ioredis", category: "cache", packages: ["ioredis"] },
+  {
+    canonical: "Upstash Redis",
+    category: "cache",
+    packages: ["@upstash/redis"],
+  },
+  { canonical: "tRPC", category: "RPC/API", packages: ["@trpc/server", "trpc"] },
+  { canonical: "Axios", category: "HTTP", packages: ["axios"] },
+  {
+    canonical: "TanStack Query",
+    category: "HTTP",
+    packages: ["@tanstack/react-query", "@tanstack/vue-query"],
+  },
+]
+
+const DATABASE_PACKAGE_RULES: Array<{ dbType: string; packages: string[] }> = [
+  { dbType: "Postgres", packages: ["pg", "postgres", "@prisma/adapter-pg"] },
+  { dbType: "MySQL", packages: ["mysql2", "mysql"] },
+  { dbType: "SQLite", packages: ["better-sqlite3", "sqlite3"] },
+  { dbType: "Mongo", packages: ["mongoose", "mongodb", "@prisma/adapter-mongo"] },
+  {
+    dbType: "Redis",
+    packages: ["ioredis", "@upstash/redis", "redis"],
+  },
+  {
+    dbType: "DynamoDB",
+    packages: ["@aws-sdk/client-dynamodb", "@aws-sdk/lib-dynamodb"],
+  },
+  { dbType: "Supabase", packages: ["@supabase/supabase-js"] },
+]
+
+const STREAM_PACKAGE_RULES: Array<{
+  streamType: string
+  packages: string[]
+}> = [
+  {
+    streamType: "Kafka",
+    packages: [
+      "kafkajs",
+      "kafka-node",
+      "node-rdkafka",
+      "@nestjs/microservices",
+      "confluent-kafka",
+      "kafka-python",
+      "aiokafka",
+    ],
+  },
+  {
+    streamType: "RabbitMQ",
+    packages: ["amqplib", "amqp", "pika", "@golevelup/nestjs-rabbitmq"],
+  },
+  { streamType: "SQS", packages: ["@aws-sdk/client-sqs"] },
+  { streamType: "SNS", packages: ["@aws-sdk/client-sns"] },
+  { streamType: "NATS", packages: ["nats", "nats.js"] },
+  { streamType: "Pulsar", packages: ["pulsar-client", "@apache/pulsar-client-node"] },
+  {
+    streamType: "Google Pub/Sub",
+    packages: ["@google-cloud/pubsub"],
+  },
+  {
+    streamType: "Azure Event Hubs",
+    packages: ["@azure/event-hubs"],
+  },
+]
+
+const INFRA_FILE_RULES: Array<{
+  test: (path: string) => boolean
+  infraType: string
+}> = [
+  {
+    test: (p) => /(^|\/)Dockerfile$/.test(p),
+    infraType: "Docker",
+  },
+  {
+    test: (p) => DOCKER_COMPOSE_RE.test(p),
+    infraType: "Docker Compose",
+  },
+  {
+    test: (p) => /(^|\/)Chart\.yaml$/.test(p),
+    infraType: "Helm",
+  },
+  {
+    test: (p) => /(^|\/)serverless\.ya?ml$/.test(p),
+    infraType: "Serverless",
+  },
+  {
+    test: (p) => /(^|\/)sam\.ya?ml$/.test(p) || /(^|\/)template\.ya?ml$/.test(p),
+    infraType: "Lambda",
+  },
+  {
+    test: (p) => /(^|\/)cloudbuild\.ya?ml$/.test(p),
+    infraType: "Cloud Run",
+  },
+  {
+    test: (p) => /\.tf$/.test(p),
+    infraType: "Terraform",
+  },
+  {
+    test: (p) => /(^|\/)Pulumi\.ya?ml$/.test(p),
+    infraType: "Pulumi",
+  },
+  {
+    test: (p) => /(^|\/)wrangler\.toml$/.test(p),
+    infraType: "Cloudflare Workers",
+  },
+  {
+    test: (p) => /(^|\/)vercel\.json$/.test(p),
+    infraType: "Vercel",
+  },
+  {
+    test: (p) => /(^|\/)fly\.toml$/.test(p),
+    infraType: "Fly.io",
+  },
+  {
+    test: (p) => /(^|\/)railway\.(json|toml)$/.test(p),
+    infraType: "Railway",
+  },
+  {
+    test: (p) => /(^|\/)render\.ya?ml$/.test(p),
+    infraType: "Render",
+  },
+]
+
+function basename(path: string): string {
+  const i = path.lastIndexOf("/")
+  return i === -1 ? path : path.slice(i + 1)
+}
+
+export function dirOf(filePath: string): string {
+  const i = filePath.lastIndexOf("/")
+  return i === -1 ? "./" : filePath.slice(0, i)
+}
+
+function normalizePathSegments(segments: string[]): string {
+  const stack: string[] = []
+  for (const seg of segments) {
+    if (seg === "" || seg === ".") continue
+    if (seg === "..") {
+      stack.pop()
+      continue
+    }
+    stack.push(seg)
+  }
+  return stack.length === 0 ? "./" : stack.join("/")
+}
+
+export function resolveRelativePath(fromDir: string, relative: string): string {
+  const base = fromDir === "./" ? [] : fromDir.split("/")
+  return normalizePathSegments([...base, ...relative.split("/")])
+}
+
+function isWorkspaceRef(version: string): boolean {
+  return (
+    version.startsWith("workspace:") ||
+    version.startsWith("link:") ||
+    version.startsWith("file:")
+  )
+}
+
+function parseJsonRecord(
+  content: string,
+): Record<string, string> | null {
+  try {
+    const parsed = JSON.parse(content) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+      peerDependencies?: Record<string, string>
+      optionalDependencies?: Record<string, string>
+    }
+    return {
+      ...parsed.dependencies,
+      ...parsed.devDependencies,
+      ...parsed.peerDependencies,
+      ...parsed.optionalDependencies,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function pathsUnderRoot(allPaths: string[], root: string): string[] {
+  if (root === "./") return allPaths
+  const prefix = `${root}/`
+  return allPaths.filter((p) => p === root || p.startsWith(prefix))
+}
+
+export function packageJsonPaths(allPaths: string[]): string[] {
+  return allPaths.filter((p) => basename(p) === PACKAGE_JSON)
+}
+
+export function manifestPaths(allPaths: string[]): string[] {
+  return allPaths.filter((p) => MANIFEST_FILES.has(basename(p)))
+}
+
+export function prismaSchemaPaths(allPaths: string[]): string[] {
+  return allPaths.filter((p) => p.endsWith(PRISMA_SCHEMA_SUFFIX))
+}
+
+export function infrastructureCandidatePaths(allPaths: string[]): string[] {
+  return allPaths.filter((p) =>
+    INFRA_FILE_RULES.some((rule) => rule.test(p)),
+  )
+}
+
+export function k8sManifestPaths(allPaths: string[]): string[] {
+  return allPaths.filter(
+    (p) => K8S_MANIFEST_RE.test(p) || /\.ya?ml$/.test(p),
+  )
+}
+
+export function buildPackageNameIndex(
+  packageJsonPathsList: string[],
+  contents: Record<string, string>,
+): Map<string, string> {
+  const index = new Map<string, string>()
+  for (const path of packageJsonPathsList) {
+    try {
+      const pkg = JSON.parse(contents[path] ?? "") as { name?: string }
+      if (typeof pkg.name === "string" && pkg.name.length > 0) {
+        index.set(pkg.name, dirOf(path))
+      }
+    } catch {
+      // skip invalid package.json
+    }
+  }
+  return index
+}
+
+function resolveProviderPath(
+  depName: string,
+  version: string,
+  consumerDir: string,
+  packageIndex: Map<string, string>,
+): string | null {
+  if (version.startsWith("file:")) {
+    const rel = version.slice("file:".length)
+    return resolveRelativePath(consumerDir, rel)
+  }
+  if (version.startsWith("link:")) {
+    const rel = version.slice("link:".length)
+    return resolveRelativePath(consumerDir, rel)
+  }
+  return packageIndex.get(depName) ?? null
+}
+
+export function scanWorkspaceDependencies(
+  packageJsonPathsList: string[],
+  contents: Record<string, string>,
+  packageIndex: Map<string, string>,
+): WorkspaceDependency[] {
+  const deps: WorkspaceDependency[] = []
+  const seen = new Set<string>()
+
+  for (const path of packageJsonPathsList) {
+    const consumerDir = dirOf(path)
+    const allDeps = parseJsonRecord(contents[path] ?? "")
+    if (!allDeps) continue
+
+    for (const [name, version] of Object.entries(allDeps)) {
+      if (!isWorkspaceRef(version)) continue
+      const providerPath = resolveProviderPath(
+        name,
+        version,
+        consumerDir,
+        packageIndex,
+      )
+      if (!providerPath) continue
+
+      const key = `${consumerDir}->${providerPath}`
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      deps.push({
+        consumerPath: consumerDir,
+        providerPath,
+        evidence: `${path}: ${name}@${version}`,
+      })
+    }
+  }
+
+  return deps
+}
+
+function matchLibraryRule(packageName: string): LibraryRule | null {
+  const lower = packageName.toLowerCase()
+  for (const rule of LIBRARY_RULES) {
+    if (rule.packages.some((p) => p.toLowerCase() === lower)) return rule
+  }
+  return null
+}
+
+function collectPackageNamesFromManifest(
+  path: string,
+  content: string,
+): string[] {
+  const base = basename(path)
+  if (base === PACKAGE_JSON) {
+    const deps = parseJsonRecord(content)
+    return deps ? Object.keys(deps) : []
+  }
+  if (base === "requirements.txt") {
+    return content
+      .split("\n")
+      .map((line) => line.trim().split(/[<>=!~\[]/)[0]?.trim() ?? "")
+      .filter(Boolean)
+  }
+  if (base === "pyproject.toml") {
+    const names: string[] = []
+    for (const line of content.split("\n")) {
+      const m = line.match(/^\s*["']?([a-zA-Z0-9_.-]+)["']?\s*=/)
+      if (m?.[1] && !["project", "tool", "build-system"].includes(m[1]))
+        names.push(m[1])
+    }
+    return names
+  }
+  if (base === "go.mod") {
+    return [...content.matchAll(/^\s+([^\s]+)\s+v[\d.]/gm)].map((m) => m[1] ?? "")
+  }
+  if (base === "Cargo.toml") {
+    return [...content.matchAll(/^([a-zA-Z0-9_-]+)\s*=\s*/gm)].map(
+      (m) => m[1] ?? "",
+    )
+  }
+  if (base === "Gemfile") {
+    return [...content.matchAll(/gem\s+['"]([^'"]+)['"]/g)].map(
+      (m) => m[1] ?? "",
+    )
+  }
+  if (base === "composer.json") {
+    const deps = parseJsonRecord(content)
+    return deps ? Object.keys(deps) : []
+  }
+  return []
+}
+
+export function scanLibraries(
+  manifestPathsList: string[],
+  contents: Record<string, string>,
+): ManifestLibrary[] {
+  const libs: ManifestLibrary[] = []
+  const seen = new Set<string>()
+
+  for (const path of manifestPathsList) {
+    const rootPath = dirOf(path)
+    const names = collectPackageNamesFromManifest(path, contents[path] ?? "")
+    for (const pkg of names) {
+      const rule = matchLibraryRule(pkg)
+      if (!rule) continue
+      const key = `${rootPath}:${rule.canonical}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      libs.push({
+        name: rule.canonical,
+        path: rootPath,
+        category: rule.category,
+        evidence: `${path}: ${pkg}`,
+      })
+    }
+  }
+
+  return libs
+}
+
+function normalizeDbTypeFromProvider(provider: string): string | null {
+  const lower = provider.toLowerCase()
+  if (lower.includes("postgres") || lower === "pg") return "Postgres"
+  if (lower.includes("mysql")) return "MySQL"
+  if (lower.includes("sqlite")) return "SQLite"
+  if (lower.includes("mongo")) return "Mongo"
+  if (lower.includes("cockroach")) return "CockroachDB"
+  if (lower.includes("sqlserver") || lower.includes("mssql")) return "SQL Server"
+  return null
+}
+
+function scanPrismaSchema(path: string, content: string): ManifestDatabase[] {
+  const match = content.match(/provider\s*=\s*["']([^"']+)["']/)
+  if (!match?.[1]) return []
+  const dbType = normalizeDbTypeFromProvider(match[1])
+  if (!dbType) return []
+  return [
+    {
+      dbType,
+      path: dirOf(path),
+      evidence: `${path}: provider=${match[1]}`,
+    },
+  ]
+}
+
+function scanDockerCompose(path: string, content: string): ManifestDatabase[] {
+  const dbs: ManifestDatabase[] = []
+  const seen = new Set<string>()
+  const rootPath = dirOf(path)
+
+  let doc: unknown
+  try {
+    doc = parseYaml(content)
+  } catch {
+    return dbs
+  }
+
+  const services =
+    typeof doc === "object" && doc !== null
+      ? (doc as { services?: Record<string, { image?: string }> }).services
+      : undefined
+  if (!services) return dbs
+
+  for (const [name, svc] of Object.entries(services)) {
+    const image = (svc?.image ?? name).toLowerCase()
+    let dbType: string | null = null
+    if (image.includes("postgres")) dbType = "Postgres"
+    else if (image.includes("mysql") || image.includes("mariadb"))
+      dbType = "MySQL"
+    else if (image.includes("mongo")) dbType = "Mongo"
+    else if (image.includes("redis")) dbType = "Redis"
+    else if (image.includes("cockroach")) dbType = "CockroachDB"
+    if (!dbType || seen.has(dbType)) continue
+    seen.add(dbType)
+    dbs.push({
+      dbType,
+      path: rootPath,
+      evidence: `${path}: service ${name}`,
+    })
+  }
+
+  return dbs
+}
+
+function scanPackageJsonDatabases(
+  path: string,
+  content: string,
+): ManifestDatabase[] {
+  const deps = parseJsonRecord(content)
+  if (!deps) return []
+  const rootPath = dirOf(path)
+  const dbs: ManifestDatabase[] = []
+  const seen = new Set<string>()
+
+  for (const [pkg, rule] of Object.entries(
+    Object.fromEntries(
+      DATABASE_PACKAGE_RULES.flatMap((r) =>
+        r.packages.map((p) => [p.toLowerCase(), r.dbType] as const),
+      ),
+    ),
+  )) {
+    if (!Object.keys(deps).some((d) => d.toLowerCase() === pkg)) continue
+    if (seen.has(rule)) continue
+    seen.add(rule)
+    dbs.push({
+      dbType: rule,
+      path: rootPath,
+      evidence: `${path}: ${pkg}`,
+    })
+  }
+
+  return dbs
+}
+
+export function scanDatabases(
+  allPaths: string[],
+  contents: Record<string, string>,
+): ManifestDatabase[] {
+  const dbs: ManifestDatabase[] = []
+  const seen = new Set<string>()
+
+  const add = (entries: ManifestDatabase[]) => {
+    for (const entry of entries) {
+      const key = `${entry.path}:${entry.dbType}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      dbs.push(entry)
+    }
+  }
+
+  for (const path of prismaSchemaPaths(allPaths)) {
+    add(scanPrismaSchema(path, contents[path] ?? ""))
+  }
+
+  for (const path of allPaths.filter((p) => DOCKER_COMPOSE_RE.test(p))) {
+    add(scanDockerCompose(path, contents[path] ?? ""))
+  }
+
+  for (const path of packageJsonPaths(allPaths)) {
+    add(scanPackageJsonDatabases(path, contents[path] ?? ""))
+  }
+
+  return dbs
+}
+
+function isKubernetesManifest(content: string): boolean {
+  const trimmed = content.trim()
+  if (!trimmed) return false
+  return (
+    /apiVersion:\s*\S+/m.test(trimmed) &&
+    /kind:\s*(Deployment|StatefulSet|DaemonSet|Service|Ingress|ConfigMap)/m.test(
+      trimmed,
+    )
+  )
+}
+
+export function scanInfrastructure(
+  allPaths: string[],
+  contents: Record<string, string>,
+): ManifestInfrastructure[] {
+  const infra: ManifestInfrastructure[] = []
+  const seen = new Set<string>()
+
+  for (const path of allPaths) {
+    for (const rule of INFRA_FILE_RULES) {
+      if (!rule.test(path)) continue
+      const rootPath = dirOf(path)
+      const key = `${rootPath}:${rule.infraType}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      infra.push({
+        infraType: rule.infraType,
+        path: rootPath === "./" ? path : rootPath,
+        evidence: path,
+      })
+      break
+    }
+  }
+
+  for (const path of k8sManifestPaths(allPaths)) {
+    const content = contents[path] ?? ""
+    if (!isKubernetesManifest(content)) continue
+    const rootPath = dirOf(path)
+    const key = `${rootPath}:Kubernetes`
+    if (seen.has(key)) continue
+    seen.add(key)
+    infra.push({
+      infraType: "Kubernetes",
+      path: rootPath === "./" ? path : rootPath,
+      evidence: path,
+    })
+  }
+
+  return infra
+}
+
+export function scanStreams(
+  manifestPathsList: string[],
+  contents: Record<string, string>,
+): ManifestStream[] {
+  const streams: ManifestStream[] = []
+  const seen = new Set<string>()
+
+  for (const path of manifestPathsList) {
+    const rootPath = dirOf(path)
+    const names = collectPackageNamesFromManifest(path, contents[path] ?? "")
+    const lowerNames = new Set(names.map((n) => n.toLowerCase()))
+
+    for (const rule of STREAM_PACKAGE_RULES) {
+      const matched = rule.packages.find((p) => lowerNames.has(p.toLowerCase()))
+      if (!matched) continue
+      const key = `${rootPath}:${rule.streamType}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      streams.push({
+        streamType: rule.streamType,
+        path: rootPath,
+        role: "both",
+        evidence: `${path}: ${matched}`,
+      })
+    }
+
+    if (
+      lowerNames.has("ioredis") ||
+      lowerNames.has("redis") ||
+      lowerNames.has("redis-py")
+    ) {
+      const key = `${rootPath}:Redis Pub/Sub`
+      if (!seen.has(key)) {
+        seen.add(key)
+        streams.push({
+          streamType: "Redis Pub/Sub",
+          path: rootPath,
+          role: "both",
+          evidence: `${path}: redis pub/sub dependency`,
+        })
+      }
+    }
+  }
+
+  return streams
+}
+
+/** Collect unique file paths needed for deterministic extraction scans. */
+export function collectDeterministicScanPaths(
+  allPaths: string[],
+  scanPaths: string[],
+): string[] {
+  const scoped =
+    scanPaths.length > 0 ? filterPathsByPartialScan(allPaths, scanPaths) : allPaths
+
+  const needed = new Set<string>()
+  for (const p of packageJsonPaths(scoped)) needed.add(p)
+  for (const p of manifestPaths(scoped)) needed.add(p)
+  for (const p of prismaSchemaPaths(scoped)) needed.add(p)
+  for (const p of infrastructureCandidatePaths(scoped)) needed.add(p)
+  for (const p of k8sManifestPaths(scoped)) needed.add(p)
+  for (const p of scoped.filter((path) => DOCKER_COMPOSE_RE.test(path)))
+    needed.add(p)
+
+  return [...needed]
+}

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
@@ -1,22 +1,25 @@
-import { HumanMessage } from "@langchain/core/messages"
-import { tool } from "langchain"
-import { z } from "zod/v3"
+/**
+ * identifyDatabases – Detects databases used by services via Prisma schemas,
+ * docker-compose services, and manifest dependencies.
+ */
+
 import { requireCurrentOrgId } from "../../../auth/context.js"
-import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
-  REPO_EXPLORER_TOOLS_HINT,
-  standardRepoExplorerTools,
-} from "../../../tools/repoExplorerTools.js"
-import { createAgent } from "../../createAgent.js"
+  fetchFiles,
+  listFilesRecursive,
+} from "../../../domain/codeIngestion/codesearchClient.js"
 import type {
   CodeIngestionState,
   ExtractedClaim,
   ExtractedObject,
 } from "../schemas.js"
 import {
+  collectDeterministicScanPaths,
+  scanDatabases,
+} from "./deterministicRepoScan.js"
+import {
+  filterPathsByPartialScan,
   partialScanPathsForExtractors,
-  partialScanPromptSuffix,
   repoPathMatchesPartialScan,
   shouldSkipExtractorForPartialDeletesOnly,
 } from "./partialIngestionScope.js"
@@ -41,88 +44,10 @@ function normalizeDbType(dbType: string): string {
   return dbType
 }
 
-type SubmittedDatabase = {
-  dbType: string
-  path: string
-  evidence?: string
-}
-
-function createIdentifyDatabasesTools(capturedDbs: {
-  value: SubmittedDatabase[]
-}) {
-  const submitDatabasesTool = tool(
-    async ({ databases }) => {
-      capturedDbs.value.push(...databases)
-      return `Recorded ${databases.length} database(s). Total: ${capturedDbs.value.length}.`
-    },
-    {
-      name: "submit_databases",
-      description: `Call this when you have discovered one or more databases used by the codebase. For each database provide dbType (e.g. Postgres, Mongo, Redis, MySQL, SQLite), path (root or directory where it's used, e.g. apps/web or apps/web/prisma), and optional evidence (brief description of how you found it).`,
-      schema: z.object({
-        databases: z.array(
-          z.object({
-            dbType: z
-              .string()
-              .describe(
-                "Database type: Postgres, MySQL, SQLite, Mongo, Redis, DynamoDB, Supabase, Cassandra, CockroachDB, etc.",
-              ),
-            path: z
-              .string()
-              .describe(
-                "Root or directory path where database is used, e.g. apps/web or .",
-              ),
-            evidence: z
-              .string()
-              .optional()
-              .describe(
-                "Brief evidence, e.g. Prisma schema provider postgresql",
-              ),
-          }),
-        ),
-      }),
-    },
-  )
-  return [...standardRepoExplorerTools, submitDatabasesTool]
-}
-
-const SYSTEM_PROMPT = `You are analyzing a repository to detect all databases used by the codebase. Look across any language — JavaScript, TypeScript, Python, Go, Java, Kotlin, Ruby, PHP, C#, Rust, Elixir, Swift, and others. Do not assume a single stack.
-
-Config files to inspect (per language):
-| Language / ecosystem | Config / schema files |
-| JS/TS (Node, Bun)    | package.json, prisma/schema.prisma, drizzle.config.* |
-| Python               | requirements.txt, pyproject.toml, Pipfile, settings.py, alembic.ini |
-| Go                   | go.mod, go.sum |
-| Java / Kotlin        | pom.xml, build.gradle, build.gradle.kts, application.yml, application.properties |
-| Ruby                 | Gemfile, database.yml, config/database.yml |
-| PHP                  | composer.json, .env.example, config/database.php |
-| C# / .NET            | *.csproj, appsettings.json, DbContext |
-| Rust                 | Cargo.toml |
-| Elixir               | mix.exs, config/*.exs |
-| Swift                | Package.swift |
-
-Database types and detection hints:
-| Database       | Detection hints |
-| PostgreSQL     | postgresql://, postgres://, provider = "postgresql", create_engine("postgresql"), psycopg2, pgx, pg package, jdbc:postgresql, DATABASE_URL with postgres |
-| MySQL          | mysql://, mysql2, pymysql, create_engine("mysql"), jdbc:mysql, GORM mysql |
-| SQLite         | sqlite://, sqlite3, better-sqlite3, .db files, provider = "sqlite" |
-| MongoDB        | mongodb://, mongoose, pymongo, Motor, MongoClient, @prisma/adapter-mongo |
-| Redis          | redis://, ioredis, redis-py, go-redis, @upstash/redis, StackExchange.Redis |
-| DynamoDB       | @aws-sdk/client-dynamodb, boto3 dynamodb |
-| Supabase       | @supabase/supabase-js, supabase-py |
-| Cassandra      | cassandra-driver, gocql |
-| CockroachDB    | cockroachdb://, pgx with cockroach |
-
-Search strategy:
-1. list_files at each root for prisma/, schema.prisma, package.json, requirements.txt, pyproject.toml, go.mod, pom.xml, Gemfile, composer.json, Cargo.toml, mix.exs, .env.example
-2. search for connection strings, ORM config, driver imports (postgresql, create_engine, SessionLocal, DATABASES, jdbc:, mongodb://, redis://)
-3. get_file on schema files, package manifests, env examples to confirm
-
-Cover only the listed roots. Call submit_databases for each database supported by ORM config, connection strings, or manifests; batch multiple databases per call. Prefer submitting once connection/ORM evidence is clear over exhaustive blind search.`
-
 export async function identifyDatabases(
   state: CodeIngestionState,
 ): Promise<Partial<CodeIngestionState>> {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const { repositoryId, orgId, roots = ["./"], targetHash } = state
   requireCurrentOrgId()
 
   if (shouldSkipExtractorForPartialDeletesOnly(state)) {
@@ -130,56 +55,27 @@ export async function identifyDatabases(
   }
 
   const scanPaths = partialScanPathsForExtractors(state)
-  const scopeHint =
-    state.ingestMode === "partial" && scanPaths.length > 0
-      ? partialScanPromptSuffix(scanPaths)
-      : ""
+  const allPaths = await listFilesRecursive(repositoryId, orgId)
+  const scopedPaths =
+    scanPaths.length > 0
+      ? filterPathsByPartialScan(allPaths, scanPaths)
+      : allPaths
 
-  const objects: ExtractedObject[] = []
-  const claims: ExtractedClaim[] = []
+  const pathsToFetch = collectDeterministicScanPaths(allPaths, scanPaths)
+  const contents = await fetchFiles(repositoryId, orgId, pathsToFetch)
 
-  const capturedDbs: { value: SubmittedDatabase[] } = { value: [] }
-  const tools = createIdentifyDatabasesTools(capturedDbs)
-  const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
-    tools,
-    contextMiddleware: {
-      clearToolUsesTriggerTokens: 140_000,
-      clearToolUsesKeepMessages: 14,
-      summarizationTriggerTokens: 220_000,
-      summarizationKeepMessages: 32,
-    },
-    systemPrompt: `${SYSTEM_PROMPT}
+  let submissions = scanDatabases(scopedPaths, contents)
 
-Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots.join(", ")}.
-
-${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
-  })
-
-  const userMessage = `For the listed roots, check config directories and search for database/ORM patterns. Call submit_databases (batch per call) once connection or schema evidence is clear; skip uncertain hits.`
-
-  await agent.invoke(
-    { messages: [new HumanMessage(userMessage)] },
-    {
-      recursionLimit: 180,
-    },
-  )
-
-  if (capturedDbs.value.length === 0) {
-    getLogger().warn(
-      "identifyDatabases: agent completed without submit_databases (no databases captured)",
-      { repositoryId, targetHash },
-    )
-  }
-
-  let submissions = capturedDbs.value
   if (state.ingestMode === "partial" && scanPaths.length > 0) {
     submissions = submissions.filter((db) =>
       repoPathMatchesPartialScan(db.path, scanPaths),
     )
   }
 
+  const objects: ExtractedObject[] = []
+  const claims: ExtractedClaim[] = []
   const seenDbs = new Set<string>()
+
   for (const root of roots) {
     const svcDeduplicationKey = `svc:${repositoryId}:${root}`
     for (const db of submissions) {
@@ -204,8 +100,8 @@ ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
         predicate: "DEPENDS_ON",
         sourceId: `identifyDatabases:${repositoryId}:${root}:${dbType}:${targetHash}`,
         sourceType: "git",
-        extractionMethod: "llm",
-        confidence: 0.8,
+        extractionMethod: "deterministic",
+        confidence: 0.9,
         provenance: { root, dbType, evidence: db.evidence },
       })
     }

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructure.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructure.ts
@@ -1,101 +1,31 @@
 /**
  * identifyInfrastructure – Extracts Infrastructure objects and RUNS_ON claims
- * (Service → Infrastructure) from repository code. Uses an LLM agent with
- * list_files, search, get_file, and submit_infrastructure tools to detect
- * deployment targets (Docker, Kubernetes, Serverless, Terraform, etc.).
+ * (Service → Infrastructure) by scanning Dockerfiles, compose files, k8s manifests,
+ * and platform config files.
  */
 
-import { HumanMessage } from "@langchain/core/messages"
-import { tool } from "langchain"
-import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
-import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
-  REPO_EXPLORER_TOOLS_HINT,
-  standardRepoExplorerTools,
-} from "../../../tools/repoExplorerTools.js"
-import { createAgent } from "../../createAgent.js"
+  fetchFiles,
+  listFilesRecursive,
+} from "../../../domain/codeIngestion/codesearchClient.js"
 import type { CodeIngestionState } from "../schemas.js"
 import {
-  processCapturedInfrastructure,
-  type SubmittedInfrastructure,
-} from "./identifyInfrastructurePostProcess.js"
+  collectDeterministicScanPaths,
+  scanInfrastructure,
+} from "./deterministicRepoScan.js"
+import { processCapturedInfrastructure } from "./identifyInfrastructurePostProcess.js"
 import {
+  filterPathsByPartialScan,
   partialScanPathsForExtractors,
-  partialScanPromptSuffix,
   repoPathMatchesPartialScan,
   shouldSkipExtractorForPartialDeletesOnly,
 } from "./partialIngestionScope.js"
 
-function createIdentifyInfrastructureTools(capturedInfra: {
-  value: SubmittedInfrastructure[]
-}) {
-  const submitInfrastructureTool = tool(
-    async ({ infrastructure }) => {
-      capturedInfra.value.push(...infrastructure)
-      return `Recorded ${infrastructure.length} infrastructure item(s). Total: ${capturedInfra.value.length}.`
-    },
-    {
-      name: "submit_infrastructure",
-      description: `Call this when you have discovered one or more infrastructure/deployment targets used by the codebase. For each provide infraType (e.g. Docker, Docker Compose, Kubernetes, Helm, Serverless, Lambda, Cloud Run, Terraform, Pulumi), path (root or directory where it's defined/used), and optional evidence (brief description of how you found it).`,
-      schema: z.object({
-        infrastructure: z.array(
-          z.object({
-            infraType: z
-              .string()
-              .describe(
-                "Infrastructure type: Docker, Docker Compose, Kubernetes, Helm, Serverless, Lambda, Cloud Run, Terraform, Pulumi, Cloudflare Workers, Vercel, Fly.io, etc.",
-              ),
-            path: z
-              .string()
-              .describe(
-                "Root or directory path where infrastructure is defined or used, e.g. apps/web or .",
-              ),
-            evidence: z
-              .string()
-              .optional()
-              .describe("Brief evidence, e.g. Dockerfile found at apps/api"),
-          }),
-        ),
-      }),
-    },
-  )
-  return [...standardRepoExplorerTools, submitInfrastructureTool]
-}
-
-const SYSTEM_PROMPT = `You are analyzing a repository to detect all infrastructure and deployment targets used by the codebase. Look across any language and platform. Do not assume a single stack.
-
-Config files and detection hints:
-
-| Infrastructure      | Detection hints |
-| ------------------- | --------------- |
-| Docker              | Dockerfile, .dockerignore |
-| Docker Compose      | docker-compose.yml, docker-compose.yaml, docker-compose.*.yml |
-| Kubernetes         | k8s/, manifests/, *.yaml with apiVersion: apps/v1, batch/v1, networking.k8s.io/v1; Deployment, Service, ConfigMap, Ingress |
-| Helm                | Chart.yaml, values.yaml, helm/ directory |
-| Serverless          | serverless.yml, serverless.yaml |
-| Lambda              | sam.yaml, template.yaml (SAM), serverless.yml with provider.aws, lambda config |
-| Cloud Run           | cloudbuild.yaml with gcr.io/run, Dockerfile + Cloud Run config, run.yaml |
-| Terraform           | *.tf files referencing compute (aws_instance, google_compute_instance, azurerm_virtual_machine) |
-| Pulumi              | Pulumi.yaml, *.ts/*.py with pulumi, aws.ec2, gcp.compute |
-| Cloudflare Workers  | wrangler.toml, workers config |
-| Vercel              | vercel.json, .vercel/ |
-| Fly.io              | fly.toml |
-| Railway             | railway.json, railway.toml |
-| Render              | render.yaml |
-
-Search strategy:
-1. list_files at each root for Dockerfile, docker-compose*.yml, k8s/, manifests/, Chart.yaml, serverless.yml, sam.yaml, *.tf, Pulumi.yaml, wrangler.toml, vercel.json, fly.toml
-2. search for apiVersion: apps/v1, kind: Deployment, FROM in Dockerfile, serverless framework, terraform, pulumi
-3. get_file on Dockerfile, docker-compose.yml, k8s manifests, serverless.yml to confirm
-
-Cover only the listed roots. Call submit_infrastructure for each deployment target supported by Dockerfiles, manifests, or IaC; batch multiple items per call. Terraform/Pulumi: focus on compute-related resources; lighter scan is acceptable. Prefer submitting once Dockerfile/manifest evidence is clear over exhaustive blind search.`
-
 export async function identifyInfrastructure(
   state: CodeIngestionState,
 ): Promise<Partial<CodeIngestionState>> {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const { repositoryId, orgId, roots = ["./"], targetHash } = state
   requireCurrentOrgId()
 
   if (shouldSkipExtractorForPartialDeletesOnly(state)) {
@@ -103,46 +33,21 @@ export async function identifyInfrastructure(
   }
 
   const scanPaths = partialScanPathsForExtractors(state)
-  const scopeHint =
-    state.ingestMode === "partial" && scanPaths.length > 0
-      ? partialScanPromptSuffix(scanPaths)
-      : ""
+  const allPaths = await listFilesRecursive(repositoryId, orgId)
+  const scopedPaths =
+    scanPaths.length > 0
+      ? filterPathsByPartialScan(allPaths, scanPaths)
+      : allPaths
 
-  const capturedInfra: { value: SubmittedInfrastructure[] } = { value: [] }
-  const tools = createIdentifyInfrastructureTools(capturedInfra)
-  const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
-    tools,
-    contextMiddleware: {
-      clearToolUsesTriggerTokens: 140_000,
-      clearToolUsesKeepMessages: 14,
-      summarizationTriggerTokens: 220_000,
-      summarizationKeepMessages: 32,
-    },
-    systemPrompt: `${SYSTEM_PROMPT}
+  const pathsToFetch = collectDeterministicScanPaths(allPaths, scanPaths)
+  const contents = await fetchFiles(repositoryId, orgId, pathsToFetch)
 
-Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots.join(", ")}.
+  let submissions = scanInfrastructure(scopedPaths, contents).map((inf) => ({
+    infraType: inf.infraType,
+    path: inf.path,
+    evidence: inf.evidence,
+  }))
 
-${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
-  })
-
-  const userMessage = `For the listed roots, check for Dockerfile, docker-compose, k8s manifests, serverless config, and Terraform/Pulumi. Call submit_infrastructure (batch per call) once manifest evidence is clear; skip uncertain hits.`
-
-  await agent.invoke(
-    { messages: [new HumanMessage(userMessage)] },
-    {
-      recursionLimit: 180,
-    },
-  )
-
-  if (capturedInfra.value.length === 0) {
-    getLogger().warn(
-      "identifyInfrastructure: agent completed without submit_infrastructure (no infrastructure captured)",
-      { repositoryId, targetHash },
-    )
-  }
-
-  let submissions = capturedInfra.value
   if (state.ingestMode === "partial" && scanPaths.length > 0) {
     submissions = submissions.filter((inf) =>
       repoPathMatchesPartialScan(inf.path, scanPaths),
@@ -154,6 +59,7 @@ ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
     repositoryId,
     roots,
     targetHash,
+    "deterministic",
   )
   return {
     extractedObjects: result.extractedObjects,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructurePostProcess.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructurePostProcess.ts
@@ -55,6 +55,7 @@ export function processCapturedInfrastructure(
   repositoryId: string,
   roots: string[],
   targetHash: string,
+  extractionMethod: "deterministic" | "llm" = "llm",
 ): { extractedObjects: ExtractedObject[]; extractedClaims: ExtractedClaim[] } {
   const byKey = new Map<string, InfraEntry>()
 
@@ -105,8 +106,8 @@ export function processCapturedInfrastructure(
       predicate: "RUNS_ON",
       sourceId: `identifyInfrastructure:${repositoryId}:${entry.root}:${entry.infraType}:${targetHash}`,
       sourceType: "git",
-      extractionMethod: "llm",
-      confidence: 0.8,
+      extractionMethod,
+      confidence: extractionMethod === "deterministic" ? 0.9 : 0.8,
       provenance: { root: entry.root, infraType: entry.infraType, evidence },
     })
   }

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
@@ -2,40 +2,35 @@
  * identifyLibraries extractor
  *
  * Detects architectural libraries (ORM, HTTP client, auth, validation, etc.) used by
- * services in a repository. Uses an LLM agent with list_files, search, and get_file
- * tools to explore package manifests and source code, then produces Library objects
- * and USES_LIBRARY claims (Service → Library).
- *
- * Deduplication: lib:${repositoryId}:${root}:${libraryName}
- * Claim path: subjectRef = svc:${repositoryId}:${root}, objectRef = lib key
+ * services in a repository by scanning package manifests and dependency files.
+ * Produces Library objects and USES_LIBRARY claims (Service → Library).
  */
 
-import { HumanMessage } from "@langchain/core/messages"
-import { tool } from "langchain"
-import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
-import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
-  REPO_EXPLORER_TOOLS_HINT,
-  standardRepoExplorerTools,
-} from "../../../tools/repoExplorerTools.js"
-import { createAgent } from "../../createAgent.js"
+  fetchFiles,
+  listFilesRecursive,
+} from "../../../domain/codeIngestion/codesearchClient.js"
 import type {
   CodeIngestionState,
   ExtractedClaim,
   ExtractedObject,
 } from "../schemas.js"
+import {
+  collectDeterministicScanPaths,
+  manifestPaths,
+  scanLibraries,
+} from "./deterministicRepoScan.js"
 import { resolveSubmissionRoot } from "./extractionSubmissionRoot.js"
 import {
+  filterPathsByPartialScan,
   partialScanPathsForExtractors,
-  partialScanPromptSuffix,
   repoPathMatchesPartialScan,
   shouldSkipExtractorForPartialDeletesOnly,
 } from "./partialIngestionScope.js"
 
 /** Normalize library name to canonical form for deduplication */
-function normalizeLibraryName(name: string): string {
+export function normalizeLibraryName(name: string): string {
   const lower = name.toLowerCase()
   const known: Record<string, string> = {
     prisma: "Prisma",
@@ -80,82 +75,10 @@ type SubmittedLibrary = {
   evidence?: string
 }
 
-function createIdentifyLibrariesTools(capturedLibraries: {
-  value: SubmittedLibrary[]
-}) {
-  const submitLibrariesTool = tool(
-    async ({ libraries }) => {
-      capturedLibraries.value.push(...libraries)
-      return `Recorded ${libraries.length} library(ies). Total: ${capturedLibraries.value.length}.`
-    },
-    {
-      name: "submit_libraries",
-      description: `Call this when you have discovered one or more architectural libraries used by the codebase. For each library provide name (e.g. Prisma, Drizzle, Express, Hono, Zod, Better Auth, ioredis), path (root or directory where it's used, e.g. apps/web or .), optional category (ORM, HTTP, auth, validation, cache, etc.), and optional evidence (brief description of how you found it). Focus on architectural deps — ORM, HTTP client, auth, validation — not every util.`,
-      schema: z.object({
-        libraries: z.array(
-          z.object({
-            name: z
-              .string()
-              .describe(
-                "Library name: Prisma, Drizzle, Express, Hono, Zod, Better Auth, ioredis, etc.",
-              ),
-            path: z
-              .string()
-              .describe(
-                "Root or directory path where library is used, e.g. apps/web or .",
-              ),
-            category: z
-              .string()
-              .optional()
-              .describe("Category: ORM, HTTP, auth, validation, cache, etc."),
-            evidence: z
-              .string()
-              .optional()
-              .describe("Brief evidence, e.g. from package.json dependencies"),
-          }),
-        ),
-      }),
-    },
-  )
-  return [...standardRepoExplorerTools, submitLibrariesTool]
-}
-
-const SYSTEM_PROMPT = `You are analyzing a repository to detect architectural libraries used by the codebase. Focus on ORM, HTTP client, auth, validation, cache, and similar — not every utility. Look across any language. Do not assume a single stack.
-
-Config files to inspect (per language):
-| Language / ecosystem | Config files |
-| JS/TS (Node, Bun)    | package.json, pnpm-lock.yaml, yarn.lock |
-| Python               | requirements.txt, pyproject.toml, Pipfile |
-| Go                   | go.mod, go.sum |
-| Java / Kotlin        | pom.xml, build.gradle, build.gradle.kts |
-| Ruby                 | Gemfile |
-| PHP                  | composer.json |
-| C# / .NET            | *.csproj |
-| Rust                 | Cargo.toml |
-| Elixir               | mix.exs |
-| Swift                | Package.swift |
-
-Library categories and detection hints:
-| Category   | Examples | Detection hints |
-| ORM        | Prisma, Drizzle, TypeORM, Sequelize, Mongoose, SQLAlchemy, GORM | prisma, drizzle, typeorm, sequelize, mongoose, sqlalchemy, gorm |
-| HTTP       | Express, Hono, Fastify, Next.js, FastAPI, Flask, Django, Axum | express, hono, fastify, next, fastapi, flask, django, axum |
-| Auth       | Better Auth, NextAuth, Passport, Auth0, Clerk | better-auth, next-auth, passport, auth0, clerk |
-| Validation | Zod, Yup, Joi, Pydantic | zod, yup, joi, pydantic |
-| Cache      | ioredis, @upstash/redis, redis-py, go-redis | ioredis, upstash, redis |
-| RPC/API    | tRPC, gRPC | trpc, grpc |
-
-Search strategy:
-1. list_files at each root for package.json, requirements.txt, pyproject.toml, go.mod, Cargo.toml, pom.xml, Gemfile, composer.json, mix.exs
-2. search for import patterns (from "prisma", import { drizzle }, require("express"), betterAuth, zod, ioredis)
-3. get_file on package.json, requirements.txt, etc. to confirm dependencies
-4. Focus on architectural deps — skip lodash, date-fns, uuid, etc. unless central to architecture
-
-Cover only the listed roots. Call submit_libraries for each architectural library supported by manifests or imports; batch multiple libraries per call. Focus on architectural deps — skip utilities unless central. Prefer submitting once you have enough manifest/import evidence over exhaustive blind search.`
-
 export async function identifyLibraries(
   state: CodeIngestionState,
 ): Promise<Partial<CodeIngestionState>> {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const { repositoryId, orgId, roots = ["./"], targetHash } = state
   requireCurrentOrgId()
 
   if (shouldSkipExtractorForPartialDeletesOnly(state)) {
@@ -163,46 +86,23 @@ export async function identifyLibraries(
   }
 
   const scanPaths = partialScanPathsForExtractors(state)
-  const scopeHint =
-    state.ingestMode === "partial" && scanPaths.length > 0
-      ? partialScanPromptSuffix(scanPaths)
-      : ""
+  const allPaths = await listFilesRecursive(repositoryId, orgId)
+  const scopedPaths =
+    scanPaths.length > 0
+      ? filterPathsByPartialScan(allPaths, scanPaths)
+      : allPaths
 
-  const capturedLibraries: { value: SubmittedLibrary[] } = { value: [] }
-  const tools = createIdentifyLibrariesTools(capturedLibraries)
-  const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
-    tools,
-    contextMiddleware: {
-      clearToolUsesTriggerTokens: 160_000,
-      clearToolUsesKeepMessages: 16,
-      summarizationTriggerTokens: 240_000,
-      summarizationKeepMessages: 36,
-    },
-    systemPrompt: `${SYSTEM_PROMPT}
+  const pathsToFetch = collectDeterministicScanPaths(allPaths, scanPaths)
+  const contents = await fetchFiles(repositoryId, orgId, pathsToFetch)
+  const scopedManifests = manifestPaths(scopedPaths)
 
-Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots.join(", ")}.
+  let submissions = scanLibraries(scopedManifests, contents).map((lib) => ({
+    name: lib.name,
+    path: lib.path,
+    category: lib.category,
+    evidence: lib.evidence,
+  }))
 
-${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
-  })
-
-  const userMessage = `For the listed roots, check package manifests and search for architectural library imports (ORM, HTTP, auth, validation, cache). Call submit_libraries (batch per call) once manifest/import evidence is clear; skip utilities and uncertain hits.`
-
-  await agent.invoke(
-    { messages: [new HumanMessage(userMessage)] },
-    {
-      recursionLimit: 220,
-    },
-  )
-
-  if (capturedLibraries.value.length === 0) {
-    getLogger().warn(
-      "identifyLibraries: agent completed without submit_libraries (no libraries captured)",
-      { repositoryId, targetHash },
-    )
-  }
-
-  let submissions = capturedLibraries.value
   if (state.ingestMode === "partial" && scanPaths.length > 0) {
     submissions = submissions.filter((lib) =>
       repoPathMatchesPartialScan(lib.path, scanPaths),
@@ -211,7 +111,7 @@ ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
 
   const { objects: postObjects, claims: postClaims } = postProcessLibraries(
     submissions,
-    { repositoryId, roots, targetHash },
+    { repositoryId, roots, targetHash, extractionMethod: "deterministic" },
   )
 
   return {
@@ -223,9 +123,16 @@ ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
 /** Post-process captured libraries into objects and claims. Exported for testing. */
 export function postProcessLibraries(
   capturedLibraries: SubmittedLibrary[],
-  state: Pick<CodeIngestionState, "repositoryId" | "roots" | "targetHash">,
+  state: Pick<CodeIngestionState, "repositoryId" | "roots" | "targetHash"> & {
+    extractionMethod?: "deterministic" | "llm"
+  },
 ): { objects: ExtractedObject[]; claims: ExtractedClaim[] } {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const {
+    repositoryId,
+    roots = ["./"],
+    targetHash,
+    extractionMethod = "llm",
+  } = state
   const objects: ExtractedObject[] = []
   const claims: ExtractedClaim[] = []
   const seenLibs = new Set<string>()
@@ -256,8 +163,8 @@ export function postProcessLibraries(
       predicate: "USES_LIBRARY",
       sourceId: `identifyLibraries:${repositoryId}:${root}:${libraryName}:${targetHash}`,
       sourceType: "git",
-      extractionMethod: "llm",
-      confidence: 0.8,
+      extractionMethod,
+      confidence: extractionMethod === "deterministic" ? 0.9 : 0.8,
       provenance: {
         root,
         libraryName,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyServiceDependencies.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyServiceDependencies.ts
@@ -1,106 +1,41 @@
 /**
  * identifyServiceDependencies extractor
  *
- * Detects cross-service dependencies within a monorepo. Uses an LLM agent with
- * list_files, search, and get_file tools to explore package manifests, workspace
- * configs, and source code. Produces DEPENDS_ON claims (Service → Service) only —
- * no new objects. Service nodes are created by extractKind.
- *
- * Detection hints:
- * - Internal package refs: "@repo/api": "workspace:*", from "@repo/shared"
- * - HTTP calls to internal URLs: localhost, internal hostnames, service discovery
- * - pnpm/npm/yarn workspace references in package.json, pnpm-workspace.yaml
- *
- * Claim path: subjectRef = svc:${repositoryId}:${consumerRoot},
- * objectRef = svc:${repositoryId}:${providerRoot}, predicate = DEPENDS_ON
+ * Detects cross-service dependencies within a monorepo by scanning package.json
+ * workspace references and file: links. Produces DEPENDS_ON claims (Service → Service)
+ * only — no new objects. Service nodes are created by extractKind.
  */
 
-import { HumanMessage } from "@langchain/core/messages"
-import { tool } from "langchain"
-import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
-import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
-  REPO_EXPLORER_TOOLS_HINT,
-  standardRepoExplorerTools,
-} from "../../../tools/repoExplorerTools.js"
-import { createAgent } from "../../createAgent.js"
+  fetchFiles,
+  listFilesRecursive,
+} from "../../../domain/codeIngestion/codesearchClient.js"
 import type { CodeIngestionState, ExtractedClaim } from "../schemas.js"
+import {
+  buildPackageNameIndex,
+  collectDeterministicScanPaths,
+  packageJsonPaths,
+  scanWorkspaceDependencies,
+} from "./deterministicRepoScan.js"
 import { resolveSubmissionRoot } from "./extractionSubmissionRoot.js"
 import {
+  filterPathsByPartialScan,
   partialScanPathsForExtractors,
-  partialScanPromptSuffix,
   repoPathMatchesPartialScan,
   shouldSkipExtractorForPartialDeletesOnly,
 } from "./partialIngestionScope.js"
 
-type SubmittedDependency = {
+export type SubmittedDependency = {
   consumerPath: string
   providerPath: string
   evidence?: string
 }
 
-function createIdentifyServiceDependenciesTools(capturedDeps: {
-  value: SubmittedDependency[]
-}) {
-  const submitServiceDependenciesTool = tool(
-    async ({ dependencies }) => {
-      capturedDeps.value.push(...dependencies)
-      return `Recorded ${dependencies.length} dependency(ies). Total: ${capturedDeps.value.length}.`
-    },
-    {
-      name: "submit_service_dependencies",
-      description: `Call this when you have discovered one or more cross-service dependencies within the monorepo. For each dependency provide consumerPath (root of the service that depends, e.g. apps/web), providerPath (root of the service being depended on, e.g. apps/api or packages/shared), and optional evidence (brief description of how you found it).`,
-      schema: z.object({
-        dependencies: z.array(
-          z.object({
-            consumerPath: z
-              .string()
-              .describe("Root of the service that depends, e.g. apps/web"),
-            providerPath: z
-              .string()
-              .describe(
-                "Root of the service being depended on, e.g. apps/api or packages/shared",
-              ),
-            evidence: z
-              .string()
-              .optional()
-              .describe(
-                "Brief evidence, e.g. package.json workspace dependency",
-              ),
-          }),
-        ),
-      }),
-    },
-  )
-  return [...standardRepoExplorerTools, submitServiceDependenciesTool]
-}
-
-const SYSTEM_PROMPT = `You are analyzing a monorepo to detect cross-service dependencies. Find which services/apps depend on which other services or shared packages within the same repository.
-
-Detection hints:
-| Signal | Examples |
-|--------|----------|
-| Internal package refs | "@repo/api": "workspace:*", "@repo/shared": "workspace:^", from "@repo/shared" |
-| Workspace config | pnpm-workspace.yaml, package.json "workspaces", yarn workspaces, lerna packages |
-| HTTP calls to internal URLs | localhost:3001, http://api.internal, service discovery, env vars like API_URL |
-| Import paths | from "@repo/shared", import from "../packages/utils" |
-
-Files to inspect:
-- package.json (dependencies, devDependencies with workspace:* or workspace:^)
-- pnpm-workspace.yaml, pnpm-workspace.yml
-- package.json "workspaces" field (npm/yarn)
-- lerna.json, nx.json
-- .env.example, config files with service URLs
-- Source code: fetch(API_URL), axios.get(internalUrl), import from workspace packages
-
-Cover only the listed roots. Call submit_service_dependencies for each in-repo dependency supported by workspace config or imports; batch multiple dependencies per call. Only report dependencies within this repository — not external npm packages. Prefer submitting once workspace/import evidence is clear over exhaustive blind search.`
-
 export async function identifyServiceDependencies(
   state: CodeIngestionState,
 ): Promise<Partial<CodeIngestionState>> {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const { repositoryId, orgId, roots = ["./"], targetHash } = state
   requireCurrentOrgId()
 
   if (shouldSkipExtractorForPartialDeletesOnly(state)) {
@@ -108,46 +43,29 @@ export async function identifyServiceDependencies(
   }
 
   const scanPaths = partialScanPathsForExtractors(state)
-  const scopeHint =
-    state.ingestMode === "partial" && scanPaths.length > 0
-      ? partialScanPromptSuffix(scanPaths)
-      : ""
+  const allPaths = await listFilesRecursive(repositoryId, orgId)
+  const scopedPaths =
+    scanPaths.length > 0
+      ? filterPathsByPartialScan(allPaths, scanPaths)
+      : allPaths
 
-  const capturedDeps: { value: SubmittedDependency[] } = { value: [] }
-  const tools = createIdentifyServiceDependenciesTools(capturedDeps)
-  const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
-    tools,
-    contextMiddleware: {
-      clearToolUsesTriggerTokens: 140_000,
-      clearToolUsesKeepMessages: 14,
-      summarizationTriggerTokens: 220_000,
-      summarizationKeepMessages: 32,
-    },
-    systemPrompt: `${SYSTEM_PROMPT}
+  const allPkgPaths = packageJsonPaths(allPaths)
+  const scopedPkgPaths = packageJsonPaths(scopedPaths)
+  const pathsToFetch = [
+    ...new Set([
+      ...collectDeterministicScanPaths(allPaths, scanPaths),
+      ...allPkgPaths,
+    ]),
+  ]
+  const contents = await fetchFiles(repositoryId, orgId, pathsToFetch)
+  const packageIndex = buildPackageNameIndex(allPkgPaths, contents)
 
-Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots.join(", ")}.
-
-${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
-  })
-
-  const userMessage = `For the listed roots, check workspace configs and search for workspace refs, internal HTTP calls, and imports from in-repo packages. Call submit_service_dependencies (batch per call) once evidence is clear; skip external npm packages and uncertain hits.`
-
-  await agent.invoke(
-    { messages: [new HumanMessage(userMessage)] },
-    {
-      recursionLimit: 180,
-    },
+  let submissions = scanWorkspaceDependencies(
+    scopedPkgPaths,
+    contents,
+    packageIndex,
   )
 
-  if (capturedDeps.value.length === 0) {
-    getLogger().warn(
-      "identifyServiceDependencies: agent completed without submit_service_dependencies (no dependencies captured)",
-      { repositoryId, targetHash },
-    )
-  }
-
-  let submissions = capturedDeps.value
   if (state.ingestMode === "partial" && scanPaths.length > 0) {
     submissions = submissions.filter(
       (dep) =>
@@ -160,6 +78,7 @@ ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
     repositoryId,
     roots,
     targetHash,
+    extractionMethod: "deterministic",
   })
 
   return {
@@ -171,9 +90,16 @@ ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
 /** Post-process captured dependencies into DEPENDS_ON claims. Exported for testing. */
 export function postProcessServiceDependencies(
   capturedDeps: SubmittedDependency[],
-  state: Pick<CodeIngestionState, "repositoryId" | "roots" | "targetHash">,
+  state: Pick<CodeIngestionState, "repositoryId" | "roots" | "targetHash"> & {
+    extractionMethod?: "deterministic" | "llm"
+  },
 ): ExtractedClaim[] {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const {
+    repositoryId,
+    roots = ["./"],
+    targetHash,
+    extractionMethod = "llm",
+  } = state
   const claims: ExtractedClaim[] = []
   const seenPairs = new Set<string>()
 
@@ -202,8 +128,8 @@ export function postProcessServiceDependencies(
       predicate: "DEPENDS_ON",
       sourceId: `identifyServiceDependencies:${repositoryId}:${consumerRoot}:${providerRoot}:${targetHash}`,
       sourceType: "git",
-      extractionMethod: "llm",
-      confidence: 0.8,
+      extractionMethod,
+      confidence: extractionMethod === "deterministic" ? 0.9 : 0.8,
       provenance: {
         consumerPath: dep.consumerPath,
         providerPath: dep.providerPath,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreams.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreams.ts
@@ -1,106 +1,34 @@
 /**
- * identifyStreams – Extracts message/event stream usage from a codebase.
+ * identifyStreams – Extracts message/event stream usage from manifest dependencies.
  *
  * Detects Kafka, RabbitMQ, SQS, SNS, Redis Pub/Sub, NATS, Pulsar, and similar
  * streaming/messaging systems. Produces Stream objects and PRODUCES_TO /
  * CONSUMES_FROM claims linking Service nodes to Stream nodes.
- *
- * @module codeIngestionGraph/nodes/identifyStreams
  */
 
-import { HumanMessage } from "@langchain/core/messages"
-import { tool } from "langchain"
-import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
-import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
-  REPO_EXPLORER_TOOLS_HINT,
-  standardRepoExplorerTools,
-} from "../../../tools/repoExplorerTools.js"
-import { createAgent } from "../../createAgent.js"
+  fetchFiles,
+  listFilesRecursive,
+} from "../../../domain/codeIngestion/codesearchClient.js"
 import type { CodeIngestionState } from "../schemas.js"
 import {
-  processStreamSubmissions,
-  type SubmittedStream,
-} from "./identifyStreamsProcess.js"
+  collectDeterministicScanPaths,
+  manifestPaths,
+  scanStreams,
+} from "./deterministicRepoScan.js"
+import { processStreamSubmissions } from "./identifyStreamsProcess.js"
 import {
+  filterPathsByPartialScan,
   partialScanPathsForExtractors,
-  partialScanPromptSuffix,
   repoPathMatchesPartialScan,
   shouldSkipExtractorForPartialDeletesOnly,
 } from "./partialIngestionScope.js"
 
-function createIdentifyStreamsTools(capturedStreams: {
-  value: SubmittedStream[]
-}) {
-  const submitStreamsTool = tool(
-    async ({ streams }) => {
-      capturedStreams.value.push(...streams)
-      return `Recorded ${streams.length} stream(s). Total: ${capturedStreams.value.length}.`
-    },
-    {
-      name: "submit_streams",
-      description: `Call this when you have discovered one or more message/event streams used by the codebase. For each stream provide streamType (e.g. Kafka, RabbitMQ, SQS, SNS, Redis Pub/Sub, NATS, Pulsar), path (root or directory where it's used), role (producer, consumer, or both), and optional evidence.`,
-      schema: z.object({
-        streams: z.array(
-          z.object({
-            streamType: z
-              .string()
-              .describe(
-                "Stream type: Kafka, RabbitMQ, SQS, SNS, Redis Pub/Sub, NATS, Pulsar, Google Pub/Sub, Azure Event Hubs, ActiveMQ, etc.",
-              ),
-            path: z
-              .string()
-              .describe(
-                "Root or directory path where stream is used, e.g. apps/web or .",
-              ),
-            role: z
-              .enum(["producer", "consumer", "both"])
-              .describe(
-                "Whether the service produces to, consumes from, or both produces and consumes the stream",
-              ),
-            evidence: z
-              .string()
-              .optional()
-              .describe("Brief evidence, e.g. kafka-python producer.send()"),
-          }),
-        ),
-      }),
-    },
-  )
-  return [...standardRepoExplorerTools, submitStreamsTool]
-}
-
-const SYSTEM_PROMPT = `You are analyzing a repository to detect all message/event streams and messaging systems used by the codebase. Look across any language — JavaScript, TypeScript, Python, Go, Java, Kotlin, Ruby, PHP, C#, Rust, Elixir, and others. Do not assume a single stack.
-
-Stream types and detection hints:
-| Stream type      | Detection hints |
-| -----------------| -----------------|
-| Kafka            | kafka-python, confluent-kafka, @nestjs/microservices (Kafka transport), sarama, kafkajs, node-rdkafka, aiokafka |
-| RabbitMQ         | amqp, pika, amqplib, @golevelup/nestjs-rabbitmq, spring-amqp |
-| AWS SQS          | @aws-sdk/client-sqs, boto3 sqs, receive_message, send_message |
-| AWS SNS          | @aws-sdk/client-sns, boto3 sns, publish, subscribe |
-| Redis Pub/Sub    | ioredis publish/subscribe, redis-py pubsub, redis.subscribe, redis.publish |
-| NATS             | nats.js, nats.go, nats-py, JetStream |
-| Pulsar           | pulsar-client, @apache/pulsar-client-node |
-| Google Pub/Sub   | @google-cloud/pubsub, google-cloud-pubsub |
-| Azure Event Hubs | @azure/event-hubs, azure-eventhub |
-| ActiveMQ         | stomp.js, activemq, @stomp/stompjs |
-
-Search strategy:
-1. list_files at each root for package.json, requirements.txt, pyproject.toml, go.mod, pom.xml, Cargo.toml
-2. search for stream/messaging imports and usage: kafka, rabbitmq, sqs, sns, redis publish, nats, pulsar
-3. get_file on manifest files and source files to confirm producer vs consumer usage
-4. For producer: look for send, publish, produce, put
-5. For consumer: look for subscribe, consume, receive, get
-
-Cover only the listed roots. Call submit_streams for each messaging system supported by dependencies or imports; batch multiple streams per call. Prefer submitting once dependency/import evidence is clear over exhaustive blind search.`
-
 export async function identifyStreams(
   state: CodeIngestionState,
 ): Promise<Partial<CodeIngestionState>> {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const { repositoryId, orgId, roots = ["./"], targetHash } = state
   requireCurrentOrgId()
 
   if (shouldSkipExtractorForPartialDeletesOnly(state)) {
@@ -108,46 +36,23 @@ export async function identifyStreams(
   }
 
   const scanPaths = partialScanPathsForExtractors(state)
-  const scopeHint =
-    state.ingestMode === "partial" && scanPaths.length > 0
-      ? partialScanPromptSuffix(scanPaths)
-      : ""
+  const allPaths = await listFilesRecursive(repositoryId, orgId)
+  const scopedPaths =
+    scanPaths.length > 0
+      ? filterPathsByPartialScan(allPaths, scanPaths)
+      : allPaths
 
-  const capturedStreams: { value: SubmittedStream[] } = { value: [] }
-  const tools = createIdentifyStreamsTools(capturedStreams)
-  const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
-    tools,
-    contextMiddleware: {
-      clearToolUsesTriggerTokens: 140_000,
-      clearToolUsesKeepMessages: 14,
-      summarizationTriggerTokens: 220_000,
-      summarizationKeepMessages: 32,
-    },
-    systemPrompt: `${SYSTEM_PROMPT}
+  const pathsToFetch = collectDeterministicScanPaths(allPaths, scanPaths)
+  const contents = await fetchFiles(repositoryId, orgId, pathsToFetch)
+  const scopedManifests = manifestPaths(scopedPaths)
 
-Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots.join(", ")}.
+  let submissions = scanStreams(scopedManifests, contents).map((stream) => ({
+    streamType: stream.streamType,
+    path: stream.path,
+    role: stream.role,
+    evidence: stream.evidence,
+  }))
 
-${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
-  })
-
-  const userMessage = `For the listed roots, check manifests and search for Kafka, RabbitMQ, SQS, SNS, Redis Pub/Sub, NATS, Pulsar, and similar patterns. Call submit_streams (batch per call) with role once dependency/import evidence is clear; skip uncertain hits.`
-
-  await agent.invoke(
-    { messages: [new HumanMessage(userMessage)] },
-    {
-      recursionLimit: 180,
-    },
-  )
-
-  if (capturedStreams.value.length === 0) {
-    getLogger().warn(
-      "identifyStreams: agent completed without submit_streams (no streams captured)",
-      { repositoryId, targetHash },
-    )
-  }
-
-  let submissions = capturedStreams.value
   if (state.ingestMode === "partial" && scanPaths.length > 0) {
     submissions = submissions.filter((s) =>
       repoPathMatchesPartialScan(s.path, scanPaths),
@@ -159,6 +64,7 @@ ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
       repositoryId,
       roots,
       targetHash,
+      extractionMethod: "deterministic",
     })
 
   return {

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreamsProcess.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreamsProcess.ts
@@ -60,9 +60,16 @@ function mergeSubmittedPaths(paths: string[]): string {
  */
 export function processStreamSubmissions(
   capturedStreams: SubmittedStream[],
-  state: Pick<CodeIngestionState, "repositoryId" | "roots" | "targetHash">,
+  state: Pick<CodeIngestionState, "repositoryId" | "roots" | "targetHash"> & {
+    extractionMethod?: "deterministic" | "llm"
+  },
 ): { objects: ExtractedObject[]; claims: ExtractedClaim[] } {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const {
+    repositoryId,
+    roots = ["./"],
+    targetHash,
+    extractionMethod = "llm",
+  } = state
   const objects: ExtractedObject[] = []
   const claims: ExtractedClaim[] = []
 
@@ -128,8 +135,8 @@ export function processStreamSubmissions(
         predicate,
         sourceId: `identifyStreams:${repositoryId}:${entry.root}:${entry.streamType}:${predicate}:${targetHash}`,
         sourceType: "git",
-        extractionMethod: "llm",
-        confidence: 0.8,
+        extractionMethod,
+        confidence: extractionMethod === "deterministic" ? 0.9 : 0.8,
         provenance: {
           root: entry.root,
           streamType: entry.streamType,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces five code-ingestion extractors that previously used ReAct LLM agents with deterministic scans of package manifests and config files. This removes LLM cost/latency for signals that are already structured in the repo.

### Converted to deterministic

| Extractor | Detection approach |
|-----------|-------------------|
| `identifyServiceDependencies` | `package.json` `workspace:*`, `link:`, and `file:` refs resolved via package name index |
| `identifyLibraries` | Known architectural deps in `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, etc. |
| `identifyDatabases` | Prisma `provider`, docker-compose service images, database driver packages |
| `identifyInfrastructure` | Dockerfile, compose files, k8s manifests (content-checked), platform configs |
| `identifyStreams` | Messaging SDK dependencies (Kafka, RabbitMQ, SQS, NATS, etc.) |

### Still LLM-based

- `identifyAPIClients` — external API usage is harder to infer from manifests alone
- `identifyPatterns` — intentionally fuzzy architectural pattern inference
- `identifyAPIs` — already hybrid (OpenAPI deterministic + LLM fallback)
- `extractKind` — already mostly deterministic

## Implementation

- New shared module: `deterministicRepoScan.ts` with scan helpers and 12 unit tests
- Extractor nodes now use `listFilesRecursive` + `fetchFiles` (codesearch) instead of ReAct agents
- Post-processors accept `extractionMethod` and use confidence `0.9` for deterministic claims
- Partial ingestion scoping preserved via existing `partialIngestionScope` helpers

## Test plan

- [x] `deterministicRepoScan.test.ts` — workspace deps, libraries, databases, infra, streams
- [x] Existing post-processor tests for service deps, libraries, infrastructure, streams
- [ ] Spot-check ingestion on a monorepo with workspace packages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0395d0b-bca7-48c6-8a72-ee982b5e0f3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0395d0b-bca7-48c6-8a72-ee982b5e0f3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

