### PR TITLE
Fix code ingestion transaction timeouts by narrowing org DB context

### DIFF
--- a/.changeset/afraid-masks-yawn.md
+++ b/.changeset/afraid-masks-yawn.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Resolve idle transaction error

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -64,7 +64,8 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           tags: |
-            ghcr.io/ctxpipe-ai/${{ matrix.image }}:pr-${{ github.event.number }}-${{ github.sha }}
+            ghcr.io/ctxpipe-ai/${{ matrix.image }}:pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+            ghcr.io/ctxpipe-ai/${{ matrix.image }}:${{ github.event.pull_request.head.sha }}
 
   deploy_pr_environment:
     name: Deploy PR environment (Railway + Neon)
@@ -79,7 +80,7 @@ jobs:
     env:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       PR_ENV: pr-${{ github.event.number }}
-      IMAGE_TAG: pr-${{ github.event.number }}-${{ github.sha }}
+      IMAGE_TAG: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
     outputs:
       env_id: ${{ steps.railway_env.outputs.env_id }}
     steps:

--- a/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.test.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest"
+import { extractionSubgraph } from "./extractionSubgraph.js"
+
+describe("extractionSubgraph", () => {
+  it("exports extractedObjects and extractedClaims to the parent graph", () => {
+    const outputChannels = extractionSubgraph.outputChannels
+    expect(outputChannels).toEqual(
+      expect.arrayContaining(["extractedObjects", "extractedClaims"]),
+    )
+  })
+})

--- a/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
@@ -17,7 +17,6 @@ import type {
   ExtractedClaim,
   ExtractedObject,
 } from "./schemas.js"
-import { withNodeOrgDbContext } from "./withNodeOrgDbContext.js"
 
 const arrayReducer = <T>(left: T[], right: T | T[]): T[] =>
   left.concat(Array.isArray(right) ? right : [right])
