### PR TITLE
Add deterministic database pass before LLM extraction

### DIFF
--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/README.md
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/README.md
@@ -19,6 +19,16 @@ When `roots` includes both `./` and package paths (e.g. `apps/web`), post-proces
 | identifyPatterns | Pattern | IMPLEMENTS_PATTERN | pat:${repositoryId}:${root}:${patternName} |
 | extractInstructionUnits | InstructionUnit, Skill | HAS_INSTRUCTION, MEMBER_OF_PRIMARY | inu:${repositoryId}:${root}:${hash}, skl:${repositoryId}:${hash} |
 
+## identifyDatabases
+
+Database extraction is now deterministic-first per root, then LLM fallback:
+
+- Deterministic scan scores DB candidates from connection strings / provider config (+0.60), client initialization or driver imports (+0.25), and dependency manifests (+0.15).
+- Candidates with score `>= 0.85` are emitted directly with `extractionMethod: deterministic`.
+- Candidates in `0.60 - 0.84` are treated as ambiguous and fed into the LLM prompt as hints.
+- LLM runs only for roots that are unresolved or ambiguous after deterministic scoring.
+- Root attribution for LLM submissions uses `resolveSubmissionRoot`, so mixed-root repos do not over-attribute unknown paths to `./`.
+
 ## identifyRoots
 
 Root detection is deterministic-first:

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.test.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { CodeIngestionState } from "../schemas.js"
+
+const createAgentMock = vi.hoisted(() => vi.fn())
+const deterministicDetectDatabasesMock = vi.hoisted(() => vi.fn())
+const requireCurrentOrgIdMock = vi.hoisted(() => vi.fn())
+const getModelMock = vi.hoisted(() => vi.fn())
+const loggerInfoMock = vi.hoisted(() => vi.fn())
+const loggerWarnMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../createAgent.js", () => ({
+  createAgent: createAgentMock,
+}))
+
+vi.mock("./identifyDatabasesDeterministic.js", () => ({
+  deterministicDetectDatabases: deterministicDetectDatabasesMock,
+  normalizeDbType: (dbType: string) => dbType,
+}))
+
+vi.mock("../../../auth/context.js", () => ({
+  requireCurrentOrgId: requireCurrentOrgIdMock,
+}))
+
+vi.mock("../../../retrieval/services/modelProvider.js", () => ({
+  getModel: getModelMock,
+}))
+
+vi.mock("../../../observability/logger.js", () => ({
+  getLogger: () => ({
+    info: loggerInfoMock,
+    warn: loggerWarnMock,
+  }),
+}))
+
+import { identifyDatabases } from "./identifyDatabases.js"
+
+function baseState(): CodeIngestionState {
+  return {
+    repositoryId: "repo_test",
+    orgId: "org_test",
+    targetHash: "abc123",
+    roots: ["apps/api"],
+    extractedObjects: [],
+    extractedClaims: [],
+    objectIds: [],
+    touchedObjectIds: [],
+    claimsForProjection: [],
+  }
+}
+
+async function submitDatabasesFromAgent(
+  tools: unknown,
+  databases: Array<{ dbType: string; path: string; evidence?: string }>,
+): Promise<void> {
+  const submitTool = (tools as Array<{ name: string; invoke: (input: unknown) => Promise<unknown> }>).find(
+    (tool) => tool.name === "submit_databases",
+  )
+  if (!submitTool) {
+    throw new Error("submit_databases tool missing in test")
+  }
+  await submitTool.invoke({ databases })
+}
+
+describe("identifyDatabases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getModelMock.mockReturnValue({ model: "test-model" })
+  })
+
+  it("skips LLM when root is fully resolved deterministically", async () => {
+    deterministicDetectDatabasesMock.mockResolvedValue({
+      accepted: [
+        {
+          root: "apps/api",
+          dbType: "Postgres",
+          normalizedDbType: "Postgres",
+          confidence: 0.85,
+          evidence: [],
+          signalKinds: ["provider-config", "client-initialization"],
+          matchedFiles: ["apps/api/prisma/schema.prisma"],
+          scoreBreakdown: {
+            "provider-config": 0.6,
+            "client-initialization": 0.25,
+          },
+        },
+      ],
+      ambiguous: [],
+      unresolvedRoots: [],
+      scanErrors: [],
+    })
+
+    const result = await identifyDatabases(baseState())
+
+    expect(createAgentMock).not.toHaveBeenCalled()
+    expect(result.extractedObjects).toEqual([
+      expect.objectContaining({
+        kind: "Database",
+        deduplicationKey: "db:repo_test:apps/api:Postgres",
+      }),
+    ])
+    expect(result.extractedClaims).toEqual([
+      expect.objectContaining({
+        extractionMethod: "deterministic",
+        confidence: 0.85,
+      }),
+    ])
+  })
+
+  it("merges deterministic and LLM outputs without duplicate DB keys", async () => {
+    deterministicDetectDatabasesMock.mockResolvedValue({
+      accepted: [
+        {
+          root: "apps/worker",
+          dbType: "Postgres",
+          normalizedDbType: "Postgres",
+          confidence: 0.85,
+          evidence: [],
+          signalKinds: ["provider-config", "client-initialization"],
+          matchedFiles: ["apps/worker/prisma/schema.prisma"],
+          scoreBreakdown: {
+            "provider-config": 0.6,
+            "client-initialization": 0.25,
+          },
+        },
+      ],
+      ambiguous: [
+        {
+          root: "apps/worker",
+          dbType: "Redis",
+          normalizedDbType: "Redis",
+          confidence: 0.6,
+          evidence: [],
+          signalKinds: ["connection-string"],
+          matchedFiles: ["apps/worker/.env"],
+          scoreBreakdown: { "connection-string": 0.6 },
+        },
+      ],
+      unresolvedRoots: [],
+      scanErrors: [],
+    })
+
+    createAgentMock.mockImplementation(({ tools }: { tools: unknown }) => ({
+      invoke: async () => {
+        await submitDatabasesFromAgent(tools, [
+          { dbType: "Postgres", path: "apps/worker/prisma/schema.prisma" },
+          { dbType: "Mongo", path: "apps/worker/src/db.ts" },
+        ])
+      },
+    }))
+
+    const result = await identifyDatabases({
+      ...baseState(),
+      roots: ["apps/worker"],
+    })
+
+    expect(createAgentMock).toHaveBeenCalledTimes(1)
+    const objects = result.extractedObjects ?? []
+    expect(objects).toHaveLength(2)
+    expect(
+      objects.filter(
+        (obj) => obj.deduplicationKey === "db:repo_test:apps/worker:Postgres",
+      ),
+    ).toHaveLength(1)
+    const claims = result.extractedClaims ?? []
+    expect(
+      claims.map((claim) => `${claim.objectRef}:${claim.extractionMethod}`).sort(),
+    ).toEqual([
+      "db:repo_test:apps/worker:Mongo:llm",
+      "db:repo_test:apps/worker:Postgres:deterministic",
+    ])
+  })
+
+  it("uses resolveSubmissionRoot semantics for mixed roots", async () => {
+    deterministicDetectDatabasesMock.mockResolvedValue({
+      accepted: [],
+      ambiguous: [],
+      unresolvedRoots: ["./", "apps/worker"],
+      scanErrors: [],
+    })
+
+    createAgentMock.mockImplementation(({ tools }: { tools: unknown }) => ({
+      invoke: async () => {
+        await submitDatabasesFromAgent(tools, [
+          { dbType: "MySQL", path: "vendor/unknown" },
+          { dbType: "Redis", path: "apps/worker/src/queue.ts" },
+        ])
+      },
+    }))
+
+    const result = await identifyDatabases({
+      ...baseState(),
+      roots: ["./", "apps/worker"],
+    })
+
+    const keys = (result.extractedObjects ?? []).map((obj) => obj.deduplicationKey)
+    expect(keys).toEqual(["db:repo_test:apps/worker:Redis"])
+  })
+})

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
@@ -16,32 +16,17 @@ import type {
   ExtractedClaim,
   ExtractedObject,
 } from "../schemas.js"
