### PR TITLE
Fix GitHub repository selection ingesting all repos

### DIFF
--- a/.changeset/fix-github-repo-selection-ingest.md
+++ b/.changeset/fix-github-repo-selection-ingest.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Fix GitHub repository setup so registering an installation no longer ingests all accessible repos before the user saves their selection. Select-mode saves now prune unselected connection-linked repositories and sync only chosen repos.

--- a/apps/backend/src/models/repositories.test.ts
+++ b/apps/backend/src/models/repositories.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const requireCurrentOrgSlugMock = vi.hoisted(() => vi.fn())
+const getOrgDbMock = vi.hoisted(() => vi.fn())
+const withGraphClientMock = vi.hoisted(() => vi.fn())
+const deleteRepositoryWithCleanupMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../auth/context.js", () => ({
+  requireCurrentOrgId: vi.fn(),
+  requireCurrentOrgSlug: requireCurrentOrgSlugMock,
+}))
+
+vi.mock("../db/client.js", () => ({
+  getOrgDb: getOrgDbMock,
+}))
+
+vi.mock("../platform/graph/client.js", () => ({
+  withGraphClient: withGraphClientMock,
+}))
+
+vi.mock("../domain/repositoryDeletion.js", () => ({
+  deleteRepositoryWithCleanup: deleteRepositoryWithCleanupMock,
+}))
+
+import { pruneGithubConnectionRepositoriesNotInGitUrls } from "./repositories.js"
+
+const orgId = "org_1"
+const githubConnectionId = "con_github"
+const orgSlug = "acme"
+
+function mockLinkedRepos(
+  rows: Array<{ id: string; gitUrl: string }>,
+) {
+  getOrgDbMock.mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  })
+}
+
+describe("pruneGithubConnectionRepositoriesNotInGitUrls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    requireCurrentOrgSlugMock.mockReturnValue(orgSlug)
+    withGraphClientMock.mockImplementation(
+      (_ctx: unknown, fn: () => Promise<unknown>) => fn(),
+    )
+    deleteRepositoryWithCleanupMock.mockResolvedValue(true)
+  })
+
+  it("deletes repos linked to the connection that are not in the allowed gitUrl set", async () => {
+    mockLinkedRepos([
+      { id: "repo_keep", gitUrl: "https://github.com/acme/keep.git" },
+      { id: "repo_drop_a", gitUrl: "https://github.com/acme/drop-a.git" },
+      { id: "repo_drop_b", gitUrl: "https://github.com/acme/drop-b.git" },
+    ])
+
+    await pruneGithubConnectionRepositoriesNotInGitUrls(
+      orgId,
+      githubConnectionId,
+      new Set(["https://github.com/acme/keep.git"]),
+    )
+
+    expect(deleteRepositoryWithCleanupMock).toHaveBeenCalledTimes(2)
+    expect(deleteRepositoryWithCleanupMock).toHaveBeenCalledWith({
+      orgId,
+      repositoryId: "repo_drop_a",
+    })
+    expect(deleteRepositoryWithCleanupMock).toHaveBeenCalledWith({
+      orgId,
+      repositoryId: "repo_drop_b",
+    })
+    expect(withGraphClientMock).toHaveBeenCalledTimes(2)
+    expect(withGraphClientMock).toHaveBeenCalledWith(
+      { orgId, orgSlug },
+      expect.any(Function),
+    )
+  })
+
+  it("does not delete repos when all linked gitUrls are allowed", async () => {
+    mockLinkedRepos([
+      { id: "repo_a", gitUrl: "https://github.com/acme/a.git" },
+      { id: "repo_b", gitUrl: "https://github.com/acme/b.git" },
+    ])
+
+    await pruneGithubConnectionRepositoriesNotInGitUrls(
+      orgId,
+      githubConnectionId,
+      new Set([
+        "https://github.com/acme/a.git",
+        "https://github.com/acme/b.git",
+      ]),
+    )
+
+    expect(deleteRepositoryWithCleanupMock).not.toHaveBeenCalled()
+    expect(withGraphClientMock).not.toHaveBeenCalled()
+  })
+
+  it("does nothing when the connection has no linked repositories", async () => {
+    mockLinkedRepos([])
+
+    await pruneGithubConnectionRepositoriesNotInGitUrls(
+      orgId,
+      githubConnectionId,
+      new Set(["https://github.com/acme/any.git"]),
+    )
+
+    expect(deleteRepositoryWithCleanupMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/models/repositories.ts
+++ b/apps/backend/src/models/repositories.ts
@@ -77,6 +77,31 @@ export async function countRepositoriesForGithubConnection(
   return Math.trunc(n)
 }
 
+/** Repos linked to a GitHub connection whose gitUrl is not in the allowed set. */
+export async function pruneGithubConnectionRepositoriesNotInGitUrls(
+  orgId: string,
+  githubConnectionId: string,
+  allowedGitUrls: Set<string>,
+): Promise<void> {
+  const orgSlug = requireCurrentOrgSlug()
+  const db = getOrgDb()
+  const rows = await db
+    .select({ id: repositories.id, gitUrl: repositories.gitUrl })
+    .from(repositories)
+    .where(
+      and(
+        eq(repositories.orgId, orgId),
+        eq(repositories.githubConnectionId, githubConnectionId),
+      ),
+    )
+  for (const row of rows) {
+    if (allowedGitUrls.has(row.gitUrl)) continue
+    await withGraphClient({ orgId, orgSlug }, () =>
+      deleteRepositoryWithCleanup({ orgId, repositoryId: row.id }),
+    )
+  }
+}
+
 /** Returns repositories for org. Use when orgId is from state (e.g. graph nodes).
  *  Assumes caller has established org DB context. */
 export const listRepositoriesForOrg = async (

--- a/apps/backend/src/openworkflow/workflows/sync-github-repositories.test.ts
+++ b/apps/backend/src/openworkflow/workflows/sync-github-repositories.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const getGithubInstallationByConnectionIdMock = vi.hoisted(() => vi.fn())
+const listAllReposForInstallationMock = vi.hoisted(() => vi.fn())
+const bulkCreateRepositoriesForOrgMock = vi.hoisted(() => vi.fn())
+const runRepositoryIngestionWorkflowMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../models/github-installation.js", () => ({
+  getGithubInstallationByConnectionId: getGithubInstallationByConnectionIdMock,
+  listAllReposForInstallation: listAllReposForInstallationMock,
+}))
+
+vi.mock("../../models/repositories.js", () => ({
+  bulkCreateRepositoriesForOrg: bulkCreateRepositoriesForOrgMock,
+}))
+
+vi.mock("../enqueue-repository-ingestion.js", () => ({
+  runRepositoryIngestionWorkflow: runRepositoryIngestionWorkflowMock,
+}))
+
+vi.mock("../../observability/logger.js", () => ({
+  createLogger: () => ({}),
+  getLogger: () => ({ error: vi.fn() }),
+  withLogger: (_logger: unknown, fn: () => unknown) => fn(),
+}))
+
+import { syncGithubRepositories } from "./sync-github-repositories.js"
+
+const installationRow = {
+  id: "con_github",
+  installationId: 123,
+  orgId: "org_1",
+  accountSlug: "acme",
+  appSlug: null,
+  ingestAllRepositories: false,
+  includeFutureRepos: false,
+  createdAt: new Date("2026-03-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+}
+
+describe("syncGithubRepositories workflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getGithubInstallationByConnectionIdMock.mockResolvedValue(installationRow)
+    listAllReposForInstallationMock.mockResolvedValue([
+      {
+        id: 1,
+        full_name: "acme/unlisted",
+        html_url: "https://github.com/acme/unlisted",
+        clone_url: "https://github.com/acme/unlisted.git",
+        name: "unlisted",
+        default_branch: "main",
+      },
+    ])
+    bulkCreateRepositoriesForOrgMock.mockResolvedValue([])
+    runRepositoryIngestionWorkflowMock.mockResolvedValue(undefined)
+  })
+
+  it("uses reposToSync when provided without listing all installation repos", async () => {
+    const step = {
+      run: async (_opts: { name: string }, fn: () => Promise<unknown>) =>
+        fn(),
+    }
+
+    await syncGithubRepositories.fn({
+      input: {
+        orgId: "org_1",
+        githubConnectionId: "con_github",
+        reposToSync: [
+          {
+            name: "acme/alpha",
+            gitUrl: "https://github.com/acme/alpha.git",
+          },
+        ],
+      },
+      step,
+    } as never)
+
+    expect(listAllReposForInstallationMock).not.toHaveBeenCalled()
+    expect(bulkCreateRepositoriesForOrgMock).toHaveBeenCalledWith(
+      "org_1",
+      [
+        {
+          name: "acme/alpha",
+          gitUrl: "https://github.com/acme/alpha.git",
+        },
+      ],
+      { githubConnectionId: "con_github" },
+    )
+  })
+
+  it("lists all repos when reposToSync is omitted", async () => {
+    const step = {
+      run: async (_opts: { name: string }, fn: () => Promise<unknown>) =>
+        fn(),
+    }
+
+    await syncGithubRepositories.fn({
+      input: {
+        orgId: "org_1",
+        githubConnectionId: "con_github",
+      },
+      step,
+    } as never)
+
+    expect(listAllReposForInstallationMock).toHaveBeenCalledWith(
+      "org_1",
+      "con_github",
+      expect.any(Object),
+    )
+    expect(bulkCreateRepositoriesForOrgMock).toHaveBeenCalledWith(
+      "org_1",
+      [
+        {
+          name: "acme/unlisted",
+          gitUrl: "https://github.com/acme/unlisted.git",
+        },
+      ],
+      { githubConnectionId: "con_github" },
+    )
+  })
+})

