### PR TITLE
Wrap repo ingestion in parent workflow for terminal failure status

### DIFF
--- a/apps/backend/src/openworkflow/enqueue-repository-ingestion.test.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-ingestion.test.ts
@@ -67,19 +67,17 @@ describe("runRepositoryIngestionWorkflow", () => {
     )
   })
 
-  it("awaits workflow result and rethrows terminal failures", async () => {
+  it("does not await workflow result", async () => {
     runWorkflowWithWorkerWakeMock.mockResolvedValue({
       result: vi.fn().mockRejectedValue(new Error("terminal failure")),
     })
     const log = { error: vi.fn() }
 
-    await expect(
-      runRepositoryIngestionWorkflow(
-        { repositoryId: "repo_1", orgId: "org_1" },
-        log,
-      ),
-    ).rejects.toThrow("terminal failure")
+    await runRepositoryIngestionWorkflow(
+      { repositoryId: "repo_1", orgId: "org_1" },
+      log,
+    )
 
-    expect(log.error).toHaveBeenCalled()
+    expect(log.error).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/openworkflow/enqueue-repository-ingestion.test.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-ingestion.test.ts
@@ -18,8 +18,10 @@ vi.mock("./client.js", () => ({
   runWorkflowWithWorkerWake: runWorkflowWithWorkerWakeMock,
 }))
 
-vi.mock("./workflows/repository-ingestion.js", () => ({
-  repositoryIngestion: { spec: { name: "repository-ingestion" } },
+vi.mock("./workflows/repository-ingestion-orchestrator.js", () => ({
+  repositoryIngestionOrchestrator: {
+    spec: { name: "repository-ingestion-orchestrator" },
+  },
 }))
 
 import {

--- a/apps/backend/src/openworkflow/enqueue-repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-ingestion.ts
@@ -59,17 +59,13 @@ export async function runRepositoryIngestionWorkflow(
   )
 
   try {
-    const handle = await runWorkflowWithWorkerWake(
-      repositoryIngestionOrchestrator.spec,
-      {
-        repositoryId: input.repositoryId,
-        orgId: input.orgId,
-        ...(input.indexingReason !== undefined
-          ? { indexingReason: input.indexingReason }
-          : {}),
-      },
-    )
-    await handle.result()
+    await runWorkflowWithWorkerWake(repositoryIngestionOrchestrator.spec, {
+      repositoryId: input.repositoryId,
+      orgId: input.orgId,
+      ...(input.indexingReason !== undefined
+        ? { indexingReason: input.indexingReason }
+        : {}),
+    })
   } catch (err: unknown) {
     log.error(err instanceof Error ? err : new Error(String(err)))
     throw err

--- a/apps/backend/src/openworkflow/enqueue-repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-ingestion.ts
@@ -3,7 +3,7 @@ import {
   markRepositoryIndexingPending,
 } from "../models/repositories.js"
 import { runWorkflowWithWorkerWake } from "./client.js"
-import { repositoryIngestion } from "./workflows/repository-ingestion.js"
+import { repositoryIngestionOrchestrator } from "./workflows/repository-ingestion-orchestrator.js"
 
 export type RepositoryIngestionEnqueueInput = {
   repositoryId: string
@@ -13,7 +13,7 @@ export type RepositoryIngestionEnqueueInput = {
 }
 
 /**
- * Marks the repo as mid-ingestion for the UI, then enqueues repository-ingestion.
+ * Marks the repo as mid-ingestion for the UI, then enqueues repository-ingestion-orchestrator.
  * Awaits the DB update so callers can return HTTP 200 after the UI can poll status.
  * Does not await workflow completion; failures are handled inside the workflow.
  */
@@ -32,7 +32,7 @@ export async function enqueueRepositoryIngestionWorkflow(
 
   void (async () => {
     try {
-      await runWorkflowWithWorkerWake(repositoryIngestion.spec, {
+      await runWorkflowWithWorkerWake(repositoryIngestionOrchestrator.spec, {
         repositoryId: input.repositoryId,
         orgId: input.orgId,
         ...(input.indexingReason !== undefined
@@ -59,13 +59,17 @@ export async function runRepositoryIngestionWorkflow(
   )
 
   try {
-    await runWorkflowWithWorkerWake(repositoryIngestion.spec, {
-      repositoryId: input.repositoryId,
-      orgId: input.orgId,
-      ...(input.indexingReason !== undefined
-        ? { indexingReason: input.indexingReason }
-        : {}),
-    })
+    const handle = await runWorkflowWithWorkerWake(
+      repositoryIngestionOrchestrator.spec,
+      {
+        repositoryId: input.repositoryId,
+        orgId: input.orgId,
+        ...(input.indexingReason !== undefined
+          ? { indexingReason: input.indexingReason }
+          : {}),
+      },
+    )
+    await handle.result()
   } catch (err: unknown) {
     log.error(err instanceof Error ? err : new Error(String(err)))
     throw err

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const withOrgDbContextMock = vi.hoisted(() =>
+  vi.fn((_orgId: string, fn: () => unknown) => Promise.resolve(fn())),
+)
+const markRepositoryIndexingFailedMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+)
+const getLoggerErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../db/client.js", () => ({
+  withOrgDbContext: withOrgDbContextMock,
+}))
+
+vi.mock("../../models/repositories.js", () => ({
+  markRepositoryIndexingFailed: markRepositoryIndexingFailedMock,
+}))
+
+vi.mock("../../observability/logger.js", () => ({
+  createLogger: () => ({}),
+  withLogger: (_logger: unknown, fn: () => unknown) => fn(),
+  getLogger: () => ({ error: getLoggerErrorMock }),
+}))
+
+vi.mock("./repository-ingestion.js", () => ({
+  repositoryIngestion: { spec: { name: "repository-ingestion" } },
+}))
+
+import { repositoryIngestionOrchestrator } from "./repository-ingestion-orchestrator.js"
+
+describe("repositoryIngestionOrchestrator workflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withOrgDbContextMock.mockImplementation(
+      (_orgId: string, fn: () => unknown) => Promise.resolve(fn()),
+    )
+    markRepositoryIndexingFailedMock.mockResolvedValue(undefined)
+  })
+
+  it("returns child result on success", async () => {
+    const step = {
+      runWorkflow: vi.fn().mockResolvedValue({
+        repositoryId: "repo_1",
+        targetHash: "abc123",
+        sourceBranch: "main",
+      }),
+      run: vi.fn(),
+    }
+
+    const result = await repositoryIngestionOrchestrator.fn({
+      input: {
+        repositoryId: "repo_1",
+        orgId: "org_1",
+        indexingReason: "manual",
+      },
+      step,
+    } as never)
+
+    expect(step.runWorkflow).toHaveBeenCalledWith(
+      { name: "repository-ingestion" },
+      {
+        repositoryId: "repo_1",
+        orgId: "org_1",
+        indexingReason: "manual",
+      },
+      { name: "repository-ingestion-child" },
+    )
+    expect(step.run).not.toHaveBeenCalled()
+    expect(markRepositoryIndexingFailedMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      repositoryId: "repo_1",
+      targetHash: "abc123",
+      sourceBranch: "main",
+    })
+  })
+
+  it("marks failed and rethrows when child fails", async () => {
+    const childError = new Error("child failed")
+    const step = {
+      runWorkflow: vi.fn().mockRejectedValue(childError),
+      run: vi.fn(
+        async (_opts: { name: string }, fn: () => Promise<unknown>) => fn(),
+      ),
+    }
+
+    await expect(
+      repositoryIngestionOrchestrator.fn({
+        input: { repositoryId: "repo_1", orgId: "org_1" },
+        step,
+      } as never),
+    ).rejects.toThrow("child failed")
+
+    expect(step.run).toHaveBeenCalledWith(
+      { name: "mark-failed" },
+      expect.any(Function),
+    )
+    expect(markRepositoryIndexingFailedMock).toHaveBeenCalledWith({
+      repositoryId: "repo_1",
+      error: childError,
+    })
+  })
+})

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.test.ts
@@ -99,4 +99,50 @@ describe("repositoryIngestionOrchestrator workflow", () => {
       error: childError,
     })
   })
+
+  it("rethrows SleepSignal without marking failed", async () => {
+    const sleepSignal = new Error("sleep")
+    sleepSignal.name = "SleepSignal"
+    const step = {
+      runWorkflow: vi.fn().mockRejectedValue(sleepSignal),
+      run: vi.fn(),
+    }
+
+    await expect(
+      repositoryIngestionOrchestrator.fn({
+        input: { repositoryId: "repo_1", orgId: "org_1" },
+        step,
+      } as never),
+    ).rejects.toMatchObject({ name: "SleepSignal" })
+
+    expect(step.run).not.toHaveBeenCalled()
+    expect(markRepositoryIndexingFailedMock).not.toHaveBeenCalled()
+  })
+
+  it("marks failed when child throws CancelSignal", async () => {
+    const cancelSignal = new Error("canceled")
+    cancelSignal.name = "CancelSignal"
+    const step = {
+      runWorkflow: vi.fn().mockRejectedValue(cancelSignal),
+      run: vi.fn(
+        async (_opts: { name: string }, fn: () => Promise<unknown>) => fn(),
+      ),
+    }
+
+    await expect(
+      repositoryIngestionOrchestrator.fn({
+        input: { repositoryId: "repo_1", orgId: "org_1" },
+        step,
+      } as never),
+    ).rejects.toMatchObject({ name: "CancelSignal" })
+
+    expect(step.run).toHaveBeenCalledWith(
+      { name: "mark-failed" },
+      expect.any(Function),
+    )
+    expect(markRepositoryIndexingFailedMock).toHaveBeenCalledWith({
+      repositoryId: "repo_1",
+      error: cancelSignal,
+    })
+  })
 })

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.ts
@@ -12,6 +12,10 @@ const repositoryIngestionOrchestratorInputSchema = z.object({
   indexingReason: z.string().nullable().optional(),
 })
 
+function isSleepSignal(err: unknown): boolean {
+  return err instanceof Error && err.name === "SleepSignal"
+}
+
 export const repositoryIngestionOrchestrator = defineWorkflow(
   {
     name: "repository-ingestion-orchestrator",
@@ -41,6 +45,11 @@ export const repositoryIngestionOrchestrator = defineWorkflow(
             { name: "repository-ingestion-child" },
           )
         } catch (err: unknown) {
+          console.log("error", err)
+          if (isSleepSignal(err)) {
+            throw err
+          }
+
           const normalized = err instanceof Error ? err : new Error(String(err))
 
           await step

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.ts
@@ -1,0 +1,70 @@
+import { defineWorkflow } from "openworkflow"
+import { z } from "zod"
+import { withOrgDbContext } from "../../db/client.js"
+import { markRepositoryIndexingFailed } from "../../models/repositories.js"
+import { createLogger, getLogger, withLogger } from "../../observability/logger.js"
+import { repositoryIngestion } from "./repository-ingestion.js"
+
+const repositoryIngestionOrchestratorInputSchema = z.object({
+  repositoryId: z.string().min(1),
+  orgId: z.string().min(1),
+  targetBranch: z.string().nullable().optional(),
+  indexingReason: z.string().nullable().optional(),
+})
+
+export const repositoryIngestionOrchestrator = defineWorkflow(
+  {
+    name: "repository-ingestion-orchestrator",
+    schema: repositoryIngestionOrchestratorInputSchema,
+  },
+  async ({ input, step }) =>
+    withLogger(
+      createLogger({
+        workflow: "repository-ingestion-orchestrator",
+        repositoryId: input.repositoryId,
+        orgId: input.orgId,
+      }),
+      async () => {
+        try {
+          return await step.runWorkflow(
+            repositoryIngestion.spec,
+            {
+              repositoryId: input.repositoryId,
+              orgId: input.orgId,
+              ...(input.targetBranch !== undefined
+                ? { targetBranch: input.targetBranch }
+                : {}),
+              ...(input.indexingReason !== undefined
+                ? { indexingReason: input.indexingReason }
+                : {}),
+            },
+            { name: "repository-ingestion-child" },
+          )
+        } catch (err: unknown) {
+          const normalized = err instanceof Error ? err : new Error(String(err))
+
+          await step
+            .run({ name: "mark-failed" }, () =>
+              withOrgDbContext(input.orgId, () =>
+                markRepositoryIndexingFailed({
+                  repositoryId: input.repositoryId,
+                  error: normalized,
+                }),
+              ),
+            )
+            .catch((markErr: unknown) => {
+              getLogger().error(
+                markErr instanceof Error ? markErr : new Error(String(markErr)),
+                {
+                  step: "repository-ingestion-orchestrator.mark-failed",
+                  repositoryId: input.repositoryId,
+                  orgId: input.orgId,
+                },
+              )
+            })
+
+          throw normalized
+        }
+      },
+    ),
+)

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -7,7 +7,6 @@ import { graph as codeIngestionGraph } from "../../graphs/codeIngestionGraph/gra
 import { reindex } from "../../graphs/codeIngestionGraph/nodes/reindex.js"
 import { retractStaleEvidence } from "../../graphs/codeIngestionGraph/nodes/retractStaleEvidence.js"
 import {
-  markRepositoryIndexingFailed,
   markRepositoryIndexingReady,
   markRepositoryIndexingRunning,
 } from "../../models/repositories.js"
@@ -341,26 +340,6 @@ export const repositoryIngestion = defineWorkflow(
             orgId: input.orgId,
             error: normalized.message,
           })
-
-          await step
-            .run({ name: "mark-failed" }, () =>
-              withOrgDbContext(input.orgId, () =>
-                markRepositoryIndexingFailed({
-                  repositoryId: input.repositoryId,
-                  error: normalized,
-                }),
-              ),
-            )
-            .catch((markErr: unknown) => {
-              getLogger().error(
-                markErr instanceof Error ? markErr : new Error(String(markErr)),
-                {
-                  step: "repository-ingestion.mark-failed",
-                  repositoryId: input.repositoryId,
-                  orgId: input.orgId,
-                },
-              )
-            })
 
           throw normalized
         }

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -58,35 +58,34 @@ export const repositoryIngestion = defineWorkflow(
         orgId: input.orgId,
       }),
       async () => {
-        try {
-          logWorkflowMilestone("repository-ingestion.workflow-handler-entered", {
-            repositoryId: input.repositoryId,
-            orgId: input.orgId,
-            targetBranch: input.targetBranch ?? null,
-            indexingReason: input.indexingReason ?? null,
-          })
+        logWorkflowMilestone("repository-ingestion.workflow-handler-entered", {
+          repositoryId: input.repositoryId,
+          orgId: input.orgId,
+          targetBranch: input.targetBranch ?? null,
+          indexingReason: input.indexingReason ?? null,
+        })
 
-          logWorkflowMilestone("repository-ingestion.start", {
-            repositoryId: input.repositoryId,
-            orgId: input.orgId,
-          })
+        logWorkflowMilestone("repository-ingestion.start", {
+          repositoryId: input.repositoryId,
+          orgId: input.orgId,
+        })
 
-          const org = await getSystemDb().query.organizations.findFirst({
-            where: { id: { eq: input.orgId } },
-          })
+        const org = await getSystemDb().query.organizations.findFirst({
+          where: { id: { eq: input.orgId } },
+        })
 
-          if (!org) {
-            throw new Error(`Organization not found: ${input.orgId}`)
-          }
+        if (!org) {
+          throw new Error(`Organization not found: ${input.orgId}`)
+        }
 
-          return await withOrgIdContext({ id: org.id, slug: org.slug }, async () => {
-            await step.run({ name: "mark-running" }, () =>
-              withOrgDbContext(input.orgId, () =>
-                markRepositoryIndexingRunning({
-                  repositoryId: input.repositoryId,
-                }),
-              ),
-            )
+        return await withOrgIdContext({ id: org.id, slug: org.slug }, async () => {
+          await step.run({ name: "mark-running" }, () =>
+            withOrgDbContext(input.orgId, () =>
+              markRepositoryIndexingRunning({
+                repositoryId: input.repositoryId,
+              }),
+            ),
+          )
 
           logWorkflowMilestone(
             "repository-ingestion.step.get-repository.start",
@@ -330,19 +329,8 @@ export const repositoryIngestion = defineWorkflow(
             targetHash: result.targetHash,
           })
 
-            return result
-          })
-        } catch (err: unknown) {
-          const normalized = err instanceof Error ? err : new Error(String(err))
-
-          logWorkflowMilestone("repository-ingestion.failed", {
-            repositoryId: input.repositoryId,
-            orgId: input.orgId,
-            error: normalized.message,
-          })
-
-          throw normalized
-        }
+          return result
+        })
       },
     ),
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `repository-ingestion-orchestrator` workflow that calls `repository-ingestion` as a child via `step.runWorkflow(...)`
- move terminal `indexing_status=failed` responsibility to the parent orchestrator (`mark-failed` step) so failed status is only written after the overall workflow terminally fails
- keep child workflow focused on ingestion execution and allow errors to bubble naturally (removed child-level `try/catch` wrapper)
- rewire enqueue helpers to run the new orchestrator workflow
- keep enqueue behavior non-blocking for long-running workflows by **not awaiting** `handle.result()`
- add tests for orchestrator success/failure behavior and update enqueue tests for non-awaiting behavior

## Verification
- `DATABASE_URL=postgresql://ctxpipe:ctxpipe@localhost:5433/ctxpipe AUTH_SECRET=abcdefghijklmnopqrstuvwxyz123456 pnpm exec vitest run src/openworkflow/enqueue-repository-ingestion.test.ts src/openworkflow/workflows/repository-ingestion-orchestrator.test.ts src/openworkflow/workflows/sync-github-repositories.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f49c0-4095-77e6-8139-107db10cec5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f49c0-4095-77e6-8139-107db10cec5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