+import { resolveSubmissionRoot } from "./extractionSubmissionRoot.js"
+import {
+  deterministicDetectDatabases,
+  normalizeDbType,
+} from "./identifyDatabasesDeterministic.js"
 import {
   partialScanPathsForExtractors,
   partialScanPromptSuffix,
   repoPathMatchesPartialScan,
   shouldSkipExtractorForPartialDeletesOnly,
 } from "./partialIngestionScope.js"
-
-function pathMatchesRoot(path: string, root: string): boolean {
-  if (root === "./") return true
-  return path.startsWith(`${root}/`) || path === root
-}
-
-/** Normalize dbType to canonical form for deduplication */
-function normalizeDbType(dbType: string): string {
-  const lower = dbType.toLowerCase()
-  if (lower.includes("postgres") || lower === "pg") return "Postgres"
-  if (lower.includes("mysql")) return "MySQL"
-  if (lower.includes("sqlite")) return "SQLite"
-  if (lower.includes("mongo")) return "Mongo"
-  if (lower.includes("redis")) return "Redis"
-  if (lower.includes("dynamo")) return "DynamoDB"
-  if (lower.includes("supabase")) return "Supabase"
-  if (lower.includes("cassandra")) return "Cassandra"
-  if (lower.includes("cockroach")) return "CockroachDB"
-  return dbType
-}
 
 type SubmittedDatabase = {
   dbType: string
@@ -54,7 +39,7 @@ function createIdentifyDatabasesTools(capturedDbs: {
 }) {
   const submitDatabasesTool = tool(
     async ({ databases }) => {
-      capturedDbs.value.push(...databases)
+      capturedDbs.value.push(...(databases as SubmittedDatabase[]))
       return `Recorded ${databases.length} database(s). Total: ${capturedDbs.value.length}.`
     },
     {
@@ -124,7 +109,7 @@ Cover only the listed roots. Call submit_databases for each database supported b
 export async function identifyDatabases(
   state: CodeIngestionState,
 ): Promise<Partial<CodeIngestionState>> {
-  const { repositoryId, roots = ["./"], targetHash } = state
+  const { repositoryId, orgId, roots = ["./"], targetHash } = state
   requireCurrentOrgId()
 
   if (shouldSkipExtractorForPartialDeletesOnly(state)) {
@@ -139,39 +124,123 @@ export async function identifyDatabases(
 
   const objects: ExtractedObject[] = []
   const claims: ExtractedClaim[] = []
+  const seenDbs = new Set<string>()
 
-  const capturedDbs: { value: SubmittedDatabase[] } = { value: [] }
-  const tools = createIdentifyDatabasesTools(capturedDbs)
-  const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
-    tools,
-    contextMiddleware: {
-      clearToolUsesTriggerTokens: 140_000,
-      clearToolUsesKeepMessages: 14,
-      summarizationTriggerTokens: 220_000,
-      summarizationKeepMessages: 32,
-    },
-    systemPrompt: `${SYSTEM_PROMPT}
-
-Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${roots.join(", ")}.
-
-${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
+  const deterministic = await deterministicDetectDatabases({
+    repositoryId,
+    orgId,
+    roots,
+    scanPaths: state.ingestMode === "partial" ? scanPaths : [],
   })
 
-  const userMessage = `For the listed roots, check config directories and search for database/ORM patterns. Call submit_databases (batch per call) once connection or schema evidence is clear; skip uncertain hits.`
+  for (const candidate of deterministic.accepted) {
+    const dbType = normalizeDbType(candidate.dbType)
+    const dedupKey = `db:${repositoryId}:${candidate.root}:${dbType}`
+    if (seenDbs.has(dedupKey)) continue
+    seenDbs.add(dedupKey)
+    objects.push({
+      kind: "Database",
+      deduplicationKey: dedupKey,
+      name: dbType,
+      summary: `${dbType} used by ${candidate.root}`,
+    })
+    claims.push({
+      subjectRef: `svc:${repositoryId}:${candidate.root}`,
+      subjectKind: "Service",
+      objectRef: dedupKey,
+      objectKind: "Database",
+      predicate: "DEPENDS_ON",
+      sourceId: `identifyDatabases:${repositoryId}:${candidate.root}:${dbType}:${targetHash}`,
+      sourceType: "git",
+      extractionMethod: "deterministic",
+      confidence: candidate.confidence,
+      provenance: {
+        root: candidate.root,
+        dbType,
+        normalizedDbType: candidate.normalizedDbType,
+        signalKinds: candidate.signalKinds,
+        matchedFiles: candidate.matchedFiles,
+        scoreBreakdown: candidate.scoreBreakdown,
+        evidence: candidate.evidence.map((entry) => ({
+          signalKind: entry.signalKind,
+          filePath: entry.filePath,
+          detail: entry.detail,
+        })),
+      },
+    })
+  }
 
-  await agent.invoke(
-    { messages: [new HumanMessage(userMessage)] },
-    mergeConfigs(getConfig(), {
-      recursionLimit: 180,
-    }),
-  )
+  const ambiguousRoots = new Set(deterministic.ambiguous.map((entry) => entry.root))
+  const acceptedRoots = new Set(deterministic.accepted.map((entry) => entry.root))
+  const rootsNeedingLlm = roots.filter((root) => {
+    const hasAccepted = acceptedRoots.has(root)
+    const hasAmbiguous = ambiguousRoots.has(root)
+    return !hasAccepted || hasAmbiguous
+  })
 
-  if (capturedDbs.value.length === 0) {
+  const rootsResolvedDeterministically = roots.filter((root) => {
+    return acceptedRoots.has(root) && !ambiguousRoots.has(root)
+  }).length
+
+  if (
+    deterministic.scanErrors.length > 0 &&
+    deterministic.accepted.length === 0 &&
+    deterministic.ambiguous.length === 0
+  ) {
     getLogger().warn(
-      "identifyDatabases: agent completed without submit_databases (no databases captured)",
-      { repositoryId, targetHash },
+      "identifyDatabases: deterministic scan failed before LLM fallback",
+      {
+        repositoryId,
+        targetHash,
+        scanErrors: deterministic.scanErrors,
+      },
     )
+  }
+
+  const capturedDbs: { value: SubmittedDatabase[] } = { value: [] }
+  if (rootsNeedingLlm.length > 0) {
+    const ambiguousByRoot = deterministic.ambiguous
+      .filter((entry) => rootsNeedingLlm.includes(entry.root))
+      .map((entry) => {
+        return `${entry.root}:${entry.dbType} (${entry.confidence.toFixed(2)} via ${entry.signalKinds.join("+")})`
+      })
+    const deterministicHint =
+      ambiguousByRoot.length > 0
+        ? `\nDeterministic ambiguous candidates:\n- ${ambiguousByRoot.join("\n- ")}\nUse these as hints and verify against repository evidence.`
+        : ""
+
+    const tools = createIdentifyDatabasesTools(capturedDbs)
+    const agent = createAgent({
+      model: getModel("medium", { temperature: 0.1 }),
+      tools,
+      contextMiddleware: {
+        clearToolUsesTriggerTokens: 140_000,
+        clearToolUsesKeepMessages: 14,
+        summarizationTriggerTokens: 220_000,
+        summarizationKeepMessages: 32,
+      },
+      systemPrompt: `${SYSTEM_PROMPT}
+
+Use repositoryId "${repositoryId}" for all tool calls. Roots to explore: ${rootsNeedingLlm.join(", ")}.
+
+${REPO_EXPLORER_TOOLS_HINT}${scopeHint}${deterministicHint}`,
+    })
+
+    const userMessage = `For these roots only: ${rootsNeedingLlm.join(", ")}. Check config directories and search for database/ORM patterns. Call submit_databases (batch per call) once connection or schema evidence is clear; skip uncertain hits.`
+
+    await agent.invoke(
+      { messages: [new HumanMessage(userMessage)] },
+      mergeConfigs(getConfig(), {
+        recursionLimit: 180,
+      }),
+    )
+
+    if (capturedDbs.value.length === 0) {
+      getLogger().warn(
+        "identifyDatabases: agent completed without submit_databases (no databases captured)",
+        { repositoryId, targetHash, rootsNeedingLlm },
+      )
+    }
   }
 
   let submissions = capturedDbs.value
@@ -181,37 +250,44 @@ ${REPO_EXPLORER_TOOLS_HINT}${scopeHint}`,
     )
   }
 
-  const seenDbs = new Set<string>()
-  for (const root of roots) {
-    const svcDeduplicationKey = `svc:${repositoryId}:${root}`
-    for (const db of submissions) {
-      if (!pathMatchesRoot(db.path, root)) continue
-      const dbType = normalizeDbType(db.dbType)
-      const dedupKey = `db:${repositoryId}:${root}:${dbType}`
-      if (seenDbs.has(dedupKey)) continue
-      seenDbs.add(dedupKey)
+  for (const db of submissions) {
+    const root = resolveSubmissionRoot(db.path, rootsNeedingLlm)
+    if (root === null) continue
+    const dbType = normalizeDbType(db.dbType)
+    const dedupKey = `db:${repositoryId}:${root}:${dbType}`
+    if (seenDbs.has(dedupKey)) continue
+    seenDbs.add(dedupKey)
 
-      objects.push({
-        kind: "Database",
-        deduplicationKey: dedupKey,
-        name: dbType,
-        summary: `${dbType} used by ${root}`,
-      })
+    objects.push({
+      kind: "Database",
+      deduplicationKey: dedupKey,
+      name: dbType,
+      summary: `${dbType} used by ${root}`,
+    })
 
-      claims.push({
-        subjectRef: svcDeduplicationKey,
-        subjectKind: "Service",
-        objectRef: dedupKey,
-        objectKind: "Database",
-        predicate: "DEPENDS_ON",
-        sourceId: `identifyDatabases:${repositoryId}:${root}:${dbType}:${targetHash}`,
-        sourceType: "git",
-        extractionMethod: "llm",
-        confidence: 0.8,
-        provenance: { root, dbType, evidence: db.evidence },
-      })
-    }
+    claims.push({
+      subjectRef: `svc:${repositoryId}:${root}`,
+      subjectKind: "Service",
+      objectRef: dedupKey,
+      objectKind: "Database",
+      predicate: "DEPENDS_ON",
+      sourceId: `identifyDatabases:${repositoryId}:${root}:${dbType}:${targetHash}`,
+      sourceType: "git",
+      extractionMethod: "llm",
+      confidence: 0.8,
+      provenance: { root, dbType, evidence: db.evidence },
+    })
   }
+
+  getLogger().info("identifyDatabases: deterministic + llm summary", {
+    repositoryId,
+    targetHash,
+    rootsTotal: roots.length,
+    rootsResolvedDeterministically,
+    rootsNeedingLlm: rootsNeedingLlm.length,
+    deterministicAccepted: deterministic.accepted.length,
+    ambiguousCount: deterministic.ambiguous.length,
+  })
 
   return {
     extractedObjects: objects,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabasesDeterministic.test.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabasesDeterministic.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const listFilesRecursiveMock = vi.hoisted(() => vi.fn())
+const fetchFilesMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../../domain/codeIngestion/codesearchClient.js", () => ({
+  listFilesRecursive: listFilesRecursiveMock,
+  fetchFiles: fetchFilesMock,
+}))
+
+import {
+  deterministicDetectDatabases,
+  normalizeDbType,
+} from "./identifyDatabasesDeterministic.js"
+
+describe("identifyDatabasesDeterministic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("normalizes db aliases to canonical names", () => {
+    expect(normalizeDbType("postgresql")).toBe("Postgres")
+    expect(normalizeDbType("pg")).toBe("Postgres")
+    expect(normalizeDbType("redis")).toBe("Redis")
+    expect(normalizeDbType("cockroach")).toBe("CockroachDB")
+  })
+
+  it("keeps provider-only signals in ambiguous range", async () => {
+    listFilesRecursiveMock.mockResolvedValue(["apps/api/prisma/schema.prisma"])
+    fetchFilesMock.mockResolvedValue({
+      "apps/api/prisma/schema.prisma":
+        'datasource db { provider = "postgresql" url = env("DATABASE_URL") }',
+    })
+
+    const result = await deterministicDetectDatabases({
+      repositoryId: "repo_test",
+      orgId: "org_test",
+      roots: ["apps/api"],
+      scanPaths: [],
+    })
+
+    expect(result.accepted).toHaveLength(0)
+    expect(result.ambiguous).toHaveLength(1)
+    expect(result.ambiguous[0]).toMatchObject({
+      root: "apps/api",
+      dbType: "Postgres",
+      confidence: 0.6,
+      signalKinds: ["provider-config"],
+    })
+    expect(result.unresolvedRoots).toHaveLength(0)
+  })
+
+  it("accepts candidates when independent signals corroborate", async () => {
+    listFilesRecursiveMock.mockResolvedValue([
+      "apps/api/prisma/schema.prisma",
+      "apps/api/package.json",
+      "apps/api/src/db.ts",
+    ])
+    fetchFilesMock.mockResolvedValue({
+      "apps/api/prisma/schema.prisma":
+        'datasource db { provider = "postgresql" url = env("DATABASE_URL") }',
+      "apps/api/package.json": JSON.stringify({
+        dependencies: { pg: "^8.0.0" },
+      }),
+      "apps/api/src/db.ts": 'import { Pool } from "pg"\nconst pool = new Pool()',
+    })
+
+    const result = await deterministicDetectDatabases({
+      repositoryId: "repo_test",
+      orgId: "org_test",
+      roots: ["apps/api"],
+      scanPaths: [],
+    })
+
+    expect(result.accepted).toHaveLength(1)
+    const accepted = result.accepted[0]
+    expect(accepted).toBeDefined()
+    if (!accepted) throw new Error("expected accepted database candidate")
+    expect(accepted).toMatchObject({
+      root: "apps/api",
+      dbType: "Postgres",
+      confidence: 1,
+    })
+    expect(accepted.signalKinds.sort()).toEqual(
+      ["provider-config", "driver-dependency", "client-initialization"].sort(),
+    )
+    expect(result.ambiguous).toHaveLength(0)
+    expect(result.unresolvedRoots).toHaveLength(0)
+  })
+
+  it("respects partial scan filtering by root paths", async () => {
+    listFilesRecursiveMock.mockImplementation(
+      async (_repositoryId: string, _orgId: string, root: string) => {
+        if (root === "apps/api") {
+          return ["apps/api/package.json", "apps/api/src/db.ts"]
+        }
+        if (root === "apps/worker") {
+          return ["apps/worker/.env"]
+        }
+        return []
+      },
+    )
+    fetchFilesMock.mockResolvedValue({
+      "apps/api/src/db.ts": 'import { Pool } from "pg"\nconst pool = new Pool()',
+      "apps/api/package.json": JSON.stringify({
+        dependencies: { pg: "^8.0.0" },
+      }),
+      "apps/worker/.env": "DATABASE_URL=postgres://worker",
+    })
+
+    const result = await deterministicDetectDatabases({
+      repositoryId: "repo_test",
+      orgId: "org_test",
+      roots: ["apps/api", "apps/worker"],
+      scanPaths: ["apps/api/src/db.ts"],
+    })
+
+    expect(result.accepted).toHaveLength(0)
+    expect(result.ambiguous).toHaveLength(0)
+    expect(result.unresolvedRoots.sort()).toEqual(["apps/api", "apps/worker"])
+  })
+})

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabasesDeterministic.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabasesDeterministic.ts
@@ -1,0 +1,642 @@
+import {
+  fetchFiles,
+  listFilesRecursive,
+} from "../../../domain/codeIngestion/codesearchClient.js"
+import { repoPathMatchesPartialScan } from "./partialIngestionScope.js"
+
+export type DatabaseSignalKind =
+  | "connection-string"
+  | "provider-config"
+  | "client-initialization"
+  | "driver-dependency"
+
+export type DeterministicDatabaseEvidence = {
+  signalKind: DatabaseSignalKind
+  filePath: string
+  detail: string
+}
+
+export type DeterministicDatabaseCandidate = {
+  root: string
+  dbType: string
+  normalizedDbType: string
+  confidence: number
+  evidence: DeterministicDatabaseEvidence[]
+  signalKinds: DatabaseSignalKind[]
+  matchedFiles: string[]
+  scoreBreakdown: Partial<Record<DatabaseSignalKind, number>>
+}
+
+export type DeterministicDatabasesResult = {
+  accepted: DeterministicDatabaseCandidate[]
+  ambiguous: DeterministicDatabaseCandidate[]
+  unresolvedRoots: string[]
+  scanErrors: { root: string; error: string }[]
+}
+
+type DeterministicScanInput = {
+  repositoryId: string
+  orgId: string
+  roots: string[]
+  scanPaths: string[]
+}
+
+type EvidenceAccumulator = {
+  evidence: DeterministicDatabaseEvidence[]
+  scoreBreakdown: Partial<Record<DatabaseSignalKind, number>>
+}
+
+const SIGNAL_POINTS: Record<DatabaseSignalKind, number> = {
+  "connection-string": 0.6,
+  "provider-config": 0.6,
+  "client-initialization": 0.25,
+  "driver-dependency": 0.15,
+}
+
+const DETERMINISTIC_ACCEPT_THRESHOLD = 0.85
+const DETERMINISTIC_AMBIGUOUS_THRESHOLD = 0.6
+
+const MANIFEST_FILE_NAMES = new Set([
+  "package.json",
+  "requirements.txt",
+  "pyproject.toml",
+  "pipfile",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "cargo.toml",
+  "mix.exs",
+  "composer.json",
+  "gemfile",
+])
+
+const SOURCE_FILE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".mts",
+  ".cts",
+  ".py",
+  ".go",
+  ".java",
+  ".kt",
+  ".rb",
+  ".php",
+  ".cs",
+  ".rs",
+  ".ex",
+  ".exs",
+])
+
+const SOURCE_PRIORITY_PATH_HINT = /db|database|prisma|drizzle|mongo|redis|dynamo|supabase|sql|orm|cache/i
+const SOURCE_PRIORITY_BASENAME = new Set([
+  "server.ts",
+  "server.js",
+  "app.ts",
+  "app.js",
+  "main.ts",
+  "main.js",
+  "index.ts",
+  "index.js",
+  "settings.py",
+  "config.py",
+])
+
+const MAX_SOURCE_FILES_PER_ROOT = 140
+const MAX_FILES_PER_ROOT = 220
+
+const DB_ALIAS_MAP: Record<string, string> = {
+  postgres: "Postgres",
+  postgresql: "Postgres",
+  pg: "Postgres",
+  mysql: "MySQL",
+  mariadb: "MySQL",
+  sqlite: "SQLite",
+  sqlite3: "SQLite",
+  mongo: "Mongo",
+  mongodb: "Mongo",
+  redis: "Redis",
+  dynamodb: "DynamoDB",
+  supabase: "Supabase",
+  cassandra: "Cassandra",
+  cockroach: "CockroachDB",
+  cockroachdb: "CockroachDB",
+}
+
+const CONNECTION_STRING_PATTERNS: Array<{
+  dbType: string
+  pattern: RegExp
+  detail: string
+}> = [
+  {
+    dbType: "Postgres",
+    pattern: /\bpostgres(?:ql)?:\/\//i,
+    detail: "postgres connection string",
+  },
+  {
+    dbType: "MySQL",
+    pattern: /\bmysql(?:\+\w+)?:\/\//i,
+    detail: "mysql connection string",
+  },
+  {
+    dbType: "SQLite",
+    pattern: /\bsqlite(?:\+\w+)?:/i,
+    detail: "sqlite connection string",
+  },
+  {
+    dbType: "Mongo",
+    pattern: /\bmongodb(?:\+srv)?:\/\//i,
+    detail: "mongodb connection string",
+  },
+  {
+    dbType: "Redis",
+    pattern: /\bredis(?:\+\w+)?:\/\//i,
+    detail: "redis connection string",
+  },
+  {
+    dbType: "CockroachDB",
+    pattern: /\bcockroach(?:db)?:\/\//i,
+    detail: "cockroach connection string",
+  },
+]
+
+const DEPENDENCY_TOKEN_MAP: Record<string, string> = {
+  pg: "Postgres",
+  "pgx/v5": "Postgres",
+  psycopg2: "Postgres",
+  psycopg: "Postgres",
+  asyncpg: "Postgres",
+  npgsql: "Postgres",
+  mysql2: "MySQL",
+  mysql: "MySQL",
+  pymysql: "MySQL",
+  mariadb: "MySQL",
+  sqlite3: "SQLite",
+  "better-sqlite3": "SQLite",
+  mongoose: "Mongo",
+  mongodb: "Mongo",
+  pymongo: "Mongo",
+  ioredis: "Redis",
+  redis: "Redis",
+  "@upstash/redis": "Redis",
+  "go-redis/redis": "Redis",
+  "@aws-sdk/client-dynamodb": "DynamoDB",
+  "aws-sdk-dynamodb": "DynamoDB",
+  "@supabase/supabase-js": "Supabase",
+  "supabase-py": "Supabase",
+  "cassandra-driver": "Cassandra",
+  gocql: "Cassandra",
+  cockroachdb: "CockroachDB",
+}
+
+const CLIENT_INIT_PATTERNS: Array<{ dbType: string; pattern: RegExp; detail: string }> =
+  [
+    {
+      dbType: "Postgres",
+      pattern: /\bfrom\s+["']pg["']|require\(\s*["']pg["']\s*\)|\bnew\s+(?:Pool|Client)\s*\(/i,
+      detail: "pg client import or initialization",
+    },
+    {
+      dbType: "MySQL",
+      pattern: /\bfrom\s+["']mysql2?["']|require\(\s*["']mysql2?["']\s*\)|\bcreatePool\s*\([^)]*mysql/i,
+      detail: "mysql client import or initialization",
+    },
+    {
+      dbType: "Mongo",
+      pattern: /\bMongoClient\b|\bfrom\s+["']mongodb["']|\bfrom\s+["']mongoose["']/i,
+      detail: "mongodb client import or initialization",
+    },
+    {
+      dbType: "Redis",
+      pattern: /\bfrom\s+["']ioredis["']|\bnew\s+Redis\s*\(|\bcreateClient\s*\([^)]*redis/i,
+      detail: "redis client import or initialization",
+    },
+    {
+      dbType: "DynamoDB",
+      pattern: /\bDynamoDBClient\b|\bfrom\s+["']@aws-sdk\/client-dynamodb["']/i,
+      detail: "dynamodb client import or initialization",
+    },
+    {
+      dbType: "Supabase",
+      pattern: /\bcreateClient\s*\([^)]*supabase|from\s+["']@supabase\/supabase-js["']/i,
+      detail: "supabase client import or initialization",
+    },
+  ]
+
+function basename(path: string): string {
+  const parts = path.split("/")
+  return parts[parts.length - 1] ?? path
+}
+
+function fileExtension(path: string): string {
+  const name = basename(path).toLowerCase()
+  const idx = name.lastIndexOf(".")
+  if (idx === -1) return ""
+  return name.slice(idx)
+}
+
+function normalizeRootPath(root: string): string {
+  if (root === "./" || root === ".") return ""
+  return root
+}
+
+export function normalizeDbType(dbType: string): string {
+  const lower = dbType.toLowerCase().trim()
+  if (!lower) return dbType
+  return DB_ALIAS_MAP[lower] ?? dbType
+}
+
+function isManifestPath(path: string): boolean {
+  return MANIFEST_FILE_NAMES.has(basename(path).toLowerCase())
+}
+
+function isConfigPath(path: string): boolean {
+  const lowerPath = path.toLowerCase()
+  const lowerBase = basename(path).toLowerCase()
+  return (
+    lowerBase.startsWith(".env") ||
+    lowerPath.endsWith("schema.prisma") ||
+    lowerPath.includes("drizzle.config.") ||
+    lowerPath.endsWith("alembic.ini") ||
+    lowerPath.endsWith("application.yml") ||
+    lowerPath.endsWith("application.yaml") ||
+    lowerPath.endsWith("application.properties") ||
+    lowerPath.endsWith("database.yml") ||
+    lowerPath.endsWith("database.php") ||
+    lowerPath.endsWith("appsettings.json") ||
+    lowerPath.endsWith("settings.py")
+  )
+}
+
+function isSourcePath(path: string): boolean {
+  return SOURCE_FILE_EXTENSIONS.has(fileExtension(path))
+}
+
+function pickSourceFiles(paths: string[]): string[] {
+  const sourcePaths = paths.filter((path) => isSourcePath(path))
+  if (sourcePaths.length <= MAX_SOURCE_FILES_PER_ROOT) return sourcePaths
+  const prioritized = sourcePaths.filter((path) => {
+    const lower = path.toLowerCase()
+    const base = basename(path).toLowerCase()
+    return SOURCE_PRIORITY_PATH_HINT.test(lower) || SOURCE_PRIORITY_BASENAME.has(base)
+  })
+  return prioritized.slice(0, MAX_SOURCE_FILES_PER_ROOT)
+}
+
+function shouldScanPathForPartial(path: string, scanPaths: string[]): boolean {
+  if (scanPaths.length === 0) return true
+  return repoPathMatchesPartialScan(path, scanPaths)
+}
+
+function addEvidence(
+  byDbType: Map<string, EvidenceAccumulator>,
+  dbType: string,
+  evidence: DeterministicDatabaseEvidence,
+): void {
+  const normalized = normalizeDbType(dbType)
+  const existing = byDbType.get(normalized) ?? {
+    evidence: [],
+    scoreBreakdown: {},
+  }
+
+  existing.evidence.push(evidence)
+  if (existing.scoreBreakdown[evidence.signalKind] === undefined) {
+    existing.scoreBreakdown[evidence.signalKind] = SIGNAL_POINTS[evidence.signalKind]
+  }
+
+  byDbType.set(normalized, existing)
+}
+
+function detectConnectionStringSignals(
+  content: string,
+  filePath: string,
+): Array<{ dbType: string; evidence: DeterministicDatabaseEvidence }> {
+  const found: Array<{ dbType: string; evidence: DeterministicDatabaseEvidence }> =
+    []
+  for (const entry of CONNECTION_STRING_PATTERNS) {
+    if (!entry.pattern.test(content)) continue
+    found.push({
+      dbType: entry.dbType,
+      evidence: {
+        signalKind: "connection-string",
+        filePath,
+        detail: entry.detail,
+      },
+    })
+  }
+  return found
+}
+
+function detectProviderSignals(
+  content: string,
+  filePath: string,
+): Array<{ dbType: string; evidence: DeterministicDatabaseEvidence }> {
+  const lowerPath = filePath.toLowerCase()
+  const out: Array<{ dbType: string; evidence: DeterministicDatabaseEvidence }> = []
+
+  if (lowerPath.endsWith("schema.prisma")) {
+    const providerMatch = content.match(/provider\s*=\s*"([^"]+)"/i)
+    if (providerMatch?.[1]) {
+      out.push({
+        dbType: providerMatch[1],
+        evidence: {
+          signalKind: "provider-config",
+          filePath,
+          detail: `prisma provider=${providerMatch[1]}`,
+        },
+      })
+    }
+  }
+
+  if (lowerPath.includes("drizzle.config.")) {
+    const dialectMatch = content.match(/dialect\s*:\s*["']([^"']+)["']/i)
+    if (dialectMatch?.[1]) {
+      out.push({
+        dbType: dialectMatch[1],
+        evidence: {
+          signalKind: "provider-config",
+          filePath,
+          detail: `drizzle dialect=${dialectMatch[1]}`,
+        },
+      })
+    }
+  }
+
+  const springJdbcMatch = content.match(/jdbc:(postgresql|mysql|sqlite|mariadb):/i)
+  if (springJdbcMatch?.[1]) {
+    out.push({
+      dbType: springJdbcMatch[1],
+      evidence: {
+        signalKind: "provider-config",
+        filePath,
+        detail: `jdbc provider=${springJdbcMatch[1]}`,
+      },
+    })
+  }
+
+  const djangoEngineMatch = content.match(
+    /django\.db\.backends\.(postgresql|mysql|sqlite3)/i,
+  )
+  if (djangoEngineMatch?.[1]) {
+    out.push({
+      dbType: djangoEngineMatch[1],
+      evidence: {
+        signalKind: "provider-config",
+        filePath,
+        detail: `django engine=${djangoEngineMatch[1]}`,
+      },
+    })
+  }
+
+  const railsAdapterMatch = content.match(/adapter:\s*(postgresql|mysql2|sqlite3)/i)
+  if (railsAdapterMatch?.[1]) {
+    out.push({
+      dbType: railsAdapterMatch[1],
+      evidence: {
+        signalKind: "provider-config",
+        filePath,
+        detail: `rails adapter=${railsAdapterMatch[1]}`,
+      },
+    })
+  }
+
+  return out
+}
+
+function parsePackageJsonDependencies(content: string): string[] {
+  try {
+    const parsed = JSON.parse(content) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+      peerDependencies?: Record<string, string>
+      optionalDependencies?: Record<string, string>
+    }
+    const names = new Set<string>()
+    for (const field of [
+      parsed.dependencies,
+      parsed.devDependencies,
+      parsed.peerDependencies,
+      parsed.optionalDependencies,
+    ]) {
+      if (!field) continue
+      for (const dep of Object.keys(field)) {
+        names.add(dep.toLowerCase())
+      }
+    }
+    return Array.from(names)
+  } catch {
+    return []
+  }
+}
+
+function detectDependencySignals(
+  content: string,
+  filePath: string,
+): Array<{ dbType: string; evidence: DeterministicDatabaseEvidence }> {
+  const lowerPath = filePath.toLowerCase()
+  const out: Array<{ dbType: string; evidence: DeterministicDatabaseEvidence }> = []
+
+  const dependencyTokens = new Set<string>()
+  if (lowerPath.endsWith("package.json")) {
+    for (const dep of parsePackageJsonDependencies(content)) {
+      dependencyTokens.add(dep)
+    }
+  } else {
+    const lowered = content.toLowerCase()
+    for (const token of Object.keys(DEPENDENCY_TOKEN_MAP)) {
+      if (lowered.includes(token)) {
+        dependencyTokens.add(token)
+      }
+    }
+  }
+
+  for (const token of dependencyTokens) {
+    const dbType = DEPENDENCY_TOKEN_MAP[token]
+    if (!dbType) continue
+    out.push({
+      dbType,
+      evidence: {
+        signalKind: "driver-dependency",
+        filePath,
+        detail: `dependency token=${token}`,
+      },
+    })
+  }
+
+  return out
+}
+
+function detectClientSignals(
+  content: string,
+  filePath: string,
+): Array<{ dbType: string; evidence: DeterministicDatabaseEvidence }> {
+  const out: Array<{ dbType: string; evidence: DeterministicDatabaseEvidence }> = []
+  for (const entry of CLIENT_INIT_PATTERNS) {
+    if (!entry.pattern.test(content)) continue
+    out.push({
+      dbType: entry.dbType,
+      evidence: {
+        signalKind: "client-initialization",
+        filePath,
+        detail: entry.detail,
+      },
+    })
+  }
+  return out
+}
+
+function scoreCandidate(accumulator: EvidenceAccumulator): {
+  confidence: number
+  signalKinds: DatabaseSignalKind[]
+  matchedFiles: string[]
+  scoreBreakdown: Partial<Record<DatabaseSignalKind, number>>
+} {
+  const score = Object.values(accumulator.scoreBreakdown).reduce(
+    (sum, points) => sum + (points ?? 0),
+    0,
+  )
+  return {
+    confidence: Math.min(1, Number(score.toFixed(2))),
+    signalKinds: Object.keys(accumulator.scoreBreakdown) as DatabaseSignalKind[],
+    matchedFiles: Array.from(new Set(accumulator.evidence.map((ev) => ev.filePath))),
+    scoreBreakdown: accumulator.scoreBreakdown,
+  }
+}
+
+function classifyRootCandidates(
+  root: string,
+  byDbType: Map<string, EvidenceAccumulator>,
+): { accepted: DeterministicDatabaseCandidate[]; ambiguous: DeterministicDatabaseCandidate[] } {
+  const accepted: DeterministicDatabaseCandidate[] = []
+  const ambiguous: DeterministicDatabaseCandidate[] = []
+
+  for (const [dbType, accumulator] of byDbType.entries()) {
+    const scored = scoreCandidate(accumulator)
+    const candidate: DeterministicDatabaseCandidate = {
+      root,
+      dbType,
+      normalizedDbType: normalizeDbType(dbType),
+      confidence: scored.confidence,
+      evidence: accumulator.evidence,
+      signalKinds: scored.signalKinds,
+      matchedFiles: scored.matchedFiles,
+      scoreBreakdown: scored.scoreBreakdown,
+    }
+    if (candidate.confidence >= DETERMINISTIC_ACCEPT_THRESHOLD) {
+      accepted.push(candidate)
+    } else if (candidate.confidence >= DETERMINISTIC_AMBIGUOUS_THRESHOLD) {
+      ambiguous.push(candidate)
+    }
+  }
+
+  return { accepted, ambiguous }
+}
+
+async function collectRootFilePaths(
+  repositoryId: string,
+  orgId: string,
+  root: string,
+): Promise<string[]> {
+  return listFilesRecursive(repositoryId, orgId, normalizeRootPath(root))
+}
+
+function selectFilesForRoot(paths: string[]): string[] {
+  const manifestsAndConfig = paths.filter(
+    (path) => isManifestPath(path) || isConfigPath(path),
+  )
+  const sourceFiles = pickSourceFiles(paths)
+  return Array.from(new Set([...manifestsAndConfig, ...sourceFiles])).slice(
+    0,
+    MAX_FILES_PER_ROOT,
+  )
+}
+
+function detectSignalsForFile(
+  byDbType: Map<string, EvidenceAccumulator>,
+  filePath: string,
+  content: string,
+): void {
+  for (const signal of detectConnectionStringSignals(content, filePath)) {
+    addEvidence(byDbType, signal.dbType, signal.evidence)
+  }
+
+  for (const provider of detectProviderSignals(content, filePath)) {
+    addEvidence(byDbType, provider.dbType, provider.evidence)
+  }
+
+  for (const dependency of detectDependencySignals(content, filePath)) {
+    addEvidence(byDbType, dependency.dbType, dependency.evidence)
+  }
+
+  for (const client of detectClientSignals(content, filePath)) {
+    addEvidence(byDbType, client.dbType, client.evidence)
+  }
+}
+
+export async function deterministicDetectDatabases(
+  input: DeterministicScanInput,
+): Promise<DeterministicDatabasesResult> {
+  const accepted: DeterministicDatabaseCandidate[] = []
+  const ambiguous: DeterministicDatabaseCandidate[] = []
+  const unresolvedRoots: string[] = []
+  const scanErrors: { root: string; error: string }[] = []
+
+  for (const root of input.roots) {
+    let rootPaths: string[]
+    try {
+      rootPaths = await collectRootFilePaths(input.repositoryId, input.orgId, root)
+    } catch (error) {
+      unresolvedRoots.push(root)
+      scanErrors.push({
+        root,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
+
+    const pathsToInspect = selectFilesForRoot(rootPaths).filter((path) =>
+      shouldScanPathForPartial(path, input.scanPaths),
+    )
+    if (pathsToInspect.length === 0) {
+      unresolvedRoots.push(root)
+      continue
+    }
+
+    let fileContents: Record<string, string>
+    try {
+      fileContents = await fetchFiles(input.repositoryId, input.orgId, pathsToInspect)
+    } catch (error) {
+      unresolvedRoots.push(root)
+      scanErrors.push({
+        root,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
+
+    const byDbType = new Map<string, EvidenceAccumulator>()
+    for (const path of pathsToInspect) {
+      const content = fileContents[path]
+      if (!content) continue
+      detectSignalsForFile(byDbType, path, content)
+    }
+
+    const classified = classifyRootCandidates(root, byDbType)
+    accepted.push(...classified.accepted)
+    ambiguous.push(...classified.ambiguous)
+    if (classified.accepted.length === 0 && classified.ambiguous.length === 0) {
+      unresolvedRoots.push(root)
+    }
+  }
+
+  return {
+    accepted,
+    ambiguous,
+    unresolvedRoots: Array.from(new Set(unresolvedRoots)),
+    scanErrors,
+  }
+}


### PR DESCRIPTION
## Summary
- add a deterministic database detector that scores connection strings, provider config, client initialization/imports, and dependency manifests per root
- run deterministic extraction first in `identifyDatabases`, emit deterministic claims for high-confidence candidates, and only invoke LLM for ambiguous/unresolved roots
- align LLM submission root attribution with `resolveSubmissionRoot` and add tests + node docs for deterministic thresholds and merged output behavior

## Test plan
- [x] `pnpm --filter @ctxpipe/backend exec vitest run src/graphs/codeIngestionGraph/nodes/identifyDatabasesDeterministic.test.ts src/graphs/codeIngestionGraph/nodes/identifyDatabases.test.ts`
- [x] `pnpm --filter @ctxpipe/backend exec biome lint src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts src/graphs/codeIngestionGraph/nodes/identifyDatabasesDeterministic.ts src/graphs/codeIngestionGraph/nodes/identifyDatabasesDeterministic.test.ts src/graphs/codeIngestionGraph/nodes/identifyDatabases.test.ts`
- [ ] `pnpm --filter @ctxpipe/backend build` *(currently fails due pre-existing backend TypeScript errors unrelated to this change)*

Made with [Cursor](https://cursor.com)