### PR TITLE
Fix Bedrock embedding model validation in aws-cdk

### DIFF
--- a/.changeset/odd-cameras-lie.md
+++ b/.changeset/odd-cameras-lie.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Validate Bedrock embedding model IDs in `CtxPipe` so non-Cohere values fail fast at synth/deploy instead of causing runtime ingestion failures. Also treat blank `models.embedding` as unset and keep the default `cohere.embed-v4:0`.

--- a/apps/backend/src/retrieval/services/modelProvider.test.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.test.ts
@@ -243,6 +243,26 @@ describe("modelProvider", () => {
     expect(embedding).toHaveLength(2000)
   })
 
+  it("generateEmbedding keeps inference-profile model id and cohere settings", async () => {
+    process.env.MODEL_PROVIDER = "bedrock"
+    delete process.env.MODEL_PROVIDER_API_KEY
+    process.env.MODEL_BEDROCK_AWS_REGION = "us-west-2"
+    process.env.MODEL_EMBEDDING_NAME = "global.cohere.embed-v4:0"
+    mockBedrockSend.mockResolvedValue({ body: fakeCohereEmbedResponse() })
+    vi.resetModules()
+    const { generateEmbedding } = await import("./modelProvider.js")
+    await generateEmbedding("hello")
+
+    const command = mockBedrockSend.mock.calls[0]?.[0] as {
+      input?: { modelId?: string; body?: string }
+    }
+    expect(command.input?.modelId).toBe("global.cohere.embed-v4:0")
+    const body = JSON.parse(String(command.input?.body)) as {
+      output_dimension?: number
+    }
+    expect(body.output_dimension).toBe(1536)
+  })
+
   it("getModel passes reasoning.effort from slash default specs on OpenRouter", async () => {
     process.env.MODEL_PROVIDER = "openrouter"
     process.env.MODEL_PROVIDER_API_KEY = "k"

--- a/apps/backend/src/retrieval/services/providers/bedrockEmbeddings.ts
+++ b/apps/backend/src/retrieval/services/providers/bedrockEmbeddings.ts
@@ -10,6 +10,10 @@ const TARGET_EMBEDDING_DIMENSIONS = 2000
 /** Cohere Embed v4 on Bedrock supports up to 1536 output dimensions. */
 const COHERE_EMBED_V4_MAX_DIMENSIONS = 1536
 
+function stripInferenceProfilePrefix(modelId: string): string {
+  return modelId.replace(/^(?:global|us|eu|ap|apac|au|jp|us-gov)\./i, "")
+}
+
 function padEmbeddingToTargetDimensions(embedding: number[]): number[] {
   if (embedding.length >= TARGET_EMBEDDING_DIMENSIONS) {
     return embedding.slice(0, TARGET_EMBEDDING_DIMENSIONS)
@@ -45,7 +49,7 @@ export async function invokeBedrockEmbedding(
     embedding_types: ["float"],
   }
 
-  if (modelId.startsWith("cohere.embed")) {
+  if (stripInferenceProfilePrefix(modelId).startsWith("cohere.embed")) {
     requestBody.output_dimension = COHERE_EMBED_V4_MAX_DIMENSIONS
   }
 

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -51,7 +51,7 @@ new CtxPipe(stack, "CtxPipe", {
 
 Before deploy, enable each model ID in the [Amazon Bedrock console](https://console.aws.amazon.com/bedrock/) for the target region (model access / one-time enablement). Use model IDs your account can invoke; mismatches fail at runtime, not at `cdk deploy`.
 
-**Embeddings on Bedrock:** The backend only supports **Cohere** embed models on Bedrock (Cohere request/response format). Default when `models.embedding` is omitted: `cohere.embed-v4:0`. Other Bedrock embedding models (for example Titan) are not supported yet.
+**Embeddings on Bedrock:** The backend only supports **Cohere** embed models on Bedrock (Cohere request/response format). Default when `models.embedding` is omitted: `cohere.embed-v4:0`. The CDK construct validates this at synth/deploy time and rejects non-Cohere `models.embedding` values (for example chat model IDs or Titan IDs).
 
 ## Model provider
 

--- a/packages/aws-cdk/src/model-provider.test.ts
+++ b/packages/aws-cdk/src/model-provider.test.ts
@@ -142,6 +142,18 @@ describe("validateModelProvider", () => {
       }),
     ).toThrow(/cohere/i);
   });
+
+  it("accepts bedrock cohere embedding inference-profile ids", () => {
+    expect(() =>
+      validateModelProvider({
+        kind: "bedrock",
+        models: {
+          fast: "anthropic.claude-sonnet-4-20250514-v1:0",
+          embedding: "global.cohere.embed-v4:0",
+        },
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe("buildModelContainerConfig", () => {

--- a/packages/aws-cdk/src/model-provider.test.ts
+++ b/packages/aws-cdk/src/model-provider.test.ts
@@ -130,6 +130,18 @@ describe("validateModelProvider", () => {
       }),
     ).toThrow(/models\.fast/i);
   });
+
+  it("rejects bedrock with non-cohere embedding model", () => {
+    expect(() =>
+      validateModelProvider({
+        kind: "bedrock",
+        models: {
+          fast: "anthropic.claude-sonnet-4-20250514-v1:0",
+          embedding: "anthropic.claude-sonnet-4-20250514-v1:0",
+        },
+      }),
+    ).toThrow(/cohere/i);
+  });
 });
 
 describe("buildModelContainerConfig", () => {
@@ -182,5 +194,19 @@ describe("buildModelContainerConfig", () => {
     );
     expect(secrets).not.toHaveProperty("MODEL_PROVIDER_API_KEY");
     expect(Object.keys(secrets)).toEqual([]);
+  });
+
+  it("uses default bedrock embedding model when embedding is empty", () => {
+    const resolved = resolveModelProvider(
+      bedrock({
+        models: {
+          fast: "anthropic.claude-sonnet-4-20250514-v1:0",
+          embedding: "   ",
+        },
+      }),
+      "us-west-2",
+    );
+
+    expect(resolved.embeddingModel).toBe(DEFAULT_BEDROCK_EMBEDDING_MODEL);
   });
 });

--- a/packages/aws-cdk/src/model-provider.ts
+++ b/packages/aws-cdk/src/model-provider.ts
@@ -6,6 +6,8 @@ import type { CtxPipeModelProviderProps } from "./types";
 
 const DEFAULT_BEDROCK_EMBEDDING_MODEL = "cohere.embed-v4:0";
 const BEDROCK_EMBEDDING_MODEL_PREFIX = "cohere.embed";
+const BEDROCK_INFERENCE_PROFILE_PREFIX =
+  /^(?:global|us|eu|ap|apac|au|jp|us-gov)\./i;
 
 type ModelProviderKind = "openai-like" | "bedrock";
 
@@ -62,6 +64,10 @@ function bedrockTaskRolePolicy(): iam.PolicyStatement {
   });
 }
 
+function normalizeBedrockEmbeddingModelId(modelId: string): string {
+  return modelId.replace(BEDROCK_INFERENCE_PROFILE_PREFIX, "");
+}
+
 export function validateModelProvider(props: CtxPipeModelProviderProps): void {
   if (isBedrockProvider(props)) {
     const fast = props.models.fast?.trim();
@@ -74,7 +80,9 @@ export function validateModelProvider(props: CtxPipeModelProviderProps): void {
     const embedding = props.models.embedding?.trim();
     if (
       embedding &&
-      !embedding.toLowerCase().startsWith(BEDROCK_EMBEDDING_MODEL_PREFIX)
+      !normalizeBedrockEmbeddingModelId(embedding)
+        .toLowerCase()
+        .startsWith(BEDROCK_EMBEDDING_MODEL_PREFIX)
     ) {
       throw new Error(
         `Bedrock modelProvider requires models.embedding to be a Cohere embedding model ID (prefix "${BEDROCK_EMBEDDING_MODEL_PREFIX}")`,

--- a/packages/aws-cdk/src/model-provider.ts
+++ b/packages/aws-cdk/src/model-provider.ts
@@ -5,6 +5,7 @@ import type * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import type { CtxPipeModelProviderProps } from "./types";
 
 const DEFAULT_BEDROCK_EMBEDDING_MODEL = "cohere.embed-v4:0";
+const BEDROCK_EMBEDDING_MODEL_PREFIX = "cohere.embed";
 
 type ModelProviderKind = "openai-like" | "bedrock";
 
@@ -69,6 +70,16 @@ export function validateModelProvider(props: CtxPipeModelProviderProps): void {
         "Bedrock modelProvider requires models.fast (non-empty model ID)",
       );
     }
+
+    const embedding = props.models.embedding?.trim();
+    if (
+      embedding &&
+      !embedding.toLowerCase().startsWith(BEDROCK_EMBEDDING_MODEL_PREFIX)
+    ) {
+      throw new Error(
+        `Bedrock modelProvider requires models.embedding to be a Cohere embedding model ID (prefix "${BEDROCK_EMBEDDING_MODEL_PREFIX}")`,
+      );
+    }
     return;
   }
 
@@ -94,7 +105,7 @@ export function resolveModelProvider(
     const region = props.region?.trim() || stackRegion;
     const tiers = resolveTierModels(props.models);
     const embeddingModel =
-      props.models.embedding?.trim() ?? DEFAULT_BEDROCK_EMBEDDING_MODEL;
+      props.models.embedding?.trim() || DEFAULT_BEDROCK_EMBEDDING_MODEL;
 
     return {
       kind: "bedrock",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Bedrock-specific validation that `modelProvider.models.embedding` must be a Cohere embedding model ID (`cohere.embed*`)
- treat blank `models.embedding` as unset so the default Bedrock embedding model (`cohere.embed-v4:0`) is applied reliably
- add unit tests for non-Cohere rejection and blank-value fallback
- document the synth/deploy-time validation behavior in the aws-cdk README
- add a changeset for `@ctxpipe/aws-cdk`

## Why
Customers can currently configure a non-embedding Bedrock model (for example a chat model) as `models.embedding`, which fails later during repo ingestion with Bedrock validation errors like `missing field messages`. This change fails fast in CDK instead of at runtime.

## Verification
- `pnpm --filter @ctxpipe/aws-cdk test -- src/model-provider.test.ts`
  - `src/model-provider.test.ts` passes
  - package test command still reports existing unrelated suite failures due missing generated `src/pinned-service-image-tag` module in this environment

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5b74-14a9-7106-9cb6-7169ef18c367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5b74-14a9-7106-9cb6-7169ef18c367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

