### PR TITLE
Wrap repository indexing failure marking in workflow step

### DIFF
--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -342,21 +342,25 @@ export const repositoryIngestion = defineWorkflow(
             error: normalized.message,
           })
 
-          await withOrgDbContext(input.orgId, () =>
-            markRepositoryIndexingFailed({
-              repositoryId: input.repositoryId,
-              error: normalized,
-            }),
-          ).catch((markErr: unknown) => {
-            getLogger().error(
-              markErr instanceof Error ? markErr : new Error(String(markErr)),
-              {
-                step: "repository-ingestion.mark-failed",
-                repositoryId: input.repositoryId,
-                orgId: input.orgId,
-              },
+          await step
+            .run({ name: "mark-failed" }, () =>
+              withOrgDbContext(input.orgId, () =>
+                markRepositoryIndexingFailed({
+                  repositoryId: input.repositoryId,
+                  error: normalized,
+                }),
+              ),
             )
-          })
+            .catch((markErr: unknown) => {
+              getLogger().error(
+                markErr instanceof Error ? markErr : new Error(String(markErr)),
+                {
+                  step: "repository-ingestion.mark-failed",
+                  repositoryId: input.repositoryId,
+                  orgId: input.orgId,
+                },
+              )
+            })
 
           throw normalized
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ensures `markRepositoryIndexingFailed` runs inside an OpenWorkflow step in the `repository-ingestion` workflow, consistent with how `mark-running` and `mark-success` are authored.

## Changes

- In the workflow `catch` block, wrap failure marking in `step.run({ name: "mark-failed" }, ...)`
- Preserve existing error logging when the mark-failed step itself fails

## Why

OpenWorkflow steps provide durable, replay-safe side effects. Failure status updates should be recorded as a named workflow step (same pattern as `forge-provision`'s `mark-failed` step), not as ad-hoc code in the catch handler.

## Testing

- Verified file has no linter issues
- `pnpm --filter @ctxpipe/backend test -- src/openworkflow/enqueue-repository-ingestion.test.ts` (pre-existing unrelated failures in other suites)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f478c-cba5-7b5a-a573-7b761bb0dc5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f478c-cba5-7b5a-a573-7b761bb0dc5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