--- a/apps/backend/src/routes/v1/github-installation.test.ts
+++ b/apps/backend/src/routes/v1/github-installation.test.ts
@@ -22,6 +22,9 @@ vi.mock("../../openworkflow/client.js", () => ({
 const countRepositoriesForGithubConnectionMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue(0),
 )
+const pruneGithubConnectionRepositoriesNotInGitUrlsMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+)
 
 vi.mock("../../models/repositories.js", async (importOriginal) => {
   const actual =
@@ -30,6 +33,8 @@ vi.mock("../../models/repositories.js", async (importOriginal) => {
     ...actual,
     countRepositoriesForGithubConnection:
       countRepositoriesForGithubConnectionMock,
+    pruneGithubConnectionRepositoriesNotInGitUrls:
+      pruneGithubConnectionRepositoriesNotInGitUrlsMock,
   }
 })
 
@@ -48,6 +53,7 @@ const resolveGithubInstallationForOrgDetailedMock = vi.hoisted(() => vi.fn())
 const deleteGithubConnectionByIdMock = vi.hoisted(() => vi.fn())
 const listReposForInstallationMock = vi.hoisted(() => vi.fn())
 const searchReposForInstallationMock = vi.hoisted(() => vi.fn())
+const updateInstallationOptionsMock = vi.hoisted(() => vi.fn())
 
 const githubRowHasAppCredentialsMock = vi.hoisted(() => vi.fn())
 
@@ -81,14 +87,28 @@ vi.mock("../../models/github-installation.js", async (importOriginal) => {
     deleteGithubConnectionById: deleteGithubConnectionByIdMock,
     listReposForInstallation: listReposForInstallationMock,
     searchReposForInstallation: searchReposForInstallationMock,
+    updateInstallationOptions: updateInstallationOptionsMock,
   }
 })
 
 import { requireOrgAdminOrOwner } from "../../auth/withAuth.js"
 import { parseEnv } from "../../config/env.js"
 import type { Env } from "../../config/env.js"
+import { syncGithubRepositories } from "../../openworkflow/workflows/sync-github-repositories.js"
 import { githubInstallationRoutes } from "./github-installation.js"
 import { meGithubInstallationsRoutes } from "./me-github-installations.js"
+
+const installationFixture = {
+  id: "con_github",
+  installationId: 123,
+  orgId: "org_1",
+  accountSlug: "acme",
+  appSlug: null,
+  ingestAllRepositories: false,
+  includeFutureRepos: false,
+  createdAt: new Date("2026-03-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+}
 
 const baseTestEnv = {
   NODE_ENV: "test",
@@ -171,6 +191,7 @@ describe("POST /github/installation", () => {
     expect(upsertInstallationMock).toHaveBeenCalled()
     expect(upsertInstallationMock.mock.calls[0]?.[0]).toBe("org_1")
     expect(upsertInstallationMock.mock.calls[0]?.[1]).toBe(123)
+    expect(runWorkflowMock).not.toHaveBeenCalled()
   })
 
   it("returns 403 when installationId is not accessible to the user", async () => {
@@ -205,6 +226,21 @@ describe("POST /github/installation", () => {
     expect(upsertInstallationMock).toHaveBeenCalled()
     expect(upsertInstallationMock.mock.calls[0]?.[0]).toBe("org_1")
     expect(upsertInstallationMock.mock.calls[0]?.[1]).toBe(123)
+    expect(runWorkflowMock).not.toHaveBeenCalled()
+  })
+
+  it("does not enqueue sync on registration", async () => {
+    getGithubUserAccessTokenMock.mockResolvedValueOnce(undefined)
+
+    const app = createApp()
+    const res = await app.request("/github/installation", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ installationId: 123 }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(runWorkflowMock).not.toHaveBeenCalled()
   })
 })
 
@@ -436,7 +472,7 @@ describe("POST /github/installation with connectionId", () => {
       }),
     )
     expect(upsertInstallationMock).not.toHaveBeenCalled()
-    expect(runWorkflowMock).toHaveBeenCalled()
+    expect(runWorkflowMock).not.toHaveBeenCalled()
   })
 })
 
