### PR TITLE
Handle Bedrock inference-profile prefixes for Cohere embeddings

### DIFF
--- a/apps/backend/src/retrieval/services/modelProvider.test.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.test.ts
@@ -243,6 +243,26 @@ describe("modelProvider", () => {
     expect(embedding).toHaveLength(2000)
   })
 
+  it("generateEmbedding keeps inference-profile model id and cohere settings", async () => {
+    process.env.MODEL_PROVIDER = "bedrock"
+    delete process.env.MODEL_PROVIDER_API_KEY
+    process.env.MODEL_BEDROCK_AWS_REGION = "us-west-2"
+    process.env.MODEL_EMBEDDING_NAME = "global.cohere.embed-v4:0"
+    mockBedrockSend.mockResolvedValue({ body: fakeCohereEmbedResponse() })
+    vi.resetModules()
+    const { generateEmbedding } = await import("./modelProvider.js")
+    await generateEmbedding("hello")
+
+    const command = mockBedrockSend.mock.calls[0]?.[0] as {
+      input?: { modelId?: string; body?: string }
+    }
+    expect(command.input?.modelId).toBe("global.cohere.embed-v4:0")
+    const body = JSON.parse(String(command.input?.body)) as {
+      output_dimension?: number
+    }
+    expect(body.output_dimension).toBe(1536)
+  })
+
   it("getModel passes reasoning.effort from slash default specs on OpenRouter", async () => {
     process.env.MODEL_PROVIDER = "openrouter"
     process.env.MODEL_PROVIDER_API_KEY = "k"

--- a/apps/backend/src/retrieval/services/providers/bedrockEmbeddings.ts
+++ b/apps/backend/src/retrieval/services/providers/bedrockEmbeddings.ts
@@ -10,6 +10,10 @@ const TARGET_EMBEDDING_DIMENSIONS = 2000
 /** Cohere Embed v4 on Bedrock supports up to 1536 output dimensions. */
 const COHERE_EMBED_V4_MAX_DIMENSIONS = 1536
 
+function stripInferenceProfilePrefix(modelId: string): string {
+  return modelId.replace(/^(?:global|us|eu|ap|apac|au|jp|us-gov)\./i, "")
+}
+
 function padEmbeddingToTargetDimensions(embedding: number[]): number[] {
   if (embedding.length >= TARGET_EMBEDDING_DIMENSIONS) {
     return embedding.slice(0, TARGET_EMBEDDING_DIMENSIONS)
@@ -45,7 +49,7 @@ export async function invokeBedrockEmbedding(
     embedding_types: ["float"],
   }
 
-  if (modelId.startsWith("cohere.embed")) {
+  if (stripInferenceProfilePrefix(modelId).startsWith("cohere.embed")) {
     requestBody.output_dimension = COHERE_EMBED_V4_MAX_DIMENSIONS
   }
 

--- a/packages/aws-cdk/src/model-provider.test.ts
+++ b/packages/aws-cdk/src/model-provider.test.ts
@@ -142,6 +142,18 @@ describe("validateModelProvider", () => {
       }),
     ).toThrow(/cohere/i);
   });
+
+  it("accepts bedrock cohere embedding inference-profile ids", () => {
+    expect(() =>
+      validateModelProvider({
+        kind: "bedrock",
+        models: {
+          fast: "anthropic.claude-sonnet-4-20250514-v1:0",
+          embedding: "global.cohere.embed-v4:0",
+        },
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe("buildModelContainerConfig", () => {

--- a/packages/aws-cdk/src/model-provider.ts
+++ b/packages/aws-cdk/src/model-provider.ts
@@ -6,6 +6,8 @@ import type { CtxPipeModelProviderProps } from "./types";
 
 const DEFAULT_BEDROCK_EMBEDDING_MODEL = "cohere.embed-v4:0";
 const BEDROCK_EMBEDDING_MODEL_PREFIX = "cohere.embed";
+const BEDROCK_INFERENCE_PROFILE_PREFIX =
+  /^(?:global|us|eu|ap|apac|au|jp|us-gov)\./i;
 
 type ModelProviderKind = "openai-like" | "bedrock";
 
@@ -62,6 +64,10 @@ function bedrockTaskRolePolicy(): iam.PolicyStatement {
   });
 }
 
+function normalizeBedrockEmbeddingModelId(modelId: string): string {
+  return modelId.replace(BEDROCK_INFERENCE_PROFILE_PREFIX, "");
+}
+
 export function validateModelProvider(props: CtxPipeModelProviderProps): void {
   if (isBedrockProvider(props)) {
     const fast = props.models.fast?.trim();
@@ -74,7 +80,9 @@ export function validateModelProvider(props: CtxPipeModelProviderProps): void {
     const embedding = props.models.embedding?.trim();
     if (
       embedding &&
-      !embedding.toLowerCase().startsWith(BEDROCK_EMBEDDING_MODEL_PREFIX)
+      !normalizeBedrockEmbeddingModelId(embedding)
+        .toLowerCase()
+        .startsWith(BEDROCK_EMBEDDING_MODEL_PREFIX)
     ) {
       throw new Error(
         `Bedrock modelProvider requires models.embedding to be a Cohere embedding model ID (prefix "${BEDROCK_EMBEDDING_MODEL_PREFIX}")`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- treat Bedrock inference-profile-prefixed embedding IDs (for example `global.cohere.embed-v4:0`) as Cohere IDs in backend embedding request shaping
- preserve the full prefixed model ID for `InvokeModel` while still applying Cohere v4 `output_dimension` handling
- update `@ctxpipe/aws-cdk` Bedrock model-provider validation to accept Cohere embedding IDs with inference-profile prefixes
- add regression tests in backend and aws-cdk packages

## Validation
- `pnpm --filter @ctxpipe/backend test src/retrieval/services/modelProvider.test.ts`
- `pnpm --filter @ctxpipe/aws-cdk test src/model-provider.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5e1f-1198-7be1-9a03-2204f0d6c568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5e1f-1198-7be1-9a03-2204f0d6c568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

