### PR TITLE
Add deterministic pre-pass to identifyLibraries

### DIFF
--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.test.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.test.ts
@@ -58,13 +58,44 @@ describe("identifyLibraries post-processing", () => {
     })
   })
 
+  it("emits deterministic extraction metadata when provided", () => {
+    const captured = [
+      {
+        name: "Drizzle",
+        path: "./",
+        category: "ORM",
+        extractionMethod: "deterministic" as const,
+        confidence: 0.9,
+        provenance: {
+          detectionSignals: ["manifest_dependency", "import_usage"],
+          scoreBreakdown: {
+            manifestDependency: 0.55,
+            corroboration: 0.1,
+            importUsage: 0.25,
+            total: 0.9,
+          },
+        },
+      },
+    ]
+
+    const { claims } = postProcessLibraries(captured, state)
+    expect(claims).toHaveLength(1)
+    expect(claims[0]).toMatchObject({
+      extractionMethod: "deterministic",
+      confidence: 0.9,
+      provenance: expect.objectContaining({
+        detectionSignals: ["manifest_dependency", "import_usage"],
+      }),
+    })
+  })
+
   it("deduplicates by library name per root", () => {
     const captured = [
       { name: "Prisma", path: "./" },
       { name: "prisma", path: "./" },
       { name: "drizzle", path: "./" },
     ]
-    const { objects, claims } = postProcessLibraries(captured, state)
+    const { objects } = postProcessLibraries(captured, state)
 
     expect(objects).toHaveLength(2) // Prisma (deduped), Drizzle
     const names = objects.map((o) => o.name).sort()
@@ -80,6 +111,26 @@ describe("identifyLibraries post-processing", () => {
     expect(objects).toHaveLength(1)
     expect(objects[0].name).toBe("Drizzle")
     expect(objects[0].deduplicationKey).toBe("lib:repo_abc:./:Drizzle")
+  })
+
+  it("prefers deterministic claims when deterministic and LLM outputs collide", () => {
+    const captured = [
+      { name: "drizzle-orm", path: "./", extractionMethod: "llm" as const },
+      {
+        name: "Drizzle",
+        path: "./",
+        extractionMethod: "deterministic" as const,
+        confidence: 0.92,
+      },
+    ]
+
+    const { objects, claims } = postProcessLibraries(captured, state)
+    expect(objects).toHaveLength(1)
+    expect(claims).toHaveLength(1)
+    expect(claims[0]).toMatchObject({
+      extractionMethod: "deterministic",
+      confidence: 0.92,
+    })
   })
 
   it("filters by pathMatchesRoot", () => {
@@ -119,5 +170,41 @@ describe("identifyLibraries post-processing", () => {
       confidence: 0.8,
       provenance: expect.objectContaining({ root: "./" }),
     })
+  })
+
+  it("supports merged deterministic and LLM outputs across roots", () => {
+    const captured = [
+      {
+        name: "Hono",
+        path: "apps/web",
+        extractionMethod: "deterministic" as const,
+        confidence: 0.88,
+      },
+      {
+        name: "Better Auth",
+        path: "./",
+        extractionMethod: "llm" as const,
+        confidence: 0.8,
+      },
+    ]
+
+    const { claims } = postProcessLibraries(captured, {
+      ...state,
+      roots: ["./", "apps/web"],
+    })
+
+    expect(claims).toHaveLength(2)
+    expect(claims).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subjectRef: "svc:repo_abc:apps/web",
+          extractionMethod: "deterministic",
+        }),
+        expect.objectContaining({
+          subjectRef: "svc:repo_abc:./",
+          extractionMethod: "llm",
+        }),
+      ]),
+    )
   })
 })

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
@@ -30,56 +30,24 @@ import type {
 } from "../schemas.js"
 import { resolveSubmissionRoot } from "./extractionSubmissionRoot.js"
 import {
+  detectLibrariesDeterministic,
+  normalizeLibraryName,
+} from "./identifyLibrariesDeterministic.js"
+import {
   partialScanPathsForExtractors,
   partialScanPromptSuffix,
   repoPathMatchesPartialScan,
   shouldSkipExtractorForPartialDeletesOnly,
 } from "./partialIngestionScope.js"
 
