### PR TITLE
Fix codesearch stale Postgres pool connections

### DIFF
--- a/.changeset/fiery-balloons-smash.md
+++ b/.changeset/fiery-balloons-smash.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Use pg pool for codesearch to prevent dead connections

--- a/apps/codesearch/src/db/client.ts
+++ b/apps/codesearch/src/db/client.ts
@@ -1,4 +1,5 @@
 import { drizzle } from "drizzle-orm/node-postgres"
+import { Pool } from "pg"
 import type { Env } from "../config/env.js"
 import * as schema from "./schema.js"
 
@@ -11,7 +12,12 @@ export function createDb(env: Env) {
   if (!connectionString) {
     throw new Error("DATABASE_URL is required for database operations")
   }
-  return drizzle(connectionString, { schema })
+  const client = new Pool({
+    connectionString,
+    idleTimeoutMillis: 300_000,
+    keepAlive: true,
+  })
+  return drizzle({ client, schema })
 }
 
 export type Db = ReturnType<typeof createDb>


### PR DESCRIPTION
## Summary
- Configure codesearch with an explicit `pg.Pool` instead of passing the connection string directly to Drizzle.
- Set `idleTimeoutMillis: 300_000` to match the backend and recycle idle clients before Neon/pooler closes them server-side.
- Enable `keepAlive: true` so dead TCP sockets are detected while connections sit idle between index jobs.