@@ -444,6 +480,17 @@ describe("PATCH /github/installation", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getActiveMemberRoleMock.mockResolvedValue({ role: "admin" })
+    countRepositoriesForGithubConnectionMock.mockResolvedValue(0)
+    resolveGithubInstallationForOrgDetailedMock.mockResolvedValue({
+      status: "ok",
+      installation: installationFixture,
+    })
+    updateInstallationOptionsMock.mockImplementation(
+      async (_orgId, _connectionId, options) => ({
+        ...installationFixture,
+        ...options,
+      }),
+    )
   })
 
   it("returns 403 when user is not org admin/owner", async () => {
@@ -461,6 +508,119 @@ describe("PATCH /github/installation", () => {
 
     expect(res.status).toBe(403)
     expect(await res.json()).toEqual({ error: "Forbidden" })
+  })
+
+  it("select mode enqueues reposToSync only", async () => {
+    const selectedRepositories = [
+      {
+        id: 1,
+        full_name: "acme/alpha",
+        name: "alpha",
+        clone_url: "https://github.com/acme/alpha.git",
+      },
+      {
+        id: 2,
+        full_name: "acme/beta",
+        name: "beta",
+        clone_url: "https://github.com/acme/beta.git",
+      },
+    ]
+
+    const app = createApp()
+    const res = await app.request("/github/installation", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ingestAllRepositories: false,
+        includeFutureRepos: false,
+        selectedRepositories,
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(pruneGithubConnectionRepositoriesNotInGitUrlsMock).toHaveBeenCalledWith(
+      "org_1",
+      "con_github",
+      new Set([
+        "https://github.com/acme/alpha.git",
+        "https://github.com/acme/beta.git",
+      ]),
+    )
+    expect(runWorkflowMock).toHaveBeenCalledWith(syncGithubRepositories.spec, {
+      orgId: "org_1",
+      githubConnectionId: "con_github",
+      reposToSync: [
+        {
+          name: "acme/alpha",
+          gitUrl: "https://github.com/acme/alpha.git",
+        },
+        {
+          name: "acme/beta",
+          gitUrl: "https://github.com/acme/beta.git",
+        },
+      ],
+    })
+  })
+
+  it("all mode enqueues full sync without reposToSync", async () => {
+    const app = createApp()
+    const res = await app.request("/github/installation", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ingestAllRepositories: true,
+        includeFutureRepos: false,
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(pruneGithubConnectionRepositoriesNotInGitUrlsMock).not.toHaveBeenCalled()
+    expect(runWorkflowMock).toHaveBeenCalledWith(syncGithubRepositories.spec, {
+      orgId: "org_1",
+      githubConnectionId: "con_github",
+    })
+    expect(runWorkflowMock.mock.calls[0]?.[1]).not.toHaveProperty("reposToSync")
+  })
+
+  it("select mode with empty selection returns 400 and does not enqueue sync", async () => {
+    const app = createApp()
+    const res = await app.request("/github/installation", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ingestAllRepositories: false,
+        includeFutureRepos: false,
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({
+      error: "Select at least one repository",
+    })
+    expect(runWorkflowMock).not.toHaveBeenCalled()
+    expect(pruneGithubConnectionRepositoriesNotInGitUrlsMock).not.toHaveBeenCalled()
+  })
+
+  it("all mode persists includeFutureRepos false", async () => {
+    const app = createApp()
+    const res = await app.request("/github/installation", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ingestAllRepositories: true,
+        includeFutureRepos: false,
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(updateInstallationOptionsMock).toHaveBeenCalledWith(
+      "org_1",
+      "con_github",
+      {
+        ingestAllRepositories: true,
+        includeFutureRepos: false,
+      },
+    )
   })
 })
 

--- a/apps/backend/src/routes/v1/github-installation.ts
+++ b/apps/backend/src/routes/v1/github-installation.ts
@@ -33,6 +33,7 @@ import {
 import {
   countRepositoriesForGithubConnection,
   listRepositories,
+  pruneGithubConnectionRepositoriesNotInGitUrls,
 } from "../../models/repositories.js"
 import { runWorkflowWithWorkerWake } from "../../openworkflow/client.js"
 import { syncGithubRepositories } from "../../openworkflow/workflows/sync-github-repositories.js"
@@ -1006,15 +1007,8 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
           )) ?? installation
       }
 
-      if (installation.installationId != null) {
-        void runWorkflowWithWorkerWake(syncGithubRepositories.spec, {
-          orgId,
-          githubConnectionId: installation.id,
-        })
-      }
       return c.json(await githubInstallationResponsePayload(installation), 200)
     } catch (e) {
-      // if it is error from evlog re-throw it
       if (e instanceof Error && e.name === "EvlogError") {
         throw e
       }
@@ -1140,6 +1134,12 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
           404,
         )
       }
+
+      const selectedRepos = body.selectedRepositories ?? []
+      if (!body.ingestAllRepositories && selectedRepos.length === 0) {
+        return c.json({ error: "Select at least one repository" }, 400)
+      }
+
       const installation = await updateInstallationOptions(
         orgId,
         resolved.installation.id,
@@ -1155,18 +1155,25 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
         )
       }
 
-      const selectedRepos = body.selectedRepositories ?? []
-      const workflowPayload =
-        !body.ingestAllRepositories && selectedRepos.length > 0
-          ? {
-              orgId,
-              githubConnectionId: installation.id,
-              reposToSync: selectedRepos.map((r) => ({
-                name: r.full_name,
-                gitUrl: r.clone_url,
-              })),
-            }
-          : { orgId, githubConnectionId: installation.id }
+      if (!body.ingestAllRepositories) {
+        const allowedGitUrls = new Set(selectedRepos.map((r) => r.clone_url))
+        await pruneGithubConnectionRepositoriesNotInGitUrls(
+          orgId,
+          installation.id,
+          allowedGitUrls,
+        )
+      }
+
+      const workflowPayload = body.ingestAllRepositories
+        ? { orgId, githubConnectionId: installation.id }
+        : {
+            orgId,
+            githubConnectionId: installation.id,
+            reposToSync: selectedRepos.map((r) => ({
+              name: r.full_name,
+              gitUrl: r.clone_url,
+            })),
+          }
       if (installation.installationId != null) {
         void runWorkflowWithWorkerWake(
           syncGithubRepositories.spec,

--- a/apps/backend/src/routes/webhooks/github/github.test.ts
+++ b/apps/backend/src/routes/webhooks/github/github.test.ts
@@ -292,6 +292,47 @@ describe("POST /api/v1/webhook/github", () => {
     )
   })
 
+  it("repository webhook skips sync when includeFutureRepos is false", async () => {
+    listInstallationsMock.mockResolvedValue([
+      {
+        id: "ghi_1",
+        orgId: "org_1",
+        installationId: 999,
+        accountSlug: null,
+        ingestAllRepositories: true,
+        includeFutureRepos: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
+
+    const app = createTestApp()
+    const payload = {
+      action: "created" as const,
+      repository: {
+        full_name: "acme/new-repo",
+        clone_url: "https://github.com/acme/new-repo.git",
+      },
+      installation: { id: 999 },
+    }
+    const body = JSON.stringify(payload)
+    const w = new Webhooks({ secret: webhookSecret })
+    const sig = await w.sign(body)
+
+    const res = await app.request("/api/v1/webhook/github", {
+      method: "POST",
+      headers: {
+        "x-github-event": "repository",
+        "x-hub-signature-256": sig,
+        "content-type": "application/json",
+      },
+      body,
+    })
+
+    expect(res.status).toBe(200)
+    expect(runWorkflowMock).not.toHaveBeenCalled()
+  })
+
   it("repository created with both flags enqueues sync workflow", async () => {
     listInstallationsMock.mockResolvedValue([
       {

--- a/apps/ui/src/features/repositories/components/GitHubRepositorySetupForm.tsx
+++ b/apps/ui/src/features/repositories/components/GitHubRepositorySetupForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useInfiniteQuery, useMutation } from "@tanstack/react-query"
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { type FormEvent, useCallback, useMemo, useRef, useState } from "react"
 import type { Selection } from "react-aria-components"
 import { toast } from "sonner"
@@ -47,6 +47,7 @@ export function GitHubRepositorySetupForm({
   onCancel,
 }: GitHubRepositorySetupFormProps) {
   const { data: session } = useSession()
+  const queryClient = useQueryClient()
 
   const contextLabel =
     pageContext === "connectors" ? "Connectors" : "Repositories"
@@ -57,7 +58,7 @@ export function GitHubRepositorySetupForm({
   )
 
   const [mode, setMode] = useState<"all" | "select">(() =>
-    setupData?.ingestAllRepositories === false ? "select" : "all",
+    setupData?.ingestAllRepositories === true ? "all" : "select",
   )
   const [includeFutureRepos, setIncludeFutureRepos] = useState(
     () => setupData?.includeFutureRepos ?? false,
@@ -175,7 +176,15 @@ export function GitHubRepositorySetupForm({
         }
       }
     },
-    onSuccess: () => {
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["repositories", orgSlug],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["github-installation-setup", orgSlug],
+        }),
+      ])
       toast.success("Repositories saved. Ingestion has started.")
       onSaveSuccess()
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug where connecting a GitHub App with many accessible repositories caused **all** repos to start ingesting before the user saved their selection on the setup form.

## Root cause

`POST /:orgSlug/api/v1/github/installation` (register installation) unconditionally enqueued `sync-github-repositories` without `reposToSync`, which listed every repo from GitHub and started ingestion immediately — before the user reached the repository picker.

## Changes

- **Defer sync until setup save:** Remove workflow enqueue from POST register; first sync happens on `PATCH /github/installation` after the user chooses all vs specific repos.
- **Harden PATCH:** Select mode requires `selectedRepositories` (400 when empty). All mode still syncs everything accessible.
- **Prune over-synced repos:** On select-mode save, delete repository rows for this GitHub connection whose `gitUrl` is not in the saved selection (handles users already affected by the eager POST sync).
- **UI:** Default setup form to **Select specific repositories**; invalidate repository/setup queries after save.
- **Tests (TDD):** Added regression tests for POST no-sync, PATCH payloads, prune behavior, workflow `reposToSync` path, and `includeFutureRepos` webhook gating.

## Test plan

- [x] `pnpm --filter @ctxpipe/backend test src/routes/v1/github-installation.test.ts`
- [x] `pnpm --filter @ctxpipe/backend test src/routes/webhooks/github/github.test.ts`
- [x] `pnpm --filter @ctxpipe/backend test src/openworkflow/workflows/sync-github-repositories.test.ts`
- [ ] Manual: connect GitHub App with many repos → confirm 0 repos ingested before setup save → select 1–2 → only those ingest
- [ ] Manual: all mode + future checkbox unchecked → new GitHub repo not auto-added; checked → auto-added
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae6342d4-fab6-47c8-b468-7bb0f5d5ff1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae6342d4-fab6-47c8-b468-7bb0f5d5ff1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