-/** Normalize library name to canonical form for deduplication */
-function normalizeLibraryName(name: string): string {
-  const lower = name.toLowerCase()
-  const known: Record<string, string> = {
-    prisma: "Prisma",
-    drizzle: "Drizzle",
-    "drizzle-orm": "Drizzle",
-    express: "Express",
-    hono: "Hono",
-    zod: "Zod",
-    "better-auth": "Better Auth",
-    ioredis: "ioredis",
-    "next.js": "Next.js",
-    next: "Next.js",
-    fastify: "Fastify",
-    "fast-api": "FastAPI",
-    fastapi: "FastAPI",
-    flask: "Flask",
-    django: "Django",
-    trpc: "tRPC",
-    "@trpc/server": "tRPC",
-    axios: "Axios",
-    fetch: "fetch",
-    "react-query": "TanStack Query",
-    "tanstack-query": "TanStack Query",
-    "@tanstack/react-query": "TanStack Query",
-    mongoose: "Mongoose",
-    typeorm: "TypeORM",
-    knex: "Knex",
-    sequelize: "Sequelize",
-    "better-sqlite3": "better-sqlite3",
-    redis: "Redis",
-    "@upstash/redis": "Upstash Redis",
-    supabase: "Supabase",
-    "@supabase/supabase-js": "Supabase",
-  }
-  return known[lower] ?? name
-}
-
 type SubmittedLibrary = {
   name: string
   path: string
   category?: string
   evidence?: string
+  extractionMethod?: "deterministic" | "llm"
+  confidence?: number
+  provenance?: Record<string, unknown>
 }
 
 function createIdentifyLibrariesTools(capturedLibraries: {
@@ -157,7 +125,7 @@ Cover only the listed roots. Call submit_libraries for each architectural librar
 export async function identifyLibraries(
   state: CodeIngestionState,
 ): Promise<Partial<CodeIngestionState>> {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const { repositoryId, orgId, roots = ["./"], targetHash } = state
   requireCurrentOrgId()
 
   if (shouldSkipExtractorForPartialDeletesOnly(state)) {
@@ -170,46 +138,113 @@ export async function identifyLibraries(
       ? partialScanPromptSuffix(scanPaths)
       : ""
 
-  const capturedLibraries: { value: SubmittedLibrary[] } = { value: [] }
-  const tools = createIdentifyLibrariesTools(capturedLibraries)
-  const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
-    tools,
-    contextMiddleware: {
-      clearToolUsesTriggerTokens: 160_000,
-      clearToolUsesKeepMessages: 16,
-      summarizationTriggerTokens: 240_000,
-      summarizationKeepMessages: 36,
-    },
-    systemPrompt: `${SYSTEM_PROMPT}
-
-Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots.join(", ")}.
-
-${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
+  const deterministic = await detectLibrariesDeterministic({
+    repositoryId,
+    orgId,
+    roots,
+    scanPaths: state.ingestMode === "partial" ? scanPaths : undefined,
   })
 
-  const userMessage = `For the listed roots, check package manifests and search for architectural library imports (ORM, HTTP, auth, validation, cache). Call submit_libraries (batch per call) once manifest/import evidence is clear; skip utilities and uncertain hits.`
-
-  await agent.invoke(
-    { messages: [new HumanMessage(userMessage)] },
-    mergeConfigs(getConfig(), {
-      recursionLimit: 220,
-    }),
-  )
-
-  if (capturedLibraries.value.length === 0) {
+  if (
+    deterministic.manifestFilesChecked > 0 &&
+    deterministic.manifestParseFailures === deterministic.manifestFilesChecked
+  ) {
     getLogger().warn(
-      "identifyLibraries: agent completed without submit_libraries (no libraries captured)",
-      { repositoryId, targetHash },
+      "identifyLibraries: deterministic parsing failed for all manifests; falling back to LLM roots",
+      {
+        repositoryId,
+        targetHash,
+        roots,
+        manifestFilesChecked: deterministic.manifestFilesChecked,
+        manifestParseFailures: deterministic.manifestParseFailures,
+      },
     )
   }
 
-  let submissions = capturedLibraries.value
+  const deterministicSubmissions: SubmittedLibrary[] = deterministic.accepted.map(
+    (candidate) => ({
+      name: candidate.name,
+      path: candidate.root,
+      category: candidate.category,
+      evidence: candidate.evidence.join("; "),
+      extractionMethod: "deterministic",
+      confidence: candidate.confidence,
+      provenance: {
+        detectionSignals: candidate.detectionSignals,
+        manifestPath: candidate.manifestPath,
+        importPath: candidate.importPath,
+        categorySource: candidate.categorySource,
+        scoreBreakdown: candidate.scoreBreakdown,
+      },
+    }),
+  )
+  const rootsNeedingLlm = deterministic.rootsNeedingLlm
+  const capturedLibraries: { value: SubmittedLibrary[] } = { value: [] }
+  if (rootsNeedingLlm.length > 0) {
+    const tools = createIdentifyLibrariesTools(capturedLibraries)
+    const agent = createAgent({
+      model: getModel("medium", { temperature: 0.1 }),
+      tools,
+      contextMiddleware: {
+        clearToolUsesTriggerTokens: 160_000,
+        clearToolUsesKeepMessages: 16,
+        summarizationTriggerTokens: 240_000,
+        summarizationKeepMessages: 36,
+      },
+      systemPrompt: `${SYSTEM_PROMPT}
+
+Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${rootsNeedingLlm.join(", ")}.
+
+${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
+    })
+
+    const userMessage = `For these roots only: ${rootsNeedingLlm.join(", ")}. Check package manifests and search for architectural library imports (ORM, HTTP, auth, validation, cache). Call submit_libraries (batch per call) once manifest/import evidence is clear; skip utilities and uncertain hits.`
+
+    await agent.invoke(
+      { messages: [new HumanMessage(userMessage)] },
+      mergeConfigs(getConfig(), {
+        recursionLimit: 220,
+      }),
+    )
+
+    if (capturedLibraries.value.length === 0) {
+      getLogger().warn(
+        "identifyLibraries: agent completed without submit_libraries for fallback roots",
+        { repositoryId, targetHash, rootsNeedingLlm },
+      )
+    }
+  }
+
+  let llmSubmissions = capturedLibraries.value.map((submission) => ({
+    ...submission,
+    extractionMethod: "llm" as const,
+    confidence: submission.confidence ?? 0.8,
+  }))
+  if (rootsNeedingLlm.length > 0) {
+    llmSubmissions = llmSubmissions.filter((lib) =>
+      rootsNeedingLlm.some((root) =>
+        root === "./"
+          ? true
+          : lib.path === root || lib.path.startsWith(`${root}/`),
+      ),
+    )
+  }
   if (state.ingestMode === "partial" && scanPaths.length > 0) {
-    submissions = submissions.filter((lib) =>
+    llmSubmissions = llmSubmissions.filter((lib) =>
       repoPathMatchesPartialScan(lib.path, scanPaths),
     )
   }
+  const submissions = [...deterministicSubmissions, ...llmSubmissions]
+
+  getLogger().info("identifyLibraries: deterministic + fallback summary", {
+    repositoryId,
+    targetHash,
+    rootsTotal: roots.length,
+    deterministicRootsResolved: deterministic.rootsResolvedDeterministically.length,
+    rootsRequiringLlm: rootsNeedingLlm.length,
+    deterministicAccepted: deterministic.accepted.length,
+    deterministicAmbiguous: deterministic.ambiguous.length,
+  })
 
   const { objects: postObjects, claims: postClaims } = postProcessLibraries(
     submissions,
@@ -231,8 +266,13 @@ export function postProcessLibraries(
   const objects: ExtractedObject[] = []
   const claims: ExtractedClaim[] = []
   const seenLibs = new Set<string>()
+  const orderedLibraries = [...capturedLibraries].sort((left, right) => {
+    const leftRank = left.extractionMethod === "deterministic" ? 0 : 1
+    const rightRank = right.extractionMethod === "deterministic" ? 0 : 1
+    return leftRank - rightRank
+  })
 
-  for (const lib of capturedLibraries) {
+  for (const lib of orderedLibraries) {
     const root = resolveSubmissionRoot(lib.path, roots)
     if (root === null) continue
     const libraryName = normalizeLibraryName(lib.name)
@@ -258,9 +298,10 @@ export function postProcessLibraries(
       predicate: "USES_LIBRARY",
       sourceId: `identifyLibraries:${repositoryId}:${root}:${libraryName}:${targetHash}`,
       sourceType: "git",
-      extractionMethod: "llm",
-      confidence: 0.8,
+      extractionMethod: lib.extractionMethod ?? "llm",
+      confidence: lib.confidence ?? 0.8,
       provenance: {
+        ...(lib.provenance ?? {}),
         root,
         libraryName,
         category: lib.category,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibrariesDeterministic.test.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibrariesDeterministic.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const fetchFilesMock = vi.hoisted(() => vi.fn())
+const listFilesRecursiveMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../../domain/codeIngestion/codesearchClient.js", () => ({
+  fetchFiles: fetchFilesMock,
+  listFilesRecursive: listFilesRecursiveMock,
+}))
+
+import {
+  detectLibrariesDeterministic,
+  normalizeLibraryName,
+  scoreLibraryCandidate,
+} from "./identifyLibrariesDeterministic.js"
+
+describe("identifyLibrariesDeterministic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("normalizes alias names to canonical library names", () => {
+    expect(normalizeLibraryName("drizzle-orm")).toBe("Drizzle")
+    expect(normalizeLibraryName("better-auth")).toBe("Better Auth")
+  })
+
+  it("scores accepted and ambiguous boundaries correctly", () => {
+    const accepted = scoreLibraryCandidate({
+      hasManifestDependency: true,
+      hasCorroboration: true,
+      hasImportUsage: true,
+    })
+    expect(accepted.confidence).toBe(1)
+
+    const ambiguous = scoreLibraryCandidate({
+      hasManifestDependency: true,
+      hasCorroboration: true,
+      hasImportUsage: false,
+    })
+    expect(ambiguous.confidence).toBe(0.75)
+  })
+
+  it("accepts deterministic candidates when all signals corroborate", async () => {
+    listFilesRecursiveMock.mockResolvedValue([
+      "apps/api/package.json",
+      "apps/api/pnpm-lock.yaml",
+      "apps/api/src/app.ts",
+    ])
+    fetchFilesMock.mockResolvedValue({
+      "apps/api/package.json": JSON.stringify({
+        dependencies: { "drizzle-orm": "^0.32.0" },
+      }),
+      "apps/api/src/app.ts":
+        'import { drizzle } from "drizzle-orm"\nconst db = drizzle({})\n',
+    })
+
+    const result = await detectLibrariesDeterministic({
+      repositoryId: "repo_abc",
+      orgId: "org_abc",
+      roots: ["apps/api"],
+    })
+
+    expect(result.accepted).toHaveLength(1)
+    expect(result.accepted[0]).toMatchObject({
+      root: "apps/api",
+      name: "Drizzle",
+      category: "ORM",
+      confidence: 1,
+    })
+    expect(result.accepted[0]?.detectionSignals).toEqual(
+      expect.arrayContaining([
+        "manifest_dependency",
+        "lock_or_config",
+        "import_usage",
+      ]),
+    )
+    expect(result.rootsNeedingLlm).toEqual([])
+  })
+
+  it("marks dependency-only candidates as ambiguous and keeps LLM fallback", async () => {
+    listFilesRecursiveMock.mockResolvedValue([
+      "apps/api/package.json",
+      "apps/api/pnpm-lock.yaml",
+    ])
+    fetchFilesMock.mockResolvedValue({
+      "apps/api/package.json": JSON.stringify({
+        dependencies: { "better-auth": "^1.0.0" },
+      }),
+    })
+
+    const result = await detectLibrariesDeterministic({
+      repositoryId: "repo_abc",
+      orgId: "org_abc",
+      roots: ["apps/api"],
+    })
+
+    expect(result.accepted).toHaveLength(0)
+    expect(result.ambiguous).toHaveLength(1)
+    expect(result.ambiguous[0]).toMatchObject({
+      root: "apps/api",
+      name: "Better Auth",
+      confidence: 0.75,
+    })
+    expect(result.rootsNeedingLlm).toEqual(["apps/api"])
+  })
+
+  it("respects partial scan filtering for deterministic roots", async () => {
+    listFilesRecursiveMock.mockResolvedValue([
+      "apps/api/package.json",
+      "apps/api/src/app.ts",
+    ])
+    fetchFilesMock.mockResolvedValue({
+      "apps/api/package.json": JSON.stringify({
+        dependencies: { zod: "^3.23.0" },
+      }),
+      "apps/api/src/app.ts": 'import { z } from "zod"\n',
+    })
+
+    const result = await detectLibrariesDeterministic({
+      repositoryId: "repo_abc",
+      orgId: "org_abc",
+      roots: ["apps/api"],
+      scanPaths: ["apps/api/src"],
+    })
+
+    expect(result.accepted).toHaveLength(0)
+    expect(result.ambiguous).toHaveLength(0)
+    expect(result.unresolvedRoots).toEqual(["apps/api"])
+    expect(result.rootsNeedingLlm).toEqual(["apps/api"])
+  })
+})

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibrariesDeterministic.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibrariesDeterministic.ts
@@ -1,0 +1,726 @@
+import {
+  fetchFiles,
+  listFilesRecursive,
+} from "../../../domain/codeIngestion/codesearchClient.js"
+import { repoPathMatchesPartialScan } from "./partialIngestionScope.js"
+
+export type DeterministicDetectionSignal =
+  | "manifest_dependency"
+  | "lock_or_config"
+  | "import_usage"
+  | "framework_marker"
+
+export type DeterministicLibraryCandidate = {
+  root: string
+  name: string
+  category?: string
+  confidence: number
+  evidence: string[]
+  detectionSignals: DeterministicDetectionSignal[]
+  manifestPath?: string
+  importPath?: string
+  categorySource: "map" | "manifest" | "import"
+  scoreBreakdown: {
+    manifestDependency: number
+    corroboration: number
+    importUsage: number
+    total: number
+  }
+}
+
+export type DeterministicLibrariesResult = {
+  accepted: DeterministicLibraryCandidate[]
+  ambiguous: DeterministicLibraryCandidate[]
+  unresolvedRoots: string[]
+  rootsResolvedDeterministically: string[]
+  rootsNeedingLlm: string[]
+  manifestFilesChecked: number
+  manifestParseFailures: number
+}
+
+type LibraryAlias = {
+  canonicalName: string
+  aliases: string[]
+  category?: string
+  importTokens: string[]
+  markerPatterns?: RegExp[]
+}
+
+type CandidateAccumulator = {
+  root: string
+  name: string
+  category?: string
+  categorySource: "map" | "manifest" | "import"
+  manifestPath?: string
+  importPath?: string
+  scoreManifestDependency: number
+  scoreCorroboration: number
+  scoreImportUsage: number
+  detectionSignals: Set<DeterministicDetectionSignal>
+  evidence: string[]
+}
+
+const MANIFEST_SCORE = 0.55
+const CORROBORATION_SCORE = 0.2
+const IMPORT_SCORE = 0.25
+const ACCEPTED_THRESHOLD = 0.85
+const AMBIGUOUS_THRESHOLD = 0.6
+const MAX_IMPORT_FILES_PER_ROOT = 140
+
+const ROOT_MANIFEST_BASENAMES = new Set([
+  "package.json",
+  "pyproject.toml",
+  "requirements.txt",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "gemfile",
+  "composer.json",
+  "cargo.toml",
+  "mix.exs",
+  "package.swift",
+])
+
+const LOCK_OR_CONFIG_BASENAMES = new Set([
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "package-lock.json",
+  "bun.lock",
+  "bun.lockb",
+  "poetry.lock",
+  "pipfile.lock",
+  "go.sum",
+  "cargo.lock",
+  "gemfile.lock",
+  "composer.lock",
+  "drizzle.config.ts",
+  "drizzle.config.js",
+  "drizzle.config.mts",
+  "drizzle.config.mjs",
+  "drizzle.config.cts",
+  "drizzle.config.cjs",
+])
+
+const SOURCE_CODE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".py",
+  ".go",
+  ".java",
+  ".kt",
+  ".rb",
+  ".php",
+  ".rs",
+  ".ex",
+  ".exs",
+  ".swift",
+])
+
+const LIBRARY_ALIASES: LibraryAlias[] = [
+  {
+    canonicalName: "Prisma",
+    aliases: ["prisma", "@prisma/client"],
+    category: "ORM",
+    importTokens: ["prisma", "@prisma/client"],
+  },
+  {
+    canonicalName: "Drizzle",
+    aliases: ["drizzle", "drizzle-orm"],
+    category: "ORM",
+    importTokens: ["drizzle-orm", "drizzle-kit"],
+    markerPatterns: [/drizzle\s*\(/i, /drizzle\.config/i],
+  },
+  {
+    canonicalName: "TypeORM",
+    aliases: ["typeorm"],
+    category: "ORM",
+    importTokens: ["typeorm"],
+  },
+  {
+    canonicalName: "Sequelize",
+    aliases: ["sequelize"],
+    category: "ORM",
+    importTokens: ["sequelize"],
+  },
+  {
+    canonicalName: "Mongoose",
+    aliases: ["mongoose"],
+    category: "ORM",
+    importTokens: ["mongoose"],
+  },
+  {
+    canonicalName: "Express",
+    aliases: ["express"],
+    category: "HTTP",
+    importTokens: ["express"],
+  },
+  {
+    canonicalName: "Hono",
+    aliases: ["hono"],
+    category: "HTTP",
+    importTokens: ["hono"],
+    markerPatterns: [/new\s+Hono\s*\(/, /createRoute\s*\(/, /\.openapi\s*\(/i],
+  },
+  {
+    canonicalName: "Fastify",
+    aliases: ["fastify"],
+    category: "HTTP",
+    importTokens: ["fastify"],
+  },
+  {
+    canonicalName: "Next.js",
+    aliases: ["next", "next.js"],
+    category: "HTTP",
+    importTokens: ["next", "next/server"],
+  },
+  {
+    canonicalName: "FastAPI",
+    aliases: ["fastapi", "fast-api"],
+    category: "HTTP",
+    importTokens: ["fastapi"],
+  },
+  {
+    canonicalName: "Flask",
+    aliases: ["flask"],
+    category: "HTTP",
+    importTokens: ["flask"],
+  },
+  {
+    canonicalName: "Django",
+    aliases: ["django"],
+    category: "HTTP",
+    importTokens: ["django"],
+  },
+  {
+    canonicalName: "Better Auth",
+    aliases: ["better-auth"],
+    category: "auth",
+    importTokens: ["better-auth"],
+    markerPatterns: [/betterAuth\s*\(/],
+  },
+  {
+    canonicalName: "Zod",
+    aliases: ["zod"],
+    category: "validation",
+    importTokens: ["zod"],
+    markerPatterns: [/\bz\.object\s*\(/, /\bz\.string\s*\(/],
+  },
+  {
+    canonicalName: "ioredis",
+    aliases: ["ioredis"],
+    category: "cache",
+    importTokens: ["ioredis"],
+  },
+  {
+    canonicalName: "Redis",
+    aliases: ["redis", "redis-py", "go-redis"],
+    category: "cache",
+    importTokens: ["redis", "go-redis"],
+  },
+  {
+    canonicalName: "Upstash Redis",
+    aliases: ["@upstash/redis"],
+    category: "cache",
+    importTokens: ["@upstash/redis"],
+  },
+  {
+    canonicalName: "tRPC",
+    aliases: ["trpc", "@trpc/server"],
+    category: "RPC/API",
+    importTokens: ["@trpc/server", "@trpc/client", "@trpc/react-query"],
+  },
+  {
+    canonicalName: "Axios",
+    aliases: ["axios"],
+    category: "HTTP",
+    importTokens: ["axios"],
+  },
+  {
+    canonicalName: "Supabase",
+    aliases: ["supabase", "@supabase/supabase-js"],
+    category: "auth",
+    importTokens: ["@supabase/supabase-js"],
+  },
+]
+
+const aliasLookup = new Map<string, LibraryAlias>()
+for (const alias of LIBRARY_ALIASES) {
+  aliasLookup.set(alias.canonicalName.toLowerCase(), alias)
+  for (const value of alias.aliases) {
+    aliasLookup.set(value.toLowerCase(), alias)
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function basename(path: string): string {
+  const slash = path.lastIndexOf("/")
+  if (slash === -1) return path
+  return path.slice(slash + 1)
+}
+
+function withinRoot(path: string, root: string): boolean {
+  if (root === "./" || root === ".") return true
+  return path === root || path.startsWith(`${root}/`)
+}
+
+function clamp01(score: number): number {
+  return Math.max(0, Math.min(1, score))
+}
+
+function isSourceFile(path: string): boolean {
+  const lower = path.toLowerCase()
+  for (const ext of SOURCE_CODE_EXTENSIONS) {
+    if (lower.endsWith(ext)) return true
+  }
+  return false
+}
+
+function parsePackageJsonDependencies(content: string): string[] {
+  const parsed = JSON.parse(content) as Record<string, unknown>
+  const keys: string[] = []
+  const dependencyFields = [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ]
+  for (const field of dependencyFields) {
+    const value = parsed[field]
+    if (!value || typeof value !== "object") continue
+    keys.push(...Object.keys(value as Record<string, unknown>))
+  }
+  return keys
+}
+
+function parseRequirementsDependencies(content: string): string[] {
+  const out: string[] = []
+  for (const line of content.split(/\r?\n/)) {
+    const cleaned = line.split("#")[0]?.trim()
+    if (!cleaned) continue
+    const token = cleaned.split(/[<>=!~[\];\s]/)[0]?.trim()
+    if (token) out.push(token)
+  }
+  return out
+}
+
+function parsePyprojectDependencies(content: string): string[] {
+  const out: string[] = []
+  const pep621Array = /dependencies\s*=\s*\[([\s\S]*?)\]/g
+  for (const match of content.matchAll(pep621Array)) {
+    const body = match[1] ?? ""
+    for (const item of body.matchAll(/["']([^"']+)["']/g)) {
+      const raw = item[1]?.trim()
+      if (!raw) continue
+      const token = raw.split(/[<>=!~[\];\s]/)[0]?.trim()
+      if (token) out.push(token)
+    }
+  }
+
+  const poetryBlock = /\[tool\.poetry\.dependencies\]([\s\S]*?)(?:\n\[|$)/g
+  for (const match of content.matchAll(poetryBlock)) {
+    const body = match[1] ?? ""
+    for (const line of body.split(/\r?\n/)) {
+      const dep = line.split("=")[0]?.trim()
+      if (!dep || dep.startsWith("#") || dep === "python") continue
+      out.push(dep.replace(/^['"]|['"]$/g, ""))
+    }
+  }
+  return out
+}
+
+function parseGoModDependencies(content: string): string[] {
+  const out: string[] = []
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (
+      !trimmed ||
+      trimmed === "require (" ||
+      trimmed === ")" ||
+      trimmed.startsWith("module ") ||
+      trimmed.startsWith("go ")
+    ) {
+      continue
+    }
+    if (trimmed.startsWith("require ")) {
+      const dep = trimmed.replace(/^require\s+/, "").split(/\s+/)[0]
+      if (dep) out.push(dep)
+      continue
+    }
+    const dep = trimmed.split(/\s+/)[0]
+    if (dep && !dep.startsWith("//")) out.push(dep)
+  }
+  return out
+}
+
+function parsePomDependencies(content: string): string[] {
+  const out: string[] = []
+  for (const match of content.matchAll(/<artifactId>([^<]+)<\/artifactId>/g)) {
+    const dep = match[1]?.trim()
+    if (dep) out.push(dep)
+  }
+  return out
+}
+
+function parseGradleDependencies(content: string): string[] {
+  const out: string[] = []
+  for (const match of content.matchAll(/["']([^"']+:[^"']+)["']/g)) {
+    const notation = match[1] ?? ""
+    const parts = notation.split(":")
+    if (parts.length >= 2) {
+      out.push(parts[1] ?? "")
+    }
+  }
+  return out.filter(Boolean)
+}
+
+function parseGemfileDependencies(content: string): string[] {
+  const out: string[] = []
+  for (const match of content.matchAll(/^\s*gem\s+["']([^"']+)["']/gm)) {
+    const dep = match[1]?.trim()
+    if (dep) out.push(dep)
+  }
+  return out
+}
+
+function parseComposerDependencies(content: string): string[] {
+  const parsed = JSON.parse(content) as Record<string, unknown>
+  const out: string[] = []
+  for (const field of ["require", "require-dev"]) {
+    const section = parsed[field]
+    if (!section || typeof section !== "object") continue
+    out.push(...Object.keys(section as Record<string, unknown>))
+  }
+  return out
+}
+
+function parseCargoDependencies(content: string): string[] {
+  const out: string[] = []
+  const dependencyBlocks = [
+    /\[dependencies\]([\s\S]*?)(?:\n\[|$)/g,
+    /\[dev-dependencies\]([\s\S]*?)(?:\n\[|$)/g,
+  ]
+  for (const block of dependencyBlocks) {
+    for (const match of content.matchAll(block)) {
+      const body = match[1] ?? ""
+      for (const line of body.split(/\r?\n/)) {
+        const trimmed = line.trim()
+        if (!trimmed || trimmed.startsWith("#")) continue
+        const dep = trimmed.split("=")[0]?.trim()
+        if (dep) out.push(dep)
+      }
+    }
+  }
+  return out
+}
+
+function parseMixDependencies(content: string): string[] {
+  const out: string[] = []
+  for (const match of content.matchAll(/\{\s*:([a-zA-Z0-9_]+)\s*,/g)) {
+    const dep = match[1]?.trim()
+    if (dep) out.push(dep)
+  }
+  return out
+}
+
+function parsePackageSwiftDependencies(content: string): string[] {
+  const out: string[] = []
+  for (const match of content.matchAll(/\.package\([^)]*url:\s*["']([^"']+)["']/g)) {
+    const url = match[1] ?? ""
+    const last = url.split("/").pop()?.replace(/\.git$/i, "")
+    if (last) out.push(last)
+  }
+  return out
+}
+
+function parseDependenciesFromManifest(
+  path: string,
+  content: string,
+): { dependencies: string[]; parsed: boolean } {
+  const file = basename(path).toLowerCase()
+  try {
+    if (file === "package.json") {
+      return { dependencies: parsePackageJsonDependencies(content), parsed: true }
+    }
+    if (file === "requirements.txt") {
+      return { dependencies: parseRequirementsDependencies(content), parsed: true }
+    }
+    if (file === "pyproject.toml") {
+      return { dependencies: parsePyprojectDependencies(content), parsed: true }
+    }
+    if (file === "go.mod") {
+      return { dependencies: parseGoModDependencies(content), parsed: true }
+    }
+    if (file === "pom.xml") {
+      return { dependencies: parsePomDependencies(content), parsed: true }
+    }
+    if (file === "build.gradle" || file === "build.gradle.kts") {
+      return { dependencies: parseGradleDependencies(content), parsed: true }
+    }
+    if (file === "gemfile") {
+      return { dependencies: parseGemfileDependencies(content), parsed: true }
+    }
+    if (file === "composer.json") {
+      return { dependencies: parseComposerDependencies(content), parsed: true }
+    }
+    if (file === "cargo.toml") {
+      return { dependencies: parseCargoDependencies(content), parsed: true }
+    }
+    if (file === "mix.exs") {
+      return { dependencies: parseMixDependencies(content), parsed: true }
+    }
+    if (file === "package.swift") {
+      return { dependencies: parsePackageSwiftDependencies(content), parsed: true }
+    }
+    return { dependencies: [], parsed: true }
+  } catch {
+    return { dependencies: [], parsed: false }
+  }
+}
+
+export function normalizeLibraryName(name: string): string {
+  const key = name.trim().toLowerCase()
+  if (!key) return name
+  return aliasLookup.get(key)?.canonicalName ?? name
+}
+
+export function scoreLibraryCandidate(input: {
+  hasManifestDependency: boolean
+  hasCorroboration: boolean
+  hasImportUsage: boolean
+}): {
+  confidence: number
+  scoreBreakdown: DeterministicLibraryCandidate["scoreBreakdown"]
+} {
+  const manifestDependency = input.hasManifestDependency ? MANIFEST_SCORE : 0
+  const corroboration = input.hasCorroboration ? CORROBORATION_SCORE : 0
+  const importUsage = input.hasImportUsage ? IMPORT_SCORE : 0
+  const total = clamp01(manifestDependency + corroboration + importUsage)
+  return {
+    confidence: total,
+    scoreBreakdown: {
+      manifestDependency,
+      corroboration,
+      importUsage,
+      total,
+    },
+  }
+}
+
+function categorizeCandidate(candidate: DeterministicLibraryCandidate):
+  | "accepted"
+  | "ambiguous"
+  | "rejected" {
+  if (candidate.confidence >= ACCEPTED_THRESHOLD) return "accepted"
+  if (candidate.confidence >= AMBIGUOUS_THRESHOLD) return "ambiguous"
+  return "rejected"
+}
+
+function hasImportSignalForAlias(content: string, alias: LibraryAlias): boolean {
+  for (const token of alias.importTokens) {
+    const escaped = escapeRegExp(token)
+    const stringLiteralRef = new RegExp(`["']${escaped}(?:["'/])`, "i")
+    if (stringLiteralRef.test(content)) return true
+    const importRef = new RegExp(
+      `\\b(?:import|from|require\\s*\\(|use)\\b[^\\n]*${escaped}`,
+      "i",
+    )
+    if (importRef.test(content)) return true
+  }
+  return false
+}
+
+function hasFrameworkMarkerForAlias(content: string, alias: LibraryAlias): boolean {
+  for (const pattern of alias.markerPatterns ?? []) {
+    if (pattern.test(content)) return true
+  }
+  return false
+}
+
+function toCandidateOutput(
+  candidate: CandidateAccumulator,
+): DeterministicLibraryCandidate {
+  const scored = scoreLibraryCandidate({
+    hasManifestDependency: candidate.scoreManifestDependency > 0,
+    hasCorroboration: candidate.scoreCorroboration > 0,
+    hasImportUsage: candidate.scoreImportUsage > 0,
+  })
+  return {
+    root: candidate.root,
+    name: candidate.name,
+    category: candidate.category,
+    confidence: scored.confidence,
+    evidence: candidate.evidence,
+    detectionSignals: Array.from(candidate.detectionSignals),
+    manifestPath: candidate.manifestPath,
+    importPath: candidate.importPath,
+    categorySource: candidate.categorySource,
+    scoreBreakdown: scored.scoreBreakdown,
+  }
+}
+
+export async function detectLibrariesDeterministic(input: {
+  repositoryId: string
+  orgId: string
+  roots: string[]
+  scanPaths?: string[]
+}): Promise<DeterministicLibrariesResult> {
+  const accepted: DeterministicLibraryCandidate[] = []
+  const ambiguous: DeterministicLibraryCandidate[] = []
+  const unresolvedRoots: string[] = []
+  let manifestFilesChecked = 0
+  let manifestParseFailures = 0
+
+  for (const root of input.roots) {
+    const rootPrefix = root === "./" || root === "." ? "" : root
+    const allRootPaths = await listFilesRecursive(
+      input.repositoryId,
+      input.orgId,
+      rootPrefix,
+    )
+    const filteredRootPaths =
+      input.scanPaths && input.scanPaths.length > 0
+        ? allRootPaths.filter((path) => repoPathMatchesPartialScan(path, input.scanPaths ?? []))
+        : allRootPaths
+
+    const manifests = filteredRootPaths.filter((path) =>
+      ROOT_MANIFEST_BASENAMES.has(basename(path).toLowerCase()),
+    )
+    const corroborationPaths = new Set(
+      filteredRootPaths.filter((path) =>
+        LOCK_OR_CONFIG_BASENAMES.has(basename(path).toLowerCase()),
+      ),
+    )
+    const sourceFiles = filteredRootPaths
+      .filter((path) => isSourceFile(path))
+      .slice(0, MAX_IMPORT_FILES_PER_ROOT)
+
+    const fetchTargets = new Set<string>([...manifests, ...sourceFiles])
+    if (fetchTargets.size === 0) {
+      unresolvedRoots.push(root)
+      continue
+    }
+
+    const contents = await fetchFiles(input.repositoryId, input.orgId, [...fetchTargets])
+    const candidates = new Map<string, CandidateAccumulator>()
+
+    for (const manifestPath of manifests) {
+      const content = contents[manifestPath]
+      if (content === undefined) continue
+      manifestFilesChecked += 1
+      const parsed = parseDependenciesFromManifest(manifestPath, content)
+      if (!parsed.parsed) {
+        manifestParseFailures += 1
+        continue
+      }
+      for (const dependency of parsed.dependencies) {
+        const mapped = aliasLookup.get(dependency.toLowerCase())
+        if (!mapped) continue
+        const dedupKey = `${root}::${mapped.canonicalName}`
+        const existing = candidates.get(dedupKey)
+        if (existing) {
+          existing.scoreManifestDependency = MANIFEST_SCORE
+          existing.detectionSignals.add("manifest_dependency")
+          existing.evidence.push(`manifest:${manifestPath}:${dependency}`)
+          if (!existing.manifestPath) existing.manifestPath = manifestPath
+          continue
+        }
+        candidates.set(dedupKey, {
+          root,
+          name: mapped.canonicalName,
+          category: mapped.category,
+          categorySource: mapped.category ? "map" : "manifest",
+          manifestPath,
+          scoreManifestDependency: MANIFEST_SCORE,
+          scoreCorroboration: 0,
+          scoreImportUsage: 0,
+          detectionSignals: new Set(["manifest_dependency"]),
+          evidence: [`manifest:${manifestPath}:${dependency}`],
+        })
+      }
+    }
+
+    if (candidates.size === 0) {
+      unresolvedRoots.push(root)
+      continue
+    }
+
+    const hasCorroborationInRoot = [...corroborationPaths].some((path) =>
+      withinRoot(path, root),
+    )
+    if (hasCorroborationInRoot) {
+      for (const candidate of candidates.values()) {
+        candidate.scoreCorroboration = CORROBORATION_SCORE
+        candidate.detectionSignals.add("lock_or_config")
+        candidate.evidence.push("corroboration:lock_or_config")
+      }
+    }
+
+    for (const sourcePath of sourceFiles) {
+      const sourceContent = contents[sourcePath]
+      if (sourceContent === undefined) continue
+      for (const candidate of candidates.values()) {
+        const alias = aliasLookup.get(candidate.name.toLowerCase())
+        if (!alias) continue
+        if (
+          candidate.scoreImportUsage === 0 &&
+          hasImportSignalForAlias(sourceContent, alias)
+        ) {
+          candidate.scoreImportUsage = IMPORT_SCORE
+          candidate.detectionSignals.add("import_usage")
+          candidate.importPath = sourcePath
+          candidate.evidence.push(`import:${sourcePath}`)
+          candidate.categorySource = candidate.category ? candidate.categorySource : "import"
+        }
+        if (hasFrameworkMarkerForAlias(sourceContent, alias)) {
+          candidate.scoreCorroboration = CORROBORATION_SCORE
+          candidate.detectionSignals.add("framework_marker")
+          candidate.evidence.push(`marker:${sourcePath}`)
+        }
+      }
+    }
+
+    let rootAccepted = 0
+    let rootAmbiguous = 0
+    for (const candidate of candidates.values()) {
+      const output = toCandidateOutput(candidate)
+      const bucket = categorizeCandidate(output)
+      if (bucket === "accepted") {
+        accepted.push(output)
+        rootAccepted += 1
+      } else if (bucket === "ambiguous") {
+        ambiguous.push(output)
+        rootAmbiguous += 1
+      }
+    }
+
+    if (rootAccepted === 0 && rootAmbiguous === 0) {
+      unresolvedRoots.push(root)
+    }
+  }
+
+  const rootsResolvedDeterministically = Array.from(new Set(accepted.map((c) => c.root)))
+  const rootsNeedingLlm = Array.from(
+    new Set([
+      ...unresolvedRoots,
+      ...ambiguous.map((c) => c.root),
+    ]),
+  ).sort()
+
+  return {
+    accepted,
+    ambiguous,
+    unresolvedRoots: Array.from(new Set(unresolvedRoots)).sort(),
+    rootsResolvedDeterministically,
+    rootsNeedingLlm,
+    manifestFilesChecked,
+    manifestParseFailures,
+  }
+}


### PR DESCRIPTION
## Summary
- add a deterministic library detection helper that scans manifest dependencies, lock/config corroboration, and import/framework markers, then scores candidates into accepted vs ambiguous buckets
- integrate `identifyLibraries` with deterministic-first root partitioning so only unresolved/ambiguous roots invoke the LLM path
- preserve existing object/claim contracts while emitting deterministic provenance and adding tests for scoring, fallback behavior, and deterministic-vs-LLM dedup preference

## Test plan
- [x] `pnpm --filter @ctxpipe/backend exec vitest run src/graphs/codeIngestionGraph/nodes/identifyLibraries.test.ts src/graphs/codeIngestionGraph/nodes/identifyLibrariesDeterministic.test.ts`
- [x] `pnpm --filter @ctxpipe/backend exec biome lint src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts src/graphs/codeIngestionGraph/nodes/identifyLibrariesDeterministic.ts src/graphs/codeIngestionGraph/nodes/identifyLibraries.test.ts src/graphs/codeIngestionGraph/nodes/identifyLibrariesDeterministic.test.ts src/graphs/codeIngestionGraph/nodes/README.md`
- [x] `pnpm --filter @ctxpipe/backend test -- src/graphs/codeIngestionGraph/nodes/identifyLibraries.test.ts src/graphs/codeIngestionGraph/nodes/identifyLibrariesDeterministic.test.ts` *(runs full backend suite in this repo; fails due to unrelated pre-existing env/test issues outside changed scope)*
- [x] `pnpm --filter @ctxpipe/backend build` *(fails with multiple pre-existing TypeScript errors outside changed files)*

Made with [Cursor](https://cursor.com)