### PR TITLE
Fix pending GitHub repository scope

### DIFF
--- a/.changeset/fix-pending-github-repos.md
+++ b/.changeset/fix-pending-github-repos.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Fix the repositories page so select-specific GitHub setup only shows selected repositories as pending indexing, instead of every GitHub-accessible repository.

--- a/apps/backend/src/models/repositories.test.ts
+++ b/apps/backend/src/models/repositories.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+const requireCurrentOrgIdMock = vi.hoisted(() => vi.fn())
 const requireCurrentOrgSlugMock = vi.hoisted(() => vi.fn())
 const getOrgDbMock = vi.hoisted(() => vi.fn())
 const withGraphClientMock = vi.hoisted(() => vi.fn())
 const deleteRepositoryWithCleanupMock = vi.hoisted(() => vi.fn())
 
 vi.mock("../auth/context.js", () => ({
-  requireCurrentOrgId: vi.fn(),
+  requireCurrentOrgId: requireCurrentOrgIdMock,
   requireCurrentOrgSlug: requireCurrentOrgSlugMock,
 }))
 
@@ -22,7 +23,10 @@ vi.mock("../domain/repositoryDeletion.js", () => ({
   deleteRepositoryWithCleanup: deleteRepositoryWithCleanupMock,
 }))
 
-import { pruneGithubConnectionRepositoriesNotInGitUrls } from "./repositories.js"
+import {
+  listRepositoriesForGithubConnection,
+  pruneGithubConnectionRepositoriesNotInGitUrls,
+} from "./repositories.js"
 
 const orgId = "org_1"
 const githubConnectionId = "con_github"
@@ -39,6 +43,46 @@ function mockLinkedRepos(
     }),
   })
 }
+
+function mockRepositoriesWithZoekt(rows: Array<Record<string, unknown>>) {
+  const where = vi.fn().mockResolvedValue(rows)
+  const innerJoin = vi.fn().mockReturnValue({ where })
+  const from = vi.fn().mockReturnValue({ innerJoin })
+  const select = vi.fn().mockReturnValue({ from })
+  getOrgDbMock.mockReturnValue({ select })
+  return { select, from, innerJoin, where }
+}
+
+describe("listRepositoriesForGithubConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    requireCurrentOrgIdMock.mockReturnValue(orgId)
+  })
+
+  it("returns repositories for the current org and GitHub connection", async () => {
+    const rows = [
+      {
+        id: "repo_linked",
+        orgId,
+        name: "acme/linked",
+        gitUrl: "https://github.com/acme/linked.git",
+        indexReady: false,
+        indexingReason: null,
+        lastIngestedHash: null,
+        githubConnectionId,
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+        zoektRepoId: 1,
+      },
+    ]
+    const query = mockRepositoriesWithZoekt(rows)
+
+    await expect(
+      listRepositoriesForGithubConnection(githubConnectionId),
+    ).resolves.toEqual(rows)
+    expect(query.where).toHaveBeenCalledTimes(1)
+  })
+})
 
 describe("pruneGithubConnectionRepositoriesNotInGitUrls", () => {
   beforeEach(() => {

--- a/apps/backend/src/models/repositories.ts
+++ b/apps/backend/src/models/repositories.ts
@@ -17,6 +17,7 @@ export type RepositoryWithSearch = typeof repositories.$inferSelect & {
 async function selectRepositoriesWithZoekt(
   db: ReturnType<typeof getOrgDb>,
   orgId: string,
+  githubConnectionId?: string,
 ) {
   return db
     .select({
@@ -40,13 +41,28 @@ async function selectRepositoriesWithZoekt(
         eq(repositoryCheckouts.checkoutKey, DEFAULT_CHECKOUT_KEY),
       ),
     )
-    .where(eq(repositories.orgId, orgId))
+    .where(
+      githubConnectionId
+        ? and(
+            eq(repositories.orgId, orgId),
+            eq(repositories.githubConnectionId, githubConnectionId),
+          )
+        : eq(repositories.orgId, orgId),
+    )
 }
 
 export const listRepositories = async (): Promise<RepositoryWithSearch[]> => {
   const orgId = requireCurrentOrgId()
   const db = getOrgDb()
   return selectRepositoriesWithZoekt(db, orgId)
+}
+
+export const listRepositoriesForGithubConnection = async (
+  githubConnectionId: string,
+): Promise<RepositoryWithSearch[]> => {
+  const orgId = requireCurrentOrgId()
+  const db = getOrgDb()
+  return selectRepositoriesWithZoekt(db, orgId, githubConnectionId)
 }
 
 /** Repositories linked to this GitHub App connection (`github_connection_id`). */

--- a/apps/backend/src/routes/v1/github-installation.test.ts
+++ b/apps/backend/src/routes/v1/github-installation.test.ts
@@ -22,6 +22,7 @@ vi.mock("../../openworkflow/client.js", () => ({
 const countRepositoriesForGithubConnectionMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue(0),
 )
+const listRepositoriesForGithubConnectionMock = vi.hoisted(() => vi.fn())
 const pruneGithubConnectionRepositoriesNotInGitUrlsMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue(undefined),
 )
@@ -33,6 +34,7 @@ vi.mock("../../models/repositories.js", async (importOriginal) => {
     ...actual,
     countRepositoriesForGithubConnection:
       countRepositoriesForGithubConnectionMock,
+    listRepositoriesForGithubConnection: listRepositoriesForGithubConnectionMock,
     pruneGithubConnectionRepositoriesNotInGitUrls:
       pruneGithubConnectionRepositoriesNotInGitUrlsMock,
   }
@@ -621,6 +623,53 @@ describe("PATCH /github/installation", () => {
         includeFutureRepos: false,
       },
     )
+  })
+})
+
+describe("GET /github/installation/setup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getActiveMemberRoleMock.mockResolvedValue({ role: "admin" })
+    countRepositoriesForGithubConnectionMock.mockResolvedValue(0)
+    resolveGithubInstallationForOrgDetailedMock.mockResolvedValue({
+      status: "ok",
+      installation: installationFixture,
+    })
+    listRepositoriesForGithubConnectionMock.mockResolvedValue([
+      {
+        id: "repo_linked",
+        orgId: "org_1",
+        name: "acme/linked",
+        gitUrl: "https://github.com/acme/linked.git",
+        indexReady: false,
+        indexingReason: null,
+        lastIngestedHash: null,
+        githubConnectionId: "con_github",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+        zoektRepoId: 1,
+      },
+    ])
+  })
+
+  it("returns saved repositories scoped to the resolved GitHub connection", async () => {
+    const app = createApp()
+    const res = await app.request("/github/installation/setup")
+
+    expect(res.status).toBe(200)
+    expect(listRepositoriesForGithubConnectionMock).toHaveBeenCalledWith(
+      "con_github",
+    )
+    expect(await res.json()).toMatchObject({
+      ingestAllRepositories: false,
+      includeFutureRepos: false,
+      savedRepositories: [
+        {
+          name: "acme/linked",
+          gitUrl: "https://github.com/acme/linked.git",
+        },
+      ],
+    })
   })
 })
 

--- a/apps/backend/src/routes/v1/github-installation.ts
+++ b/apps/backend/src/routes/v1/github-installation.ts
@@ -32,7 +32,7 @@ import {
 } from "../../models/github-mcp-config-pr.js"
 import {
   countRepositoriesForGithubConnection,
-  listRepositories,
+  listRepositoriesForGithubConnection,
   pruneGithubConnectionRepositoriesNotInGitUrls,
 } from "../../models/repositories.js"
 import { runWorkflowWithWorkerWake } from "../../openworkflow/client.js"
@@ -809,7 +809,7 @@ export const githubInstallationRoutes = new OpenAPIHono<AppEnv>()
       return c.json({ error: "No GitHub installation found for this org" }, 404)
     }
     const installation = resolved.installation
-    const repos = await listRepositories()
+    const repos = await listRepositoriesForGithubConnection(installation.id)
     return c.json(
       {
         ingestAllRepositories: installation.ingestAllRepositories,

--- a/apps/ui/src/features/repositories/components/GitHubRepositorySetupForm.tsx
+++ b/apps/ui/src/features/repositories/components/GitHubRepositorySetupForm.tsx
@@ -184,6 +184,9 @@ export function GitHubRepositorySetupForm({
         queryClient.invalidateQueries({
           queryKey: ["github-installation-setup", orgSlug],
         }),
+        queryClient.invalidateQueries({
+          queryKey: ["github-installation-repos-preview", orgSlug],
+        }),
       ])
       toast.success("Repositories saved. Ingestion has started.")
       onSaveSuccess()

--- a/apps/ui/src/features/repositories/pendingGithubRepos.test.ts
+++ b/apps/ui/src/features/repositories/pendingGithubRepos.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import { derivePendingGithubRepos } from "./pendingGithubRepos"
+
+const connectedGithubRepos = [
+  {
+    id: 1,
+    full_name: "acme/selected-indexing",
+    html_url: "https://github.com/acme/selected-indexing",
+    clone_url: "https://github.com/acme/selected-indexing.git",
+    name: "selected-indexing",
+  },
+  {
+    id: 2,
+    full_name: "acme/selected-pending",
+    html_url: "https://github.com/acme/selected-pending",
+    clone_url: "https://github.com/acme/selected-pending.git",
+    name: "selected-pending",
+  },
+  {
+    id: 3,
+    full_name: "acme/unselected",
+    html_url: "https://github.com/acme/unselected",
+    clone_url: "https://github.com/acme/unselected.git",
+    name: "unselected",
+  },
+]
+
+describe("derivePendingGithubRepos", () => {
+  it("select mode only shows saved selected repos that are not already in the repository list", () => {
+    const result = derivePendingGithubRepos({
+      connectedGithubRepos,
+      savedSetupRepos: [
+        {
+          name: "acme/selected-indexing",
+          gitUrl: "https://github.com/acme/selected-indexing.git",
+        },
+        {
+          name: "acme/selected-pending",
+          gitUrl: "https://github.com/acme/selected-pending.git",
+        },
+      ],
+      existingGitUrls: new Set([
+        "https://github.com/acme/selected-indexing.git",
+      ]),
+      setupData: {
+        ingestAllRepositories: false,
+        includeFutureRepos: false,
+        savedRepositories: [
+          {
+            name: "acme/selected-indexing",
+            gitUrl: "https://github.com/acme/selected-indexing.git",
+          },
+          {
+            name: "acme/selected-pending",
+            gitUrl: "https://github.com/acme/selected-pending.git",
+          },
+        ],
+      },
+      setupPending: false,
+    })
+
+    expect(result.pendingConnectedGithubRepos).toEqual([])
+    expect(result.pendingSavedSetupRepos).toEqual([
+      {
+        name: "acme/selected-pending",
+        gitUrl: "https://github.com/acme/selected-pending.git",
+      },
+    ])
+  })
+
+  it("all mode shows accessible GitHub repos that are not already in the repository list", () => {
+    const result = derivePendingGithubRepos({
+      connectedGithubRepos,
+      savedSetupRepos: [],
+      existingGitUrls: new Set([
+        "https://github.com/acme/selected-indexing.git",
+      ]),
+      setupData: {
+        ingestAllRepositories: true,
+        includeFutureRepos: false,
+        savedRepositories: [],
+      },
+      setupPending: false,
+    })
+
+    expect(
+      result.pendingConnectedGithubRepos.map((repo) => repo.full_name),
+    ).toEqual(["acme/selected-pending", "acme/unselected"])
+    expect(result.pendingSavedSetupRepos).toEqual([])
+  })
+
+  it("suppresses preview pending rows while setup state is still loading", () => {
+    const result = derivePendingGithubRepos({
+      connectedGithubRepos,
+      savedSetupRepos: [],
+      existingGitUrls: new Set(),
+      setupData: undefined,
+      setupPending: true,
+    })
+
+    expect(result.pendingConnectedGithubRepos).toEqual([])
+    expect(result.pendingSavedSetupRepos).toEqual([])
+  })
+})

--- a/apps/ui/src/features/repositories/pendingGithubRepos.ts
+++ b/apps/ui/src/features/repositories/pendingGithubRepos.ts
@@ -1,0 +1,55 @@
+export type PendingConnectedGithubRepo = {
+  id: number
+  full_name: string
+  html_url: string
+  clone_url: string
+  name: string
+}
+
+export type PendingSavedSetupRepo = {
+  name: string
+  gitUrl: string
+}
+
+export type PendingGithubSetupData = {
+  ingestAllRepositories: boolean
+  includeFutureRepos: boolean
+  savedRepositories: PendingSavedSetupRepo[]
+}
+
+export function derivePendingGithubRepos({
+  connectedGithubRepos,
+  savedSetupRepos,
+  existingGitUrls,
+  setupData,
+  setupPending,
+}: {
+  connectedGithubRepos: PendingConnectedGithubRepo[]
+  savedSetupRepos: PendingSavedSetupRepo[]
+  existingGitUrls: Set<string>
+  setupData?: PendingGithubSetupData | null
+  setupPending: boolean
+}) {
+  if (setupPending || !setupData) {
+    return {
+      pendingConnectedGithubRepos: [],
+      pendingSavedSetupRepos: [],
+    }
+  }
+
+  if (setupData.ingestAllRepositories) {
+    return {
+      pendingConnectedGithubRepos: connectedGithubRepos.filter(
+        (repo) => !existingGitUrls.has(repo.clone_url),
+      ),
+      pendingSavedSetupRepos: [],
+    }
+  }
+
+  return {
+    pendingConnectedGithubRepos: [],
+    pendingSavedSetupRepos: savedSetupRepos.filter(
+      (repo) => !existingGitUrls.has(repo.gitUrl),
+    ),
+  }
+}

--- a/apps/ui/src/routes/$orgSlug.repositories.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.repositories.index.tsx
@@ -22,6 +22,7 @@ import {
   RepositoryStatus,
 } from "@/features/repositories"
 import { githubRepoFullNameFromGitUrl } from "@/features/repositories/github-web-url"
+import { derivePendingGithubRepos } from "@/features/repositories/pendingGithubRepos"
 import { client } from "@/lib/api"
 import { useSession } from "@/lib/auth-client"
 
@@ -42,6 +43,8 @@ type GitHubReposPreview = {
   warning?: string | null
 }
 type GitHubSetupData = {
+  ingestAllRepositories: boolean
+  includeFutureRepos: boolean
   savedRepositories: Array<{ name: string; gitUrl: string }>
 }
 
@@ -138,7 +141,7 @@ function RepositoriesPage() {
     },
     enabled: !!installation,
   })
-  const { data: githubSetupData } = useQuery({
+  const { data: githubSetupData, isPending: githubSetupPending } = useQuery({
     queryKey: ["github-installation-setup", orgSlug],
     queryFn: async () => {
       const res = await (
@@ -266,12 +269,14 @@ function RepositoriesPage() {
   const githubPreviewWarning = githubPreview?.warning ?? null
   const savedSetupRepos = githubSetupData?.savedRepositories ?? []
   const existingGitUrls = new Set(repos.map((repo) => repo.gitUrl))
-  const pendingConnectedGithubRepos = connectedGithubRepos.filter(
-    (repo) => !existingGitUrls.has(repo.clone_url),
-  )
-  const pendingSavedSetupRepos = savedSetupRepos.filter(
-    (repo) => !existingGitUrls.has(repo.gitUrl),
-  )
+  const { pendingConnectedGithubRepos, pendingSavedSetupRepos } =
+    derivePendingGithubRepos({
+      connectedGithubRepos,
+      savedSetupRepos,
+      existingGitUrls,
+      setupData: githubSetupData,
+      setupPending: Boolean(installation) && githubSetupPending,
+    })
   const hasConnectedGithubRepos = pendingConnectedGithubRepos.length > 0
   const hasSavedSetupRepos = pendingSavedSetupRepos.length > 0
   const hasPendingGithubRepos = hasConnectedGithubRepos || hasSavedSetupRepos


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a follow-up GitHub repository setup bug where the repositories page showed every GitHub-accessible repository as `pending indexing` after a select-specific save.

## Changes

- Scope `GET /github/installation/setup` `savedRepositories` to the resolved GitHub connection instead of all org repositories.
- Add `derivePendingGithubRepos` so select-specific mode derives pending rows only from saved/selected setup repos, while all-mode can still show GitHub-accessible repos as pending.
- Suppress preview-derived pending rows while setup state is loading to avoid a brief all-repos flash.
- Invalidate the GitHub preview query after setup save.
- Add a patch changeset for `@ctxpipe/aws-cdk`.

## Test plan

- [x] `pnpm test src/routes/v1/github-installation.test.ts src/models/repositories.test.ts` from `apps/backend`
- [x] `pnpm test src/features/repositories/pendingGithubRepos.test.ts` from `apps/ui`
- [x] `pnpm exec biome lint src/models/repositories.ts src/models/repositories.test.ts src/routes/v1/github-installation.ts src/routes/v1/github-installation.test.ts` from `apps/backend`
- [x] `pnpm exec biome lint 'src/routes/$orgSlug.repositories.index.tsx' src/features/repositories/pendingGithubRepos.ts src/features/repositories/pendingGithubRepos.test.ts src/features/repositories/components/GitHubRepositorySetupForm.tsx` from `apps/ui`
- [ ] Manual browser verification blocked in this VM: Docker CLI, Docker service, Bun, psql, and app ports are unavailable, so the cloud runbook cannot start the local app stack here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae6342d4-fab6-47c8-b468-7bb0f5d5ff1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae6342d4-fab6-47c8-b468-7bb0f5d5ff1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