@@ -76,28 +75,19 @@ const ExtractionStateAnnotation = Annotation.Root({
 const extractionSubgraph = new StateGraph(ExtractionStateAnnotation, {
   output: Annotation.Root({}),
 })
-  .addNode("extractKind", withNodeOrgDbContext(extractKind))
-  .addNode("identifyAPIClients", withNodeOrgDbContext(identifyAPIClients))
-  .addNode("identifyAPIs", withNodeOrgDbContext(identifyAPIs))
-  .addNode("identifyDatabases", withNodeOrgDbContext(identifyDatabases))
-  .addNode(
-    "identifyInfrastructure",
-    withNodeOrgDbContext(identifyInfrastructure),
-  )
-  .addNode("identifyStreams", withNodeOrgDbContext(identifyStreams))
-  .addNode(
-    "identifyServiceDependencies",
-    withNodeOrgDbContext(identifyServiceDependencies),
-  )
-  .addNode("identifyLibraries", withNodeOrgDbContext(identifyLibraries))
-  .addNode("identifyPatterns", withNodeOrgDbContext(identifyPatterns))
-  .addNode(
-    "extractInstructionUnits",
-    withNodeOrgDbContext(extractInstructionUnits),
-  )
-  .addNode("deduplicateAndStore", withNodeOrgDbContext(deduplicateAndStore))
-  .addNode("project", withNodeOrgDbContext(project))
-  .addNode("embed", withNodeOrgDbContext(embed))
+  .addNode("extractKind", extractKind)
+  .addNode("identifyAPIClients", identifyAPIClients) // use repo explorer
+  .addNode("identifyAPIs", identifyAPIs) // use repo explorer
+  .addNode("identifyDatabases", identifyDatabases) //  use repo explorer
+  .addNode("identifyInfrastructure", identifyInfrastructure) //  use repo explorer
+  .addNode("identifyStreams", identifyStreams) //  use repo explorer
+  .addNode("identifyServiceDependencies", identifyServiceDependencies) //  use repo explorer
+  .addNode("identifyLibraries", identifyLibraries) //  use repo explorer
+  .addNode("identifyPatterns", identifyPatterns) //  use repo explorer
+  .addNode("extractInstructionUnits", extractInstructionUnits)
+  .addNode("deduplicateAndStore", deduplicateAndStore) // use org db directly and via services has upsert.
+  .addNode("project", project) // use org db directly but only for select. upsert is done to graph so no need for transaction
+  .addNode("embed", embed) // use org db directly and has upsert
   .addEdge(START, "extractKind")
   .addEdge("extractKind", "identifyAPIClients")
   .addEdge("extractKind", "identifyAPIs")

--- a/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
@@ -1,6 +1,4 @@
 import { Annotation, END, START, StateGraph } from "@langchain/langgraph"
-import { deduplicateAndStore } from "./nodes/deduplicateAndStore.js"
-import { embed } from "./nodes/embed.js"
 import { extractInstructionUnits } from "./nodes/extractInstructionUnits.js"
 import { extractKind } from "./nodes/extractKind.js"
 import { identifyAPIClients } from "./nodes/identifyAPIClients.js"
@@ -11,12 +9,7 @@ import { identifyLibraries } from "./nodes/identifyLibraries.js"
 import { identifyPatterns } from "./nodes/identifyPatterns.js"
 import { identifyServiceDependencies } from "./nodes/identifyServiceDependencies.js"
 import { identifyStreams } from "./nodes/identifyStreams.js"
-import { project } from "./nodes/project.js"
-import type {
-  ClaimForProjection,
-  ExtractedClaim,
-  ExtractedObject,
-} from "./schemas.js"
+import type { ExtractedClaim, ExtractedObject } from "./schemas.js"
 
 const arrayReducer = <T>(left: T[], right: T | T[]): T[] =>
   left.concat(Array.isArray(right) ? right : [right])
@@ -56,20 +49,6 @@ const ExtractionStateAnnotation = Annotation.Root({
     reducer: arrayReducer,
     default: () => [],
   }),
-  objectIds: Annotation<string[]>({
-    reducer: (left, right) =>
-      (Array.isArray(right) ? right : right ? [right] : left) ?? left,
-    default: () => [],
-  }),
-  touchedObjectIds: Annotation<string[]>({
-    reducer: (left, right) =>
-      (Array.isArray(right) ? right : right ? [right] : left) ?? left,
-    default: () => [],
-  }),
-  claimsForProjection: Annotation<ClaimForProjection[]>({
-    reducer: arrayReducer,
-    default: () => [],
-  }),
 })
 
 const extractionSubgraph = new StateGraph(ExtractionStateAnnotation, {
@@ -85,9 +64,6 @@ const extractionSubgraph = new StateGraph(ExtractionStateAnnotation, {
   .addNode("identifyLibraries", identifyLibraries) //  use repo explorer
   .addNode("identifyPatterns", identifyPatterns) //  use repo explorer
   .addNode("extractInstructionUnits", extractInstructionUnits)
-  .addNode("deduplicateAndStore", deduplicateAndStore) // use org db directly and via services has upsert.
-  .addNode("project", project) // use org db directly but only for select. upsert is done to graph so no need for transaction
-  .addNode("embed", embed) // use org db directly and has upsert
   .addEdge(START, "extractKind")
   .addEdge("extractKind", "identifyAPIClients")
   .addEdge("extractKind", "identifyAPIs")
@@ -110,11 +86,8 @@ const extractionSubgraph = new StateGraph(ExtractionStateAnnotation, {
       "identifyPatterns",
       "extractInstructionUnits",
     ],
-    "deduplicateAndStore",
+    END,
   )
-  .addEdge("deduplicateAndStore", "project")
-  .addEdge("project", "embed")
-  .addEdge("embed", END)
   .compile()
 
 export { extractionSubgraph }

--- a/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
@@ -14,6 +14,15 @@ import type { ExtractedClaim, ExtractedObject } from "./schemas.js"
 const arrayReducer = <T>(left: T[], right: T | T[]): T[] =>
   left.concat(Array.isArray(right) ? right : [right])
 
+const extractedObjectsAnnotation = Annotation<ExtractedObject[]>({
+  reducer: arrayReducer,
+  default: () => [],
+})
+const extractedClaimsAnnotation = Annotation<ExtractedClaim[]>({
+  reducer: arrayReducer,
+  default: () => [],
+})
+
 const ExtractionStateAnnotation = Annotation.Root({
   repositoryId: Annotation<string>(),
   orgId: Annotation<string>(),
@@ -41,18 +50,18 @@ const ExtractionStateAnnotation = Annotation.Root({
       (Array.isArray(right) ? right : right ? [right] : left) ?? left,
     default: () => [],
   }),
-  extractedObjects: Annotation<ExtractedObject[]>({
-    reducer: arrayReducer,
-    default: () => [],
-  }),
-  extractedClaims: Annotation<ExtractedClaim[]>({
-    reducer: arrayReducer,
-    default: () => [],
-  }),
+  extractedObjects: extractedObjectsAnnotation,
+  extractedClaims: extractedClaimsAnnotation,
+})
+
+/** Parent `deduplicateAndStore` reads these after parallel `extractForRoot` branches merge. */
+const ExtractionOutputAnnotation = Annotation.Root({
+  extractedObjects: extractedObjectsAnnotation,
+  extractedClaims: extractedClaimsAnnotation,
 })
 
 const extractionSubgraph = new StateGraph(ExtractionStateAnnotation, {
-  output: Annotation.Root({}),
+  output: ExtractionOutputAnnotation,
 })
   .addNode("extractKind", extractKind)
   .addNode("identifyAPIClients", identifyAPIClients) // use repo explorer

--- a/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/extractionSubgraph.ts
@@ -74,20 +74,15 @@ const extractionSubgraph = new StateGraph(ExtractionStateAnnotation, {
   .addEdge("extractKind", "identifyLibraries")
   .addEdge("extractKind", "identifyPatterns")
   .addEdge("extractKind", "extractInstructionUnits")
-  .addEdge(
-    [
-      "identifyAPIClients",
-      "identifyAPIs",
-      "identifyDatabases",
-      "identifyInfrastructure",
-      "identifyStreams",
-      "identifyServiceDependencies",
-      "identifyLibraries",
-      "identifyPatterns",
-      "extractInstructionUnits",
-    ],
-    END,
-  )
+  .addEdge("identifyAPIClients", END)
+  .addEdge("identifyAPIs", END)
+  .addEdge("identifyDatabases", END)
+  .addEdge("identifyInfrastructure", END)
+  .addEdge("identifyStreams", END)
+  .addEdge("identifyServiceDependencies", END)
+  .addEdge("identifyLibraries", END)
+  .addEdge("identifyPatterns", END)
+  .addEdge("extractInstructionUnits", END)
   .compile()
 
 export { extractionSubgraph }

--- a/apps/backend/src/graphs/codeIngestionGraph/graph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/graph.ts
@@ -2,7 +2,10 @@ import { END, Send, START, StateGraph } from "@langchain/langgraph"
 import "@langchain/langgraph/zod"
 import { getLogger } from "../../observability/logger.js"
 import { extractionSubgraph } from "./extractionSubgraph.js"
+import { deduplicateAndStore } from "./nodes/deduplicateAndStore.js"
+import { embed } from "./nodes/embed.js"
 import { identifyRoots } from "./nodes/identifyRoots.js"
+import { project } from "./nodes/project.js"
 import type { CodeIngestionState } from "./schemas.js"
 import { CodeIngestionStateSchema } from "./schemas.js"
 
@@ -19,9 +22,15 @@ function fanOutRoots(state: CodeIngestionState): Send[] {
 const graph = new StateGraph(CodeIngestionStateSchema)
   .addNode("identifyRoots", identifyRoots)
   .addNode("extractForRoot", extractionSubgraph)
+  .addNode("deduplicateAndStore", deduplicateAndStore)
+  .addNode("project", project)
+  .addNode("embed", embed)
   .addEdge(START, "identifyRoots")
   .addConditionalEdges("identifyRoots", fanOutRoots)
-  .addEdge("extractForRoot", END)
+  .addEdge("extractForRoot", "deduplicateAndStore")
+  .addEdge("deduplicateAndStore", "project")
+  .addEdge("project", "embed")
+  .addEdge("embed", END)
   .compile()
 
 export { graph }

--- a/apps/backend/src/graphs/codeIngestionGraph/graph.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/graph.ts
@@ -5,7 +5,6 @@ import { extractionSubgraph } from "./extractionSubgraph.js"
 import { identifyRoots } from "./nodes/identifyRoots.js"
 import type { CodeIngestionState } from "./schemas.js"
 import { CodeIngestionStateSchema } from "./schemas.js"
-import { withNodeOrgDbContext } from "./withNodeOrgDbContext.js"
 
 function fanOutRoots(state: CodeIngestionState): Send[] {
   const roots = state.roots ?? []
@@ -18,7 +17,7 @@ function fanOutRoots(state: CodeIngestionState): Send[] {
 }
 
 const graph = new StateGraph(CodeIngestionStateSchema)
-  .addNode("identifyRoots", withNodeOrgDbContext(identifyRoots))
+  .addNode("identifyRoots", identifyRoots)
   .addNode("extractForRoot", extractionSubgraph)
   .addEdge(START, "identifyRoots")
   .addConditionalEdges("identifyRoots", fanOutRoots)

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/deduplicateAndStore.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/deduplicateAndStore.ts
@@ -18,6 +18,7 @@ import {
 import { upsertRetrievalObjectByDeduplicationKey } from "../../../retrieval/services/retrievalObjectWrite.js"
 import type { ClaimForProjection, CodeIngestionState } from "../schemas.js"
 import { isIdRef } from "../schemas.js"
+import { withNodeOrgDbContext } from "../withNodeOrgDbContext.js"
 
 /**
  * Resolves a subject/object ref: stable object ids pass through; deduplication keys
@@ -46,339 +47,346 @@ export async function resolveDedupRefToId(
   return null
 }
 
-export async function deduplicateAndStore(
-  state: CodeIngestionState,
-): Promise<Partial<CodeIngestionState>> {
-  const logger = getLogger()
-  logger.set({
-    repositoryId: state.repositoryId,
-    orgId: state.orgId,
-    roots: state.roots,
-    extractedObjectsCount: state.extractedObjects?.length ?? 0,
-    extractedClaimsCount: state.extractedClaims?.length ?? 0,
-  })
-  logger.info("deduplicating and storing")
-  const orgId = requireCurrentOrgId()
-  const db = getOrgDb()
-  const { extractedObjects = [], extractedClaims = [] } = state
-  const { targetHash } = state
+export const deduplicateAndStore = withNodeOrgDbContext(
+  async (state: CodeIngestionState): Promise<Partial<CodeIngestionState>> => {
+    const logger = getLogger()
+    logger.set({
+      repositoryId: state.repositoryId,
+      orgId: state.orgId,
+      roots: state.roots,
+      extractedObjectsCount: state.extractedObjects?.length ?? 0,
+      extractedClaimsCount: state.extractedClaims?.length ?? 0,
+    })
+    logger.info("deduplicating and storing")
+    const orgId = requireCurrentOrgId()
+    const db = getOrgDb()
+    const { extractedObjects = [], extractedClaims = [] } = state
+    const { targetHash } = state
 
-  const objectIds: string[] = []
-  const touchedObjectIds: string[] = []
-  const claimsForProjection: ClaimForProjection[] = []
-  const claimIdsToFetch: string[] = []
-  const claimIdToKinds = new Map<
-    string,
-    { subjectKind: string; objectKind: string }
-  >()
-  const keyToId = new Map<string, string>()
-  let claimsDuplicateEvidenceSkipped = 0
-  let claimsNewCreated = 0
-  let claimsEvidenceAddedToExisting = 0
-  let claimsSkippedUnresolvedRef = 0
-  let warnedWindowsDriveColonInSourceId = false
+    const objectIds: string[] = []
+    const touchedObjectIds: string[] = []
+    const claimsForProjection: ClaimForProjection[] = []
+    const claimIdsToFetch: string[] = []
+    const claimIdToKinds = new Map<
+      string,
+      { subjectKind: string; objectKind: string }
+    >()
+    const keyToId = new Map<string, string>()
+    let claimsDuplicateEvidenceSkipped = 0
+    let claimsNewCreated = 0
+    let claimsEvidenceAddedToExisting = 0
+    let claimsSkippedUnresolvedRef = 0
+    let warnedWindowsDriveColonInSourceId = false
 
-  const sortedObjects = [...extractedObjects].sort((a, b) => {
-    const aStub =
-      typeof a.payload === "object" &&
-      a.payload !== null &&
-      (a.payload as Record<string, unknown>).inferredFromConsumer === true
-    const bStub =
-      typeof b.payload === "object" &&
-      b.payload !== null &&
-      (b.payload as Record<string, unknown>).inferredFromConsumer === true
-    if (aStub === bStub) return 0
-    return aStub ? 1 : -1
-  })
+    const sortedObjects = [...extractedObjects].sort((a, b) => {
+      const aStub =
+        typeof a.payload === "object" &&
+        a.payload !== null &&
+        (a.payload as Record<string, unknown>).inferredFromConsumer === true
+      const bStub =
+        typeof b.payload === "object" &&
+        b.payload !== null &&
+        (b.payload as Record<string, unknown>).inferredFromConsumer === true
+      if (aStub === bStub) return 0
+      return aStub ? 1 : -1
+    })
 
-  for (const obj of sortedObjects) {
-    const payload: Record<string, unknown> = {
-      name: obj.name,
-      summary: obj.summary,
-      ...(typeof obj.payload === "object" && obj.payload !== null
-        ? obj.payload
-        : {}),
+    for (const obj of sortedObjects) {
+      const payload: Record<string, unknown> = {
+        name: obj.name,
+        summary: obj.summary,
+        ...(typeof obj.payload === "object" && obj.payload !== null
+          ? obj.payload
+          : {}),
+      }
+      const { id, needsEmbeddingRefresh } =
+        await upsertRetrievalObjectByDeduplicationKey(orgId, {
+          kind: obj.kind as string,
+          deduplicationKey: obj.deduplicationKey,
+          payload,
+        })
+      keyToId.set(obj.deduplicationKey, id)
+      objectIds.push(id)
+      if (needsEmbeddingRefresh) {
+        touchedObjectIds.push(id)
+      }
     }
-    const { id, needsEmbeddingRefresh } =
-      await upsertRetrievalObjectByDeduplicationKey(orgId, {
-        kind: obj.kind as string,
-        deduplicationKey: obj.deduplicationKey,
-        payload,
-      })
-    keyToId.set(obj.deduplicationKey, id)
-    objectIds.push(id)
-    if (needsEmbeddingRefresh) {
-      touchedObjectIds.push(id)
-    }
-  }
 
-  const now = new Date()
-  const nowIso = now.toISOString()
+    const now = new Date()
+    const nowIso = now.toISOString()
 
-  const derivedKeyExpr = deriveLogicalSourceKeySql(
-    claimEvidence.sourceId,
-    targetHash,
-  )
-
-  for (const c of extractedClaims) {
-    const subjectId = await resolveDedupRefToId(
-      c.subjectRef,
-      keyToId,
-      orgId,
-      db,
+    const derivedKeyExpr = deriveLogicalSourceKeySql(
+      claimEvidence.sourceId,
+      targetHash,
     )
-    if (!subjectId) {
-      claimsSkippedUnresolvedRef++
-      logger.set({
-        step: "codeIngestion.deduplicateAndStore.claimSkipped",
-        reason: "unresolved_subject_ref",
-        repositoryId: state.repositoryId,
+
+    for (const c of extractedClaims) {
+      const subjectId = await resolveDedupRefToId(
+        c.subjectRef,
+        keyToId,
         orgId,
-        roots: state.roots,
-        predicate: c.predicate,
-        subjectRef: c.subjectRef,
-        objectRef: c.objectRef,
-        sourceId: c.sourceId,
-      })
-      logger.warn(
-        "[codeIngestion] skipping claim: unresolved subject deduplication ref",
-        {
-          repositoryId: state.repositoryId,
-          predicate: c.predicate,
-          subjectRef: c.subjectRef,
-          objectRef: c.objectRef,
-          sourceId: c.sourceId,
-        },
+        db,
       )
-      continue
-    }
-
-    const objectId = await resolveDedupRefToId(c.objectRef, keyToId, orgId, db)
-    if (!objectId) {
-      claimsSkippedUnresolvedRef++
-      logger.set({
-        step: "codeIngestion.deduplicateAndStore.claimSkipped",
-        reason: "unresolved_object_ref",
-        repositoryId: state.repositoryId,
-        orgId,
-        roots: state.roots,
-        predicate: c.predicate,
-        subjectRef: c.subjectRef,
-        objectRef: c.objectRef,
-        sourceId: c.sourceId,
-      })
-      logger.warn(
-        "[codeIngestion] skipping claim: unresolved object deduplication ref",
-        {
-          repositoryId: state.repositoryId,
-          predicate: c.predicate,
-          subjectRef: c.subjectRef,
-          objectRef: c.objectRef,
-          sourceId: c.sourceId,
-        },
-      )
-      continue
-    }
-
-    const subjectKind = c.subjectKind
-    const objectKind = c.objectKind
-
-    const logicalKey = deriveLogicalSourceKey(c.sourceId, targetHash)
-
-    if (
-      !warnedWindowsDriveColonInSourceId &&
-      evidenceSourceIdMayHaveWindowsDriveColon(c.sourceId)
-    ) {
-      warnedWindowsDriveColonInSourceId = true
-      logger.warn(
-        "deduplicateAndStore: source_id may contain a Windows drive colon; colon-delimited evidence keys can be ambiguous",
-        {
+      if (!subjectId) {
+        claimsSkippedUnresolvedRef++
+        logger.set({
+          step: "codeIngestion.deduplicateAndStore.claimSkipped",
+          reason: "unresolved_subject_ref",
           repositoryId: state.repositoryId,
           orgId,
+          roots: state.roots,
+          predicate: c.predicate,
+          subjectRef: c.subjectRef,
+          objectRef: c.objectRef,
           sourceId: c.sourceId,
-        },
-      )
-    }
+        })
+        logger.warn(
+          "[codeIngestion] skipping claim: unresolved subject deduplication ref",
+          {
+            repositoryId: state.repositoryId,
+            predicate: c.predicate,
+            subjectRef: c.subjectRef,
+            objectRef: c.objectRef,
+            sourceId: c.sourceId,
+          },
+        )
+        continue
+      }
 
-    const existingClaimWithEvidence = await db
-      .select({
-        claimId: claims.id,
-        sourceId: claimEvidence.sourceId,
-      })
-      .from(claims)
-      .innerJoin(claimEvidence, eq(claims.id, claimEvidence.claimId))
-      .where(
-        and(
-          eq(claims.orgId, orgId),
-          eq(claims.subjectId, subjectId),
-          eq(claims.predicate, c.predicate),
-          eq(claims.objectId, objectId),
-          or(
-            eq(claimEvidence.logicalSourceKey, logicalKey),
-            eq(claimEvidence.sourceId, c.sourceId),
-            and(
-              isNull(claimEvidence.logicalSourceKey),
-              eq(derivedKeyExpr, logicalKey),
+      const objectId = await resolveDedupRefToId(
+        c.objectRef,
+        keyToId,
+        orgId,
+        db,
+      )
+      if (!objectId) {
+        claimsSkippedUnresolvedRef++
+        logger.set({
+          step: "codeIngestion.deduplicateAndStore.claimSkipped",
+          reason: "unresolved_object_ref",
+          repositoryId: state.repositoryId,
+          orgId,
+          roots: state.roots,
+          predicate: c.predicate,
+          subjectRef: c.subjectRef,
+          objectRef: c.objectRef,
+          sourceId: c.sourceId,
+        })
+        logger.warn(
+          "[codeIngestion] skipping claim: unresolved object deduplication ref",
+          {
+            repositoryId: state.repositoryId,
+            predicate: c.predicate,
+            subjectRef: c.subjectRef,
+            objectRef: c.objectRef,
+            sourceId: c.sourceId,
+          },
+        )
+        continue
+      }
+
+      const subjectKind = c.subjectKind
+      const objectKind = c.objectKind
+
+      const logicalKey = deriveLogicalSourceKey(c.sourceId, targetHash)
+
+      if (
+        !warnedWindowsDriveColonInSourceId &&
+        evidenceSourceIdMayHaveWindowsDriveColon(c.sourceId)
+      ) {
+        warnedWindowsDriveColonInSourceId = true
+        logger.warn(
+          "deduplicateAndStore: source_id may contain a Windows drive colon; colon-delimited evidence keys can be ambiguous",
+          {
+            repositoryId: state.repositoryId,
+            orgId,
+            sourceId: c.sourceId,
+          },
+        )
+      }
+
+      const existingClaimWithEvidence = await db
+        .select({
+          claimId: claims.id,
+          sourceId: claimEvidence.sourceId,
+        })
+        .from(claims)
+        .innerJoin(claimEvidence, eq(claims.id, claimEvidence.claimId))
+        .where(
+          and(
+            eq(claims.orgId, orgId),
+            eq(claims.subjectId, subjectId),
+            eq(claims.predicate, c.predicate),
+            eq(claims.objectId, objectId),
+            or(
+              eq(claimEvidence.logicalSourceKey, logicalKey),
+              eq(claimEvidence.sourceId, c.sourceId),
+              and(
+                isNull(claimEvidence.logicalSourceKey),
+                eq(derivedKeyExpr, logicalKey),
+              ),
             ),
           ),
-        ),
-      )
-      .limit(1)
+        )
+        .limit(1)
 
-    // Duplicate evidence: skip DB writes, but still queue projection so the graph
-    // stays in sync (e.g. first projection failed, graph was wiped, or dev DB restored).
-    if (existingClaimWithEvidence[0]) {
-      claimsDuplicateEvidenceSkipped++
-      const cid = existingClaimWithEvidence[0].claimId
-      claimIdsToFetch.push(cid)
-      claimIdToKinds.set(cid, { subjectKind, objectKind })
-      continue
-    }
+      // Duplicate evidence: skip DB writes, but still queue projection so the graph
+      // stays in sync (e.g. first projection failed, graph was wiped, or dev DB restored).
+      if (existingClaimWithEvidence[0]) {
+        claimsDuplicateEvidenceSkipped++
+        const cid = existingClaimWithEvidence[0].claimId
+        claimIdsToFetch.push(cid)
+        claimIdToKinds.set(cid, { subjectKind, objectKind })
+        continue
+      }
 
-    const existingClaim = await db
-      .select({ id: claims.id })
-      .from(claims)
-      .where(
-        and(
-          eq(claims.orgId, orgId),
-          eq(claims.subjectId, subjectId),
-          eq(claims.predicate, c.predicate),
-          eq(claims.objectId, objectId),
-        ),
-      )
-      .limit(1)
+      const existingClaim = await db
+        .select({ id: claims.id })
+        .from(claims)
+        .where(
+          and(
+            eq(claims.orgId, orgId),
+            eq(claims.subjectId, subjectId),
+            eq(claims.predicate, c.predicate),
+            eq(claims.objectId, objectId),
+          ),
+        )
+        .limit(1)
 
-    if (existingClaim[0]) {
-      claimsEvidenceAddedToExisting++
-      await addEvidence({
-        claimId: existingClaim[0].id,
-        sourceType: c.sourceType,
-        sourceId: c.sourceId,
-        logicalSourceKey: logicalKey,
-        extractionMethod: c.extractionMethod,
-        confidence: c.confidence,
-        provenance: c.provenance ?? null,
-      })
-      claimIdsToFetch.push(existingClaim[0].id)
-      claimIdToKinds.set(existingClaim[0].id, {
-        subjectKind,
-        objectKind,
-      })
-    } else {
-      claimsNewCreated++
-      const claimId = await createClaim(
-        {
-          subjectId,
-          predicate: c.predicate,
-          objectId,
-          subjectKind,
-          objectKind,
-        },
-        {
+      if (existingClaim[0]) {
+        claimsEvidenceAddedToExisting++
+        await addEvidence({
+          claimId: existingClaim[0].id,
           sourceType: c.sourceType,
           sourceId: c.sourceId,
           logicalSourceKey: logicalKey,
           extractionMethod: c.extractionMethod,
           confidence: c.confidence,
           provenance: c.provenance ?? null,
-        },
+        })
+        claimIdsToFetch.push(existingClaim[0].id)
+        claimIdToKinds.set(existingClaim[0].id, {
+          subjectKind,
+          objectKind,
+        })
+      } else {
+        claimsNewCreated++
+        const claimId = await createClaim(
+          {
+            subjectId,
+            predicate: c.predicate,
+            objectId,
+            subjectKind,
+            objectKind,
+          },
+          {
+            sourceType: c.sourceType,
+            sourceId: c.sourceId,
+            logicalSourceKey: logicalKey,
+            extractionMethod: c.extractionMethod,
+            confidence: c.confidence,
+            provenance: c.provenance ?? null,
+          },
+        )
+        const agg = aggregateConfidence([
+          {
+            sourceType: c.sourceType,
+            extractionMethod: c.extractionMethod,
+            confidence: c.confidence,
+            observedAt: now,
+          },
+        ])
+        claimsForProjection.push({
+          id: claimId,
+          subjectId,
+          objectId,
+          subjectKind,
+          objectKind,
+          predicate: c.predicate,
+          status: "active",
+          aggregatedConfidence: agg,
+          sourceCount: 1,
+          lastObservedAt: nowIso,
+          validFrom: null,
+          validTo: null,
+        })
+      }
+    }
+
+    if (claimIdsToFetch.length > 0) {
+      const fetchedClaims = await db
+        .select({
+          id: claims.id,
+          subjectId: claims.subjectId,
+          objectId: claims.objectId,
+          predicate: claims.predicate,
+          status: claims.status,
+          aggregatedConfidence: claims.aggregatedConfidence,
+          lastObservedAt: claims.lastObservedAt,
+          validFrom: claims.validFrom,
+          validTo: claims.validTo,
+        })
+        .from(claims)
+        .where(
+          and(eq(claims.orgId, orgId), inArray(claims.id, claimIdsToFetch)),
+        )
+
+      const evidenceCounts = Object.fromEntries(
+        (
+          await db
+            .select({
+              claimId: claimEvidence.claimId,
+              count: sql<number>`count(*)::int`,
+            })
+            .from(claimEvidence)
+            .where(inArray(claimEvidence.claimId, claimIdsToFetch))
+            .groupBy(claimEvidence.claimId)
+        ).map((r) => [r.claimId, r.count]),
       )
-      const agg = aggregateConfidence([
-        {
-          sourceType: c.sourceType,
-          extractionMethod: c.extractionMethod,
-          confidence: c.confidence,
-          observedAt: now,
-        },
-      ])
-      claimsForProjection.push({
-        id: claimId,
-        subjectId,
-        objectId,
-        subjectKind,
-        objectKind,
-        predicate: c.predicate,
-        status: "active",
-        aggregatedConfidence: agg,
-        sourceCount: 1,
-        lastObservedAt: nowIso,
-        validFrom: null,
-        validTo: null,
-      })
+
+      for (const row of fetchedClaims) {
+        const kinds = claimIdToKinds.get(row.id)
+        if (!kinds) continue
+        claimsForProjection.push({
+          id: row.id,
+          subjectId: row.subjectId,
+          objectId: row.objectId,
+          subjectKind: kinds.subjectKind,
+          objectKind: kinds.objectKind,
+          predicate: row.predicate,
+          status: row.status,
+          aggregatedConfidence: row.aggregatedConfidence,
+          sourceCount: evidenceCounts[row.id] ?? 1,
+          lastObservedAt: row.lastObservedAt.toISOString(),
+          validFrom: row.validFrom?.toISOString() ?? null,
+          validTo: row.validTo?.toISOString() ?? null,
+        })
+      }
     }
-  }
 
-  if (claimIdsToFetch.length > 0) {
-    const fetchedClaims = await db
-      .select({
-        id: claims.id,
-        subjectId: claims.subjectId,
-        objectId: claims.objectId,
-        predicate: claims.predicate,
-        status: claims.status,
-        aggregatedConfidence: claims.aggregatedConfidence,
-        lastObservedAt: claims.lastObservedAt,
-        validFrom: claims.validFrom,
-        validTo: claims.validTo,
-      })
-      .from(claims)
-      .where(and(eq(claims.orgId, orgId), inArray(claims.id, claimIdsToFetch)))
+    const uniqueObjectIds = [...new Set(objectIds)]
+    const uniqueTouchedObjectIds = [...new Set(touchedObjectIds)]
+    logger.set({
+      step: "codeIngestion.deduplicateAndStore.summary",
+      repositoryId: state.repositoryId,
+      orgId: state.orgId,
+      roots: state.roots,
+      extractedObjectsCount: extractedObjects.length,
+      extractedClaimsCount: extractedClaims.length,
+      objectsUpsertedCount: uniqueObjectIds.length,
+      claimsObserved: extractedClaims.length,
+      claimsNewCreated,
+      claimsEvidenceAddedToExisting,
+      claimsDuplicateEvidenceSkipped,
+      claimsSkippedUnresolvedRef,
+      claimsForProjectionCount: claimsForProjection.length,
+    })
+    logger.info("deduplicateAndStore summary")
 
-    const evidenceCounts = Object.fromEntries(
-      (
-        await db
-          .select({
-            claimId: claimEvidence.claimId,
-            count: sql<number>`count(*)::int`,
-          })
-          .from(claimEvidence)
-          .where(inArray(claimEvidence.claimId, claimIdsToFetch))
-          .groupBy(claimEvidence.claimId)
-      ).map((r) => [r.claimId, r.count]),
-    )
-
-    for (const row of fetchedClaims) {
-      const kinds = claimIdToKinds.get(row.id)
-      if (!kinds) continue
-      claimsForProjection.push({
-        id: row.id,
-        subjectId: row.subjectId,
-        objectId: row.objectId,
-        subjectKind: kinds.subjectKind,
-        objectKind: kinds.objectKind,
-        predicate: row.predicate,
-        status: row.status,
-        aggregatedConfidence: row.aggregatedConfidence,
-        sourceCount: evidenceCounts[row.id] ?? 1,
-        lastObservedAt: row.lastObservedAt.toISOString(),
-        validFrom: row.validFrom?.toISOString() ?? null,
-        validTo: row.validTo?.toISOString() ?? null,
-      })
+    return {
+      objectIds: uniqueObjectIds,
+      touchedObjectIds: uniqueTouchedObjectIds,
+      claimsForProjection,
     }
-  }
-
-  const uniqueObjectIds = [...new Set(objectIds)]
-  const uniqueTouchedObjectIds = [...new Set(touchedObjectIds)]
-  logger.set({
-    step: "codeIngestion.deduplicateAndStore.summary",
-    repositoryId: state.repositoryId,
-    orgId: state.orgId,
-    roots: state.roots,
-    extractedObjectsCount: extractedObjects.length,
-    extractedClaimsCount: extractedClaims.length,
-    objectsUpsertedCount: uniqueObjectIds.length,
-    claimsObserved: extractedClaims.length,
-    claimsNewCreated,
-    claimsEvidenceAddedToExisting,
-    claimsDuplicateEvidenceSkipped,
-    claimsSkippedUnresolvedRef,
-    claimsForProjectionCount: claimsForProjection.length,
-  })
-  logger.info("deduplicateAndStore summary")
-
-  return {
-    objectIds: uniqueObjectIds,
-    touchedObjectIds: uniqueTouchedObjectIds,
-    claimsForProjection,
-  }
-}
+  },
+)

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/embed.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/embed.ts
@@ -1,14 +1,9 @@
 import { and, eq, inArray } from "drizzle-orm"
-import { requireCurrentOrgId } from "../../../auth/context.js"
-import { getOrgDb } from "../../../db/client.js"
+import { getSystemDb } from "../../../db/client.js"
 import { objects } from "../../../db/schema/objects.js"
 import { getLogger } from "../../../observability/logger.js"
 import { generateEmbedding } from "../../../retrieval/services/modelProvider.js"
-import {
-  computeEmbeddingSearchContentForObject,
-  upsertRetrievalEmbedding,
-  upsertRetrievalSearch,
-} from "../../../retrieval/services/retrievalObjectWrite.js"
+import { computeEmbeddingSearchContentForObject } from "../../../retrieval/services/retrievalObjectWrite.js"
 import type { CodeIngestionState } from "../schemas.js"
 
 /**
@@ -46,8 +41,8 @@ export async function embed(
     return {}
   }
 
-  const orgId = requireCurrentOrgId()
-  const db = getOrgDb()
+  const orgId = state.orgId
+  const db = getSystemDb()
 
   const rows = await db
     .select({
@@ -74,8 +69,14 @@ export async function embed(
     }
 
     const embedding = await generateEmbedding(searchContent)
-    await upsertRetrievalEmbedding(orgId, obj.id, embedding)
-    await upsertRetrievalSearch(orgId, obj.id, searchContent)
+    await db
+      .update(objects)
+      .set({
+        embedding,
+        searchContent,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(objects.id, obj.id), eq(objects.orgId, orgId)))
     objectsEmbedded++
   }
 

--- a/apps/backend/src/graphs/codeIngestionGraph/schemas.test.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/schemas.test.ts
@@ -18,7 +18,59 @@ const sampleClaim = {
   validTo: null,
 } as const
 
+const sampleExtractedObject = {
+  kind: "Service" as const,
+  deduplicationKey: "svc:backend",
+  name: "backend",
+} as const
+
+const sampleExtractedClaim = {
+  subjectRef: "svc:backend",
+  subjectKind: "Service",
+  objectRef: "inu:readme",
+  objectKind: "InstructionUnit",
+  predicate: "HAS_INSTRUCTION",
+  sourceId: "repo_1",
+  sourceType: "repository" as const,
+  extractionMethod: "llm" as const,
+  confidence: 0.9,
+} as const
+
 describe("CodeIngestionStateSchema", () => {
+  it("concat-merges extractedObjects across parallel branch updates", () => {
+    const channels = schemaMetaRegistry.getChannelsForSchema(
+      CodeIngestionStateSchema,
+    )
+    const ch = channels.extractedObjects
+    ch.update([
+      [sampleExtractedObject],
+      [{ ...sampleExtractedObject, deduplicationKey: "svc:ui" }],
+    ])
+    const merged = ch.get()
+    expect(merged).toHaveLength(2)
+    expect(merged.map((o) => o.deduplicationKey)).toEqual([
+      "svc:backend",
+      "svc:ui",
+    ])
+  })
+
+  it("concat-merges extractedClaims across parallel branch updates", () => {
+    const channels = schemaMetaRegistry.getChannelsForSchema(
+      CodeIngestionStateSchema,
+    )
+    const ch = channels.extractedClaims
+    ch.update([
+      [sampleExtractedClaim],
+      [{ ...sampleExtractedClaim, objectRef: "inu:setup" }],
+    ])
+    const merged = ch.get()
+    expect(merged).toHaveLength(2)
+    expect(merged.map((c) => c.objectRef)).toEqual([
+      "inu:readme",
+      "inu:setup",
+    ])
+  })
+
   it("concat-merges claimsForProjection across parallel branch updates", () => {
     const channels = schemaMetaRegistry.getChannelsForSchema(
       CodeIngestionStateSchema,

--- a/apps/backend/src/lib/agentToolRuntime.test.ts
+++ b/apps/backend/src/lib/agentToolRuntime.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest"
 
 vi.mock("../models/repositories.js", () => ({
-  getRepository: vi.fn(),
-  listRepositories: vi.fn(),
+  getRepositoryForOrg: vi.fn(),
+  listRepositoriesForOrg: vi.fn(),
 }))
 
 import { getFileTool } from "../tools/getFile.js"

--- a/apps/backend/src/models/repositories.test.ts
+++ b/apps/backend/src/models/repositories.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const requireCurrentOrgIdMock = vi.hoisted(() => vi.fn())
 const requireCurrentOrgSlugMock = vi.hoisted(() => vi.fn())
 const getOrgDbMock = vi.hoisted(() => vi.fn())
+const getSystemDbMock = vi.hoisted(() => vi.fn())
 const withGraphClientMock = vi.hoisted(() => vi.fn())
 const deleteRepositoryWithCleanupMock = vi.hoisted(() => vi.fn())
 
@@ -13,6 +14,7 @@ vi.mock("../auth/context.js", () => ({
 
 vi.mock("../db/client.js", () => ({
   getOrgDb: getOrgDbMock,
+  getSystemDb: getSystemDbMock,
 }))
 
 vi.mock("../platform/graph/client.js", () => ({
@@ -24,13 +26,16 @@ vi.mock("../domain/repositoryDeletion.js", () => ({
 }))
 
 import {
+  getRepositoryForOrg,
   listRepositoriesForGithubConnection,
+  listRepositoriesForOrg,
   pruneGithubConnectionRepositoriesNotInGitUrls,
 } from "./repositories.js"
 
 const orgId = "org_1"
 const githubConnectionId = "con_github"
 const orgSlug = "acme"
+const repositoryId = "repo_AAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 function mockLinkedRepos(
   rows: Array<{ id: string; gitUrl: string }>,
@@ -44,13 +49,29 @@ function mockLinkedRepos(
   })
 }
 
-function mockRepositoriesWithZoekt(rows: Array<Record<string, unknown>>) {
+function mockRepositoriesWithZoekt(
+  rows: Array<Record<string, unknown>>,
+  dbMock: typeof getOrgDbMock | typeof getSystemDbMock = getOrgDbMock,
+) {
   const where = vi.fn().mockResolvedValue(rows)
   const innerJoin = vi.fn().mockReturnValue({ where })
   const from = vi.fn().mockReturnValue({ innerJoin })
   const select = vi.fn().mockReturnValue({ from })
-  getOrgDbMock.mockReturnValue({ select })
+  dbMock.mockReturnValue({ select })
   return { select, from, innerJoin, where }
+}
+
+function mockRepositoryWithZoekt(
+  row: Record<string, unknown> | null,
+  dbMock: typeof getSystemDbMock = getSystemDbMock,
+) {
+  const limit = vi.fn().mockResolvedValue(row ? [row] : [])
+  const where = vi.fn().mockReturnValue({ limit })
+  const innerJoin = vi.fn().mockReturnValue({ where })
+  const from = vi.fn().mockReturnValue({ innerJoin })
+  const select = vi.fn().mockReturnValue({ from })
+  dbMock.mockReturnValue({ select })
+  return { select, from, innerJoin, where, limit }
 }
 
 describe("listRepositoriesForGithubConnection", () => {
@@ -80,6 +101,72 @@ describe("listRepositoriesForGithubConnection", () => {
     await expect(
       listRepositoriesForGithubConnection(githubConnectionId),
     ).resolves.toEqual(rows)
+    expect(query.where).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("getRepositoryForOrg", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("queries system db with org and repository id filters", async () => {
+    const row = {
+      id: repositoryId,
+      orgId,
+      name: "acme/app",
+      gitUrl: "https://github.com/acme/app.git",
+      indexReady: true,
+      indexingReason: null,
+      lastIngestedHash: "abc123",
+      githubConnectionId: null,
+      createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+      zoektRepoId: 42,
+    }
+    const query = mockRepositoryWithZoekt(row)
+
+    await expect(getRepositoryForOrg(orgId, repositoryId)).resolves.toEqual(row)
+    expect(getSystemDbMock).toHaveBeenCalledTimes(1)
+    expect(query.where).toHaveBeenCalledTimes(1)
+    expect(query.limit).toHaveBeenCalledWith(1)
+  })
+
+  it("returns null when no row matches (cross-tenant id)", async () => {
+    mockRepositoryWithZoekt(null)
+
+    await expect(
+      getRepositoryForOrg(orgId, repositoryId),
+    ).resolves.toBeNull()
+    expect(getSystemDbMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("listRepositoriesForOrg", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("queries system db filtered by org id", async () => {
+    const rows = [
+      {
+        id: repositoryId,
+        orgId,
+        name: "acme/app",
+        gitUrl: "https://github.com/acme/app.git",
+        indexReady: true,
+        indexingReason: null,
+        lastIngestedHash: null,
+        githubConnectionId: null,
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+        zoektRepoId: 1,
+      },
+    ]
+    const query = mockRepositoriesWithZoekt(rows, getSystemDbMock)
+
+    await expect(listRepositoriesForOrg(orgId)).resolves.toEqual(rows)
+    expect(getSystemDbMock).toHaveBeenCalledTimes(1)
     expect(query.where).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/backend/src/models/repositories.ts
+++ b/apps/backend/src/models/repositories.ts
@@ -1,6 +1,6 @@
 import { and, count, eq } from "drizzle-orm"
 import { requireCurrentOrgId, requireCurrentOrgSlug } from "../auth/context.js"
-import { getOrgDb, withOrgDbContext } from "../db/client.js"
+import { type Db, getOrgDb, getSystemDb, withOrgDbContext } from "../db/client.js"
 import { repositories } from "../db/schema/repositories.js"
 import { repositoryCheckouts } from "../db/schema/repository_checkouts.js"
 import { deleteRepositoryWithCleanup } from "../domain/repositoryDeletion.js"
@@ -14,25 +14,23 @@ export type RepositoryWithSearch = typeof repositories.$inferSelect & {
   zoektRepoId: number
 }
 
-async function selectRepositoriesWithZoekt(
-  db: ReturnType<typeof getOrgDb>,
-  orgId: string,
-  githubConnectionId?: string,
-) {
+const repositoryWithZoektSelect = {
+  id: repositories.id,
+  orgId: repositories.orgId,
+  name: repositories.name,
+  gitUrl: repositories.gitUrl,
+  indexReady: repositories.indexReady,
+  indexingReason: repositories.indexingReason,
+  lastIngestedHash: repositories.lastIngestedHash,
+  githubConnectionId: repositories.githubConnectionId,
+  createdAt: repositories.createdAt,
+  updatedAt: repositories.updatedAt,
+  zoektRepoId: repositoryCheckouts.zoektRepoId,
+}
+
+function repositoryWithZoektJoin(db: Db) {
   return db
-    .select({
-      id: repositories.id,
-      orgId: repositories.orgId,
-      name: repositories.name,
-      gitUrl: repositories.gitUrl,
-      indexReady: repositories.indexReady,
-      indexingReason: repositories.indexingReason,
-      lastIngestedHash: repositories.lastIngestedHash,
-      githubConnectionId: repositories.githubConnectionId,
-      createdAt: repositories.createdAt,
-      updatedAt: repositories.updatedAt,
-      zoektRepoId: repositoryCheckouts.zoektRepoId,
-    })
+    .select(repositoryWithZoektSelect)
     .from(repositories)
     .innerJoin(
       repositoryCheckouts,
@@ -41,14 +39,34 @@ async function selectRepositoriesWithZoekt(
         eq(repositoryCheckouts.checkoutKey, DEFAULT_CHECKOUT_KEY),
       ),
     )
+}
+
+async function selectRepositoriesWithZoekt(
+  db: Db,
+  orgId: string,
+  githubConnectionId?: string,
+) {
+  return repositoryWithZoektJoin(db).where(
+    githubConnectionId
+      ? and(
+          eq(repositories.orgId, orgId),
+          eq(repositories.githubConnectionId, githubConnectionId),
+        )
+      : eq(repositories.orgId, orgId),
+  )
+}
+
+async function selectRepositoryWithZoekt(
+  db: Db,
+  orgId: string,
+  repositoryId: string,
+) {
+  const [row] = await repositoryWithZoektJoin(db)
     .where(
-      githubConnectionId
-        ? and(
-            eq(repositories.orgId, orgId),
-            eq(repositories.githubConnectionId, githubConnectionId),
-          )
-        : eq(repositories.orgId, orgId),
+      and(eq(repositories.id, repositoryId), eq(repositories.orgId, orgId)),
     )
+    .limit(1)
+  return row ?? null
 }
 
 export const listRepositories = async (): Promise<RepositoryWithSearch[]> => {
@@ -118,12 +136,19 @@ export async function pruneGithubConnectionRepositoriesNotInGitUrls(
   }
 }
 
-/** Returns repositories for org. Use when orgId is from state (e.g. graph nodes).
- *  Assumes caller has established org DB context. */
+/** Returns repositories for org via system DB (explicit orgId filter). */
 export const listRepositoriesForOrg = async (
   orgId: string,
 ): Promise<RepositoryWithSearch[]> => {
-  return selectRepositoriesWithZoekt(getOrgDb(), orgId)
+  return selectRepositoriesWithZoekt(getSystemDb(), orgId)
+}
+
+/** Single repository for org via system DB (explicit orgId + repositoryId filter). */
+export const getRepositoryForOrg = async (
+  orgId: string,
+  repositoryId: string,
+): Promise<RepositoryWithSearch | null> => {
+  return selectRepositoryWithZoekt(getSystemDb(), orgId, repositoryId)
 }
 
 export const getRepository = async (
@@ -131,33 +156,7 @@ export const getRepository = async (
 ): Promise<RepositoryWithSearch | null> => {
   const orgId = requireCurrentOrgId()
   const db = getOrgDb()
-  const [row] = await db
-    .select({
-      id: repositories.id,
-      orgId: repositories.orgId,
-      name: repositories.name,
-      gitUrl: repositories.gitUrl,
-      indexReady: repositories.indexReady,
-      indexingReason: repositories.indexingReason,
-      lastIngestedHash: repositories.lastIngestedHash,
-      githubConnectionId: repositories.githubConnectionId,
-      createdAt: repositories.createdAt,
-      updatedAt: repositories.updatedAt,
-      zoektRepoId: repositoryCheckouts.zoektRepoId,
-    })
-    .from(repositories)
-    .innerJoin(
-      repositoryCheckouts,
-      and(
-        eq(repositoryCheckouts.repositoryId, repositories.id),
-        eq(repositoryCheckouts.checkoutKey, DEFAULT_CHECKOUT_KEY),
-      ),
-    )
-    .where(
-      and(eq(repositories.id, repositoryId), eq(repositories.orgId, orgId)),
-    )
-    .limit(1)
-  return row ?? null
+  return selectRepositoryWithZoekt(db, orgId, repositoryId)
 }
 
 /** For worker/ingestion paths: requires org DB context (`withOrgDbContext`). */

--- a/apps/backend/src/retrieval/index.ts
+++ b/apps/backend/src/retrieval/index.ts
@@ -71,9 +71,5 @@ export {
   corroborationReranker,
   passThroughReranker,
 } from "./services/reranker.js"
-export {
-  upsertRetrievalEmbedding,
-  upsertRetrievalSearch,
-} from "./services/retrievalObjectWrite.js"
 export type { VectorSearchResult } from "./services/vectorSearch.js"
 export { vectorSearch } from "./services/vectorSearch.js"

--- a/apps/backend/src/retrieval/services/graphProjection.ts
+++ b/apps/backend/src/retrieval/services/graphProjection.ts
@@ -3,7 +3,7 @@ import {
   requireCurrentOrgId,
   requireCurrentOrgSlug,
 } from "../../auth/context.js"
-import { getOrgDb } from "../../db/client.js"
+import { getOrgDb, getSystemDb } from "../../db/client.js"
 import { claimEvidence } from "../../db/schema/claim_evidence.js"
 import { claims } from "../../db/schema/claims.js"
 import { objects } from "../../db/schema/objects.js"
@@ -62,6 +62,38 @@ function extractNodeProps(
   return props
 }
 
+async function loadEntityMapForProjection(
+  orgId: string,
+  uniqueIds: Set<string>,
+): Promise<Map<string, { kind: string; payload: Record<string, unknown> }>> {
+  const entityMap = new Map<
+    string,
+    { kind: string; payload: Record<string, unknown> }
+  >()
+
+  if (uniqueIds.size === 0) return entityMap
+
+  const db = getSystemDb()
+  const ids = [...uniqueIds]
+  const rows = await db
+    .select({
+      id: objects.id,
+      kind: objects.kind,
+      payload: objects.payload,
+    })
+    .from(objects)
+    .where(and(eq(objects.orgId, orgId), inArray(objects.id, ids)))
+
+  for (const r of rows) {
+    entityMap.set(r.id, {
+      kind: r.kind,
+      payload: (r.payload ?? {}) as Record<string, unknown>,
+    })
+  }
+
+  return entityMap
+}
+
 /**
  * Projects claims from graph state into FalkorDB.
  * Stores architecture/semantic nodes with enriched properties and predicate-typed edges.
@@ -96,30 +128,7 @@ export async function projectClaimsFromState(
     }
   }
 
-  const db = getOrgDb()
-  const entityMap = new Map<
-    string,
-    { kind: string; payload: Record<string, unknown> }
-  >()
-
-  if (uniqueIds.size > 0) {
-    const ids = [...uniqueIds]
-    const rows = await db
-      .select({
-        id: objects.id,
-        kind: objects.kind,
-        payload: objects.payload,
-      })
-      .from(objects)
-      .where(and(eq(objects.orgId, resolvedOrgId), inArray(objects.id, ids)))
-
-    for (const r of rows) {
-      entityMap.set(r.id, {
-        kind: r.kind,
-        payload: (r.payload ?? {}) as Record<string, unknown>,
-      })
-    }
-  }
+  const entityMap = await loadEntityMapForProjection(resolvedOrgId, uniqueIds)
 
   logger.info("projectClaimsFromState: projecting claims to graph", {
     claimCount: claims.length,

--- a/apps/backend/src/retrieval/services/retrievalObjectWrite.ts
+++ b/apps/backend/src/retrieval/services/retrievalObjectWrite.ts
@@ -113,37 +113,3 @@ export async function upsertRetrievalObjectByDeduplicationKey(
   })
   return { id, needsEmbeddingRefresh: true }
 }
-
-/**
- * Upserts embedding for an object row. Replaces existing embedding.
- * Uses getOrgDb() - must be called within org context.
- */
-export async function upsertRetrievalEmbedding(
-  orgId: string,
-  objectId: string,
-  embedding: number[],
-): Promise<void> {
-  const db = getOrgDb()
-  const now = new Date()
-  await db
-    .update(objects)
-    .set({ embedding, updatedAt: now })
-    .where(and(eq(objects.id, objectId), eq(objects.orgId, orgId)))
-}
-
-/**
- * Upserts BM25 search text on the object row. Replaces existing content.
- * Uses getOrgDb() - must be called within org context.
- */
-export async function upsertRetrievalSearch(
-  _orgId: string,
-  objectId: string,
-  content: string,
-): Promise<void> {
-  const db = getOrgDb()
-  const now = new Date()
-  await db
-    .update(objects)
-    .set({ searchContent: content, updatedAt: now })
-    .where(eq(objects.id, objectId))
-}

--- a/apps/backend/src/tools/codegraphTools.ts
+++ b/apps/backend/src/tools/codegraphTools.ts
@@ -1,8 +1,9 @@
 import { tool } from "langchain"
 import { z } from "zod/v3"
+import { requireCurrentOrgId } from "../auth/context.js"
 import { repositoryIdSchema, toToon } from "../lib/agentToolRuntime.js"
 import { assertStructuralGraphAnchor } from "../lib/repoExplorerPlanner.js"
-import { getRepository } from "../models/repositories.js"
+import { getRepositoryForOrg } from "../models/repositories.js"
 import { codesearchGraphQuery } from "./codesearchGraph.js"
 
 const anchorSchema = z.object({
@@ -13,7 +14,10 @@ const anchorSchema = z.object({
 
 export const graphFindSymbolTool = tool(
   async ({ repositoryId, symbol, filePath, module, checkoutKey }) => {
-    const repository = await getRepository(repositoryId)
+    const repository = await getRepositoryForOrg(
+      requireCurrentOrgId(),
+      repositoryId,
+    )
     if (!repository) {
       throw new Error(`repository not found: ${repositoryId}`)
     }
@@ -51,7 +55,10 @@ Requires checkoutKey (default branch uses checkoutKey "default"). Provide symbol
 
 export const graphCallersTool = tool(
   async ({ repositoryId, symbol, filePath, module, checkoutKey, limit }) => {
-    const repository = await getRepository(repositoryId)
+    const repository = await getRepositoryForOrg(
+      requireCurrentOrgId(),
+      repositoryId,
+    )
     if (!repository) {
       throw new Error(`repository not found: ${repositoryId}`)
     }
@@ -87,7 +94,10 @@ export const graphCallersTool = tool(
 
 export const graphCalleesTool = tool(
   async ({ repositoryId, symbol, filePath, module, checkoutKey, limit }) => {
-    const repository = await getRepository(repositoryId)
+    const repository = await getRepositoryForOrg(
+      requireCurrentOrgId(),
+      repositoryId,
+    )
     if (!repository) {
       throw new Error(`repository not found: ${repositoryId}`)
     }

--- a/apps/backend/src/tools/getFile.ts
+++ b/apps/backend/src/tools/getFile.ts
@@ -1,5 +1,6 @@
 import { tool } from "langchain"
 import { z } from "zod/v3"
+import { requireCurrentOrgId } from "../auth/context.js"
 import { signUpstreamJwt } from "../auth/upstreamJwt.js"
 import { parseEnv } from "../config/env.js"
 import {
@@ -7,7 +8,7 @@ import {
   repositoryIdSchema,
   toToon,
 } from "../lib/agentToolRuntime.js"
-import { getRepository } from "../models/repositories.js"
+import { getRepositoryForOrg } from "../models/repositories.js"
 
 /** Hard cap for any single read (UTF-8 chars). */
 const MAX_GET_FILE_CHARS = 96_000
@@ -27,7 +28,10 @@ export const getFileTool = tool(
     maxChars,
     mode = "preview",
   }) => {
-    const repository = await getRepository(repositoryId)
+    const repository = await getRepositoryForOrg(
+      requireCurrentOrgId(),
+      repositoryId,
+    )
     if (!repository) {
       throw new Error(`repository not found: ${repositoryId}`)
     }

--- a/apps/backend/src/tools/listFiles.ts
+++ b/apps/backend/src/tools/listFiles.ts
@@ -1,5 +1,6 @@
 import { tool } from "langchain"
 import { z } from "zod/v3"
+import { requireCurrentOrgId } from "../auth/context.js"
 import { signUpstreamJwt } from "../auth/upstreamJwt.js"
 import { parseEnv } from "../config/env.js"
 import {
@@ -7,14 +8,17 @@ import {
   repositoryIdSchema,
   toToon,
 } from "../lib/agentToolRuntime.js"
-import { getRepository } from "../models/repositories.js"
+import { getRepositoryForOrg } from "../models/repositories.js"
 
 const MAX_LIST_FILES_ENTRIES = 500
 const DEFAULT_LIST_LIMIT = 100
 
 export const listFilesTool = tool(
   async ({ repositoryId, path, limit, offset }) => {
-    const repository = await getRepository(repositoryId)
+    const repository = await getRepositoryForOrg(
+      requireCurrentOrgId(),
+      repositoryId,
+    )
     if (!repository) {
       return toToon({
         error: "repository_not_found",

--- a/apps/backend/src/tools/listRepositories.ts
+++ b/apps/backend/src/tools/listRepositories.ts
@@ -1,11 +1,12 @@
 import { tool } from "langchain"
-import { listRepositories } from "../models/repositories.js"
 import { z } from "zod"
+import { requireCurrentOrgId } from "../auth/context.js"
+import { listRepositoriesForOrg } from "../models/repositories.js"
 import { toToon } from "../lib/agentToolRuntime.js"
 
 export const listRepositoriesTool = tool(
   async () => {
-    const repositories = await listRepositories()
+    const repositories = await listRepositoriesForOrg(requireCurrentOrgId())
     return toToon({ repositories })
   },
   {

--- a/apps/backend/src/tools/search.ts
+++ b/apps/backend/src/tools/search.ts
@@ -1,7 +1,8 @@
 import { tool } from "langchain"
 import { z } from "zod/v3"
+import { requireCurrentOrgId } from "../auth/context.js"
 import { repositoryIdSchema, toToon } from "../lib/agentToolRuntime.js"
-import { getRepository } from "../models/repositories.js"
+import { getRepositoryForOrg } from "../models/repositories.js"
 import {
   isZoektSearchClientFailure,
   zoektSearchRepository,
@@ -14,7 +15,10 @@ import {
 
 export const searchTool = tool(
   async ({ repositoryId, query, detail = "compact" }) => {
-    const repository = await getRepository(repositoryId)
+    const repository = await getRepositoryForOrg(
+      requireCurrentOrgId(),
+      repositoryId,
+    )
     if (!repository) {
       return toToon({
         error: "repository_not_found",

--- a/apps/backend/src/tools/symbolTools.ts
+++ b/apps/backend/src/tools/symbolTools.ts
@@ -1,7 +1,8 @@
 import { tool } from "langchain"
 import { z } from "zod/v3"
+import { requireCurrentOrgId } from "../auth/context.js"
 import { repositoryIdSchema, toToon } from "../lib/agentToolRuntime.js"
-import { getRepository } from "../models/repositories.js"
+import { getRepositoryForOrg } from "../models/repositories.js"
 import {
   isZoektSearchClientFailure,
   zoektSearchRepository,
@@ -21,7 +22,10 @@ const languageSchema = z
 
 export const findSymbolDefinitionsTool = tool(
   async ({ repositoryId, symbol, language }) => {
-    const repository = await getRepository(repositoryId)
+    const repository = await getRepositoryForOrg(
+      requireCurrentOrgId(),
+      repositoryId,
+    )
     if (!repository) {
       return toToon({
         error: "repository_not_found",
@@ -77,7 +81,10 @@ References (uses) are not exact; use find_symbol_references for heuristic occurr
 
 export const findSymbolReferencesTool = tool(
   async ({ repositoryId, symbol, language }) => {
-    const repository = await getRepository(repositoryId)
+    const repository = await getRepositoryForOrg(
+      requireCurrentOrgId(),
+      repositoryId,
+    )
     if (!repository) {
       return toToon({
         error: "repository_not_found",


### PR DESCRIPTION
## Summary

- **Narrow org DB transaction scope in code ingestion**: Remove blanket `withNodeOrgDbContext` wrapping from graph/subgraph node registration; only `deduplicateAndStore` establishes org DB context (with extended idle-in-transaction timeout) since it performs multi-step upserts. Other nodes (`embed`, `project`, repo explorer steps) no longer hold an open transaction while doing slow I/O (LLM, embeddings, graph projection).
- **Move persist pipeline to the parent graph**: `deduplicateAndStore`, `project`, and `embed` now run on the parent `codeIngestionGraph` after parallel `extractForRoot` branches merge, instead of inside each extraction subgraph instance. The extraction subgraph only performs LLM extraction and fans out to `END` per branch.
- **Fix extraction subgraph for OpenWorkflow + parent merge**: Replace the subgraph fan-in edge to `deduplicateAndStore` with per-branch `END` edges so OpenWorkflow can import the workflow. Add an explicit `ExtractionOutputAnnotation` (`extractedObjects`, `extractedClaims`) so merged extraction results flow back to the parent state.
- **Use system DB for read paths and embedding writes**: `embed` updates `embedding` + `searchContent` in one system-DB write keyed by `state.orgId`; graph projection loads object rows via system DB; repository lookups for agent tools use new `getRepositoryForOrg` / `listRepositoriesForOrg` with explicit org filters instead of org-scoped connection context.
- **Remove redundant helpers**: Drop `upsertRetrievalEmbedding` / `upsertRetrievalSearch` in favor of direct `objects` updates; refactor repository Zoekt join into shared helpers.
- **CI**: Tag PR deploy images with `github.event.pull_request.head.sha` (branch head) instead of `github.sha` (merge commit), so preview environments match the PR branch.
- **Release**: Add `@ctxpipe/aws-cdk` patch changeset for the idle-transaction fix.

## Test plan

- [ ] Run `pnpm --filter @ctxpipe/backend test`
- [ ] Trigger a code ingestion run and confirm it completes without `idle_in_transaction_session_timeout` errors
- [ ] Verify multi-root ingestion merges `extractedObjects` / `extractedClaims` before `deduplicateAndStore` runs once on the parent graph
- [ ] Confirm OpenWorkflow can import the extraction subgraph workflow (no invalid fan-in `END` edges)
- [ ] Verify agent tools (`get_file`, `list_files`, `search`, graph tools) still resolve repositories correctly
- [ ] Confirm embeddings and search content are persisted after ingestion (`embed` node)
- [ ] Confirm PR preview deploy picks up the correct image tag for the branch head commit