### PR TITLE
Add org DB context to repository ingestion graph

### DIFF
--- a/.changeset/public-weeks-heal.md
+++ b/.changeset/public-weeks-heal.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Resolve issues with ingestion timing out

--- a/apps/backend/openworkflow.config.ts
+++ b/apps/backend/openworkflow.config.ts
@@ -52,4 +52,7 @@ export default defineConfig({
   dirs: ["./src/openworkflow/workflows"],
   // CLI imports every *.ts under dirs; skip Vitest files (dev-only deps).
   ignorePatterns: ["**/*.test.*", "**/*.spec.*"],
+  worker: {
+    concurrency: 20
+  }
 })

--- a/apps/backend/src/db/client.ts
+++ b/apps/backend/src/db/client.ts
@@ -48,15 +48,25 @@ export function getOrgDb(): Db {
   )
 }
 
+export type OrgDbContextOptions = {
+  idleInTransactionSessionTimeout?: string
+}
+
 export async function withOrgDbContext<T>(
   orgId: string,
   handler: (db: Db) => Promise<T>,
+  options?: OrgDbContextOptions,
 ): Promise<T> {
   const db = getSystemDb()
   return db.transaction(async (tx) => {
     await tx.execute(
       sql`select set_config('app.organization_id', ${orgId}, true)`,
     )
+    if (options?.idleInTransactionSessionTimeout) {
+      await tx.execute(
+        sql`select set_config('idle_in_transaction_session_timeout', ${options.idleInTransactionSessionTimeout}, true)`,
+      )
+    }
     try {
       // Explicit `async` wrapper: some runtimes (e.g. Bun inside OpenWorkflow steps)
       // drop AsyncLocalStorage across `() => handler(tx)` when `handler` is async.

--- a/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
@@ -17,6 +17,7 @@ import type {
   ExtractedClaim,
   ExtractedObject,
 } from "./schemas.js"
+import { withNodeOrgDbContext } from "./withNodeOrgDbContext.js"
 
 const arrayReducer = <T>(left: T[], right: T | T[]): T[] =>
   left.concat(Array.isArray(right) ? right : [right])
@@ -75,19 +76,28 @@ const ExtractionStateAnnotation = Annotation.Root({
 const extractionSubgraph = new StateGraph(ExtractionStateAnnotation, {
   output: Annotation.Root({}),
 })
-  .addNode("extractKind", extractKind)
-  .addNode("identifyAPIClients", identifyAPIClients)
-  .addNode("identifyAPIs", identifyAPIs)
-  .addNode("identifyDatabases", identifyDatabases)
-  .addNode("identifyInfrastructure", identifyInfrastructure)
-  .addNode("identifyStreams", identifyStreams)
-  .addNode("identifyServiceDependencies", identifyServiceDependencies)
-  .addNode("identifyLibraries", identifyLibraries)
-  .addNode("identifyPatterns", identifyPatterns)
-  .addNode("extractInstructionUnits", extractInstructionUnits)
-  .addNode("deduplicateAndStore", deduplicateAndStore)
-  .addNode("project", project)
-  .addNode("embed", embed)
+  .addNode("extractKind", withNodeOrgDbContext(extractKind))
+  .addNode("identifyAPIClients", withNodeOrgDbContext(identifyAPIClients))
+  .addNode("identifyAPIs", withNodeOrgDbContext(identifyAPIs))
+  .addNode("identifyDatabases", withNodeOrgDbContext(identifyDatabases))
+  .addNode(
+    "identifyInfrastructure",
+    withNodeOrgDbContext(identifyInfrastructure),
+  )
+  .addNode("identifyStreams", withNodeOrgDbContext(identifyStreams))
+  .addNode(
+    "identifyServiceDependencies",
+    withNodeOrgDbContext(identifyServiceDependencies),
+  )
+  .addNode("identifyLibraries", withNodeOrgDbContext(identifyLibraries))
+  .addNode("identifyPatterns", withNodeOrgDbContext(identifyPatterns))
+  .addNode(
+    "extractInstructionUnits",
+    withNodeOrgDbContext(extractInstructionUnits),
+  )
+  .addNode("deduplicateAndStore", withNodeOrgDbContext(deduplicateAndStore))
+  .addNode("project", withNodeOrgDbContext(project))
+  .addNode("embed", withNodeOrgDbContext(embed))
   .addEdge(START, "extractKind")
   .addEdge("extractKind", "identifyAPIClients")
   .addEdge("extractKind", "identifyAPIs")

--- a/apps/backend/src/graphs/codeIngestionGraph/graph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/graph.ts
@@ -3,10 +3,9 @@ import "@langchain/langgraph/zod"
 import { getLogger } from "../../observability/logger.js"
 import { extractionSubgraph } from "./extractionSubgraph.js"
 import { identifyRoots } from "./nodes/identifyRoots.js"
-import { reindex } from "./nodes/reindex.js"
-import { retractStaleEvidence } from "./nodes/retractStaleEvidence.js"
 import type { CodeIngestionState } from "./schemas.js"
 import { CodeIngestionStateSchema } from "./schemas.js"
+import { withNodeOrgDbContext } from "./withNodeOrgDbContext.js"
 
 function fanOutRoots(state: CodeIngestionState): Send[] {
   const roots = state.roots ?? []
@@ -19,13 +18,9 @@ function fanOutRoots(state: CodeIngestionState): Send[] {
 }
 
 const graph = new StateGraph(CodeIngestionStateSchema)
-  .addNode("reindex", reindex)
-  .addNode("retractStaleEvidence", retractStaleEvidence)
-  .addNode("identifyRoots", identifyRoots)
+  .addNode("identifyRoots", withNodeOrgDbContext(identifyRoots))
   .addNode("extractForRoot", extractionSubgraph)
-  .addEdge(START, "reindex")
-  .addEdge("reindex", "retractStaleEvidence")
-  .addEdge("retractStaleEvidence", "identifyRoots")
+  .addEdge(START, "identifyRoots")
   .addConditionalEdges("identifyRoots", fanOutRoots)
   .addEdge("extractForRoot", END)
   .compile()

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/reindex.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/reindex.ts
@@ -4,7 +4,6 @@ import { parseEnv } from "../../../config/env.js"
 import { codesearchBaseUrl } from "../../../lib/agentToolRuntime.js"
 import { getInstallationToken } from "../../../models/github-installation.js"
 import { flushWorkflowLog, getLogger } from "../../../observability/logger.js"
-import type { CodeIngestionState } from "../schemas.js"
 
 const codesearchIndexResponseSchema = z.object({
   ok: z.literal(true),
@@ -21,9 +20,25 @@ const codesearchIndexResponseSchema = z.object({
   message: z.string().optional(),
 })
 
-export async function reindex(
-  state: CodeIngestionState,
-): Promise<Partial<CodeIngestionState>> {
+type ReindexInput = {
+  repositoryId: string
+  orgId: string
+  targetHash: string
+  fromHash?: string
+  sourceBranch?: string
+  githubConnectionId?: string
+}
+
+export type ReindexStepResult = {
+  indexedAt: string
+  targetHash: string
+  ingestMode: "full" | "partial"
+  changedPaths: string[]
+  deletedPaths: string[]
+  renames: Array<{ from: string; to: string }>
+}
+
+export async function reindex(state: ReindexInput): Promise<ReindexStepResult> {
   let logger = getLogger()
   logger.set({
     step: "codeIngestion.reindex.start",

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/retractStaleEvidence.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/retractStaleEvidence.ts
@@ -1,11 +1,26 @@
 import { getOrgDb } from "../../../db/client.js"
 import { getLogger } from "../../../observability/logger.js"
 import { retractIngestionForDiffPg } from "../../../retrieval/services/ingestionRetraction.js"
-import type { CodeIngestionState } from "../schemas.js"
+import type { RetractionGraphEffects, RetractionStats } from "../schemas.js"
+
+type RetractionInput = {
+  orgId: string
+  repositoryId: string
+  targetHash: string
+  ingestMode?: "full" | "partial"
+  changedPaths?: string[]
+  deletedPaths?: string[]
+  renames?: Array<{ from: string; to: string }>
+}
+
+export type RetractionStepResult = {
+  retractionStats: RetractionStats
+  retractionGraphEffects: RetractionGraphEffects
+}
 
 export async function retractStaleEvidence(
-  state: CodeIngestionState,
-): Promise<Partial<CodeIngestionState>> {
+  state: RetractionInput,
+): Promise<RetractionStepResult> {
   const logger = getLogger()
   const {
     orgId,

--- a/apps/backend/src/graphs/codeIngestionGraph/schemas.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/schemas.ts
@@ -114,8 +114,6 @@ export const CodeIngestionStateSchema = z.object({
   deletedPaths: z.array(z.string()).optional(),
   renames: z.array(CodeIngestionRenameSchema).optional(),
   indexedAt: z.string().optional(),
-  retractionStats: RetractionStatsSchema.optional(),
-  retractionGraphEffects: RetractionGraphEffectsSchema.optional(),
   roots: z.array(z.string()).optional(),
   extractedObjects: zodArrayConcat(ExtractedObjectSchema),
   extractedClaims: zodArrayConcat(ExtractedClaimSchema),

--- a/apps/backend/src/graphs/codeIngestionGraph/withNodeOrgDbContext.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/withNodeOrgDbContext.ts
@@ -1,0 +1,13 @@
+import { withOrgDbContext } from "../../db/client.js"
+
+const DEFAULT_IDLE_IN_TRANSACTION_SESSION_TIMEOUT = "20min"
+
+export function withNodeOrgDbContext<TState extends { orgId: string }, TResult>(
+  node: (state: TState) => Promise<TResult>,
+) {
+  return async (state: TState) =>
+    withOrgDbContext(state.orgId, () => node(state), {
+      idleInTransactionSessionTimeout:
+        DEFAULT_IDLE_IN_TRANSACTION_SESSION_TIMEOUT,
+    })
+}

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -6,6 +6,8 @@ import { getOrgDb, getSystemDb, withOrgDbContext } from "../../db/client.js"
 import { repositories } from "../../db/schema/repositories.js"
 import { resolveRepositoryRef } from "../../domain/codeIngestion/queue.js"
 import { graph as codeIngestionGraph } from "../../graphs/codeIngestionGraph/graph.js"
+import { reindex } from "../../graphs/codeIngestionGraph/nodes/reindex.js"
+import { retractStaleEvidence } from "../../graphs/codeIngestionGraph/nodes/retractStaleEvidence.js"
 import type { CodeIngestionState } from "../../graphs/codeIngestionGraph/schemas.js"
 import {
   getLangfuseHandler,
@@ -75,8 +77,6 @@ export const repositoryIngestion = defineWorkflow(
         }
 
         return withOrgIdContext({ id: org.id, slug: org.slug }, async () => {
-          let ingestOutputState: CodeIngestionState | undefined
-
           logWorkflowMilestone(
             "repository-ingestion.step.get-repository.start",
             {
@@ -142,13 +142,68 @@ export const repositoryIngestion = defineWorkflow(
             sourceBranch: resolved.branch,
           })
 
-          logWorkflowMilestone("repository-ingestion.step.ingest.start", {
+          logWorkflowMilestone("repository-ingestion.step.reindex.start", {
             repositoryId: input.repositoryId,
             targetHash: resolved.hash,
           })
 
-          ingestOutputState = await step.run({ name: "ingest", retryPolicy: { maximumAttempts: 2 } }, () =>
+          const reindexState = await step.run({ name: "reindexStep" }, () =>
             withOrgDbContext(input.orgId, () =>
+              reindex({
+                repositoryId: input.repositoryId,
+                orgId: input.orgId,
+                githubConnectionId: githubConnectionId ?? undefined,
+                fromHash: repository.lastIngestedHash ?? undefined,
+                targetHash: resolved.hash,
+              }),
+            ),
+          )
+
+          logWorkflowMilestone("repository-ingestion.step.reindex.done", {
+            repositoryId: input.repositoryId,
+            targetHash: reindexState.targetHash ?? resolved.hash,
+            ingestMode: reindexState.ingestMode,
+            changedPathsCount: reindexState.changedPaths?.length ?? 0,
+            deletedPathsCount: reindexState.deletedPaths?.length ?? 0,
+            renamesCount: reindexState.renames?.length ?? 0,
+          })
+
+          logWorkflowMilestone("repository-ingestion.step.retraction.start", {
+            repositoryId: input.repositoryId,
+            targetHash: reindexState.targetHash ?? resolved.hash,
+            ingestMode: reindexState.ingestMode,
+          })
+
+          const retractionResult = await step.run(
+            { name: "retractionStep" },
+            () =>
+              withOrgDbContext(input.orgId, () =>
+                retractStaleEvidence({
+                  orgId: input.orgId,
+                  repositoryId: input.repositoryId,
+                  targetHash: reindexState.targetHash ?? resolved.hash,
+                  ingestMode: reindexState.ingestMode,
+                  changedPaths: reindexState.changedPaths,
+                  deletedPaths: reindexState.deletedPaths,
+                  renames: reindexState.renames,
+                }),
+              ),
+          )
+
+          logWorkflowMilestone("repository-ingestion.step.retraction.done", {
+            repositoryId: input.repositoryId,
+            targetHash: reindexState.targetHash ?? resolved.hash,
+            retractionStats: retractionResult.retractionStats,
+          })
+
+          logWorkflowMilestone("repository-ingestion.step.ingest.start", {
+            repositoryId: input.repositoryId,
+            targetHash: reindexState.targetHash ?? resolved.hash,
+          })
+
+          await step.run(
+            { name: "ingest", retryPolicy: { maximumAttempts: 2 } },
+            () =>
               runWithLangfuseContext(
                 {
                   sessionId: input.repositoryId,
@@ -164,7 +219,7 @@ export const repositoryIngestion = defineWorkflow(
                     "repository-ingestion.ingest.invoke-graph.start",
                     {
                       repositoryId: input.repositoryId,
-                      targetHash: resolved.hash,
+                      targetHash: reindexState.targetHash ?? resolved.hash,
                     },
                   )
 
@@ -174,7 +229,12 @@ export const repositoryIngestion = defineWorkflow(
                       orgId: input.orgId,
                       githubConnectionId: githubConnectionId ?? undefined,
                       fromHash: repository.lastIngestedHash ?? undefined,
-                      targetHash: resolved.hash,
+                      targetHash: reindexState.targetHash ?? resolved.hash,
+                      indexedAt: reindexState.indexedAt,
+                      ingestMode: reindexState.ingestMode,
+                      changedPaths: reindexState.changedPaths,
+                      deletedPaths: reindexState.deletedPaths,
+                      renames: reindexState.renames,
                     },
                     {
                       recursionLimit: 1000,
@@ -186,7 +246,7 @@ export const repositoryIngestion = defineWorkflow(
                     "repository-ingestion.ingest.invoke-graph.done",
                     {
                       repositoryId: input.repositoryId,
-                      targetHash: resolved.hash,
+                      targetHash: reindexState.targetHash ?? resolved.hash,
                     },
                   )
 
@@ -194,7 +254,7 @@ export const repositoryIngestion = defineWorkflow(
                   logWorkflowMilestone("repository-ingestion.graph.complete", {
                     repositoryId: input.repositoryId,
                     orgId: input.orgId,
-                    targetHash: resolved.hash,
+                    targetHash: reindexState.targetHash ?? resolved.hash,
                     indexedAt: state.indexedAt,
                     rootsCount: state.roots?.length ?? 0,
                     roots: state.roots,
@@ -207,34 +267,30 @@ export const repositoryIngestion = defineWorkflow(
                   return graphResult as CodeIngestionState
                 },
               ),
-            ),
           )
 
           const result = {
             repositoryId: input.repositoryId,
-            targetHash: resolved.hash,
+            targetHash: reindexState.targetHash ?? resolved.hash,
             sourceBranch: resolved.branch,
           }
 
-          const effects = ingestOutputState?.retractionGraphEffects
+          const effects = retractionResult.retractionGraphEffects
           if (
-            effects &&
-            (effects.deletedClaimIds.length > 0 ||
-              effects.refreshedClaimIds.length > 0 ||
-              effects.deletedObjectIds.length > 0)
+            effects.deletedClaimIds.length > 0 ||
+            effects.refreshedClaimIds.length > 0 ||
+            effects.deletedObjectIds.length > 0
           ) {
             await step.run({ name: "sync-retraction-graph" }, () =>
               withOrgDbContext(input.orgId, async () => {
                 const graph =
                   await applyIngestionRetractionGraphEffects(effects)
-                if (ingestOutputState?.retractionStats) {
-                  ingestOutputState.retractionStats.graphEdgesDeleted =
-                    graph.graphEdgesDeleted
-                  ingestOutputState.retractionStats.graphClaimsRefreshed =
-                    graph.graphClaimsRefreshed
-                  ingestOutputState.retractionStats.graphOrphanObjectsDeleted =
-                    graph.graphOrphanObjectsDeleted
-                }
+                retractionResult.retractionStats.graphEdgesDeleted =
+                  graph.graphEdgesDeleted
+                retractionResult.retractionStats.graphClaimsRefreshed =
+                  graph.graphClaimsRefreshed
+                retractionResult.retractionStats.graphOrphanObjectsDeleted =
+                  graph.graphOrphanObjectsDeleted
               }),
             )
           }

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -147,7 +147,7 @@ export const repositoryIngestion = defineWorkflow(
             targetHash: resolved.hash,
           })
 
-          ingestOutputState = await step.run({ name: "ingest" }, () =>
+          ingestOutputState = await step.run({ name: "ingest", retryPolicy: { maximumAttempts: 2 } }, () =>
             withOrgDbContext(input.orgId, () =>
               runWithLangfuseContext(
                 {


### PR DESCRIPTION
## Summary
- wire organization DB context through repository ingestion graph nodes using `withNodeOrgDbContext`
- update repository ingestion workflow execution and OpenWorkflow tuning to better support context-aware steps
- refine ingestion graph state/schema and transaction idle-timeout handling in org DB context wrappers

Made with [Cursor](https://cursor.com)