### PR TITLE
Document Bedrock Organizations SCP requirements

### DIFF
--- a/apps/docs/content/docs/self-hosting/deployment/aws.mdx
+++ b/apps/docs/content/docs/self-hosting/deployment/aws.mdx
@@ -82,7 +82,11 @@ For Bedrock, set `kind: "bedrock"` and tier model IDs only. The construct grants
 Enable each model ID in the [Amazon Bedrock console](https://console.aws.amazon.com/bedrock/) for your stack region before relying on chat or embeddings.
 
 <Callout type="info" title="Bedrock embeddings (Cohere only)">
-  Bedrock embeddings currently support **Cohere** embed models only (the backend uses Cohere's invoke format). Default when `models.embedding` is omitted: `cohere.embed-v4:0`. Non-Cohere Bedrock embed models (for example Titan) are not supported yet.
+  Bedrock embeddings currently support **Cohere** embed models only (the backend uses Cohere's invoke format). Default when `models.embedding` is omitted: `cohere.embed-v4:0`. You can also use inference-profile IDs such as `global.cohere.embed-v4:0`. Non-Cohere Bedrock embed models (for example Titan) are not supported yet.
+</Callout>
+
+<Callout type="warn" title="Organizations SCPs can still block Bedrock">
+  The construct attaches `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` to the backend and worker task roles, but an AWS Organizations **service control policy (SCP)** can override that with an **explicit deny**. Typical log text: `AccessDeniedException` … `explicit deny in a service control policy`. Allow your chat and Cohere embed foundation-model ARNs in the SCP (denies for `global.cohere.embed-v4:0` often name `…/foundation-model/cohere.embed-v4:0`). This is separate from chat stream stalls such as `Bedrock Converse stream timed out … without receiving a chunk`—those need CloudTrail `ConverseStream` investigation, not a wider task-role policy.
 </Callout>
 
 ```ts
@@ -99,7 +103,7 @@ new CtxPipe(stack, "CtxPipe", {
       fast: "anthropic.claude-sonnet-4-20250514-v1:0",
       medium: "anthropic.claude-sonnet-4-20250514-v1:0",
       high: "anthropic.claude-opus-4-20250514-v1:0",
-      embedding: "cohere.embed-v4:0", // optional; Cohere models only
+      embedding: "cohere.embed-v4:0", // optional; Cohere models only (e.g. global.cohere.embed-v4:0)
     },
   },
 });

--- a/apps/docs/content/docs/self-hosting/models.mdx
+++ b/apps/docs/content/docs/self-hosting/models.mdx
@@ -19,11 +19,11 @@ If **`MODEL_PROVIDER`** is unset, it defaults to **`openai-like`**. To keep **pr
 Vertex and other gateways that expect Bearer + base URL use **`openai-like`** (or **`openrouter`** if routed via OpenRouter).
 
 <Callout type="info" title="AWS CDK Bedrock deployments">
-  When you deploy with [`@ctxpipe/aws-cdk`](/docs/self-hosting/deployment/aws) and `modelProvider.kind: "bedrock"`, the construct does **not** store a static `MODEL_PROVIDER_API_KEY`. Backend and worker tasks receive IAM permissions (`bedrock:InvokeModel`, `bedrock:InvokeModelWithResponseStream`) and call Bedrock Runtime through the AWS SDK using the ECS task role (SigV4). Enable your chosen model IDs in the Bedrock console for the stack region before use.
+  When you deploy with [`@ctxpipe/aws-cdk`](/docs/self-hosting/deployment/aws) and `modelProvider.kind: "bedrock"`, the construct does **not** store a static `MODEL_PROVIDER_API_KEY`. Backend and worker tasks receive IAM permissions (`bedrock:InvokeModel`, `bedrock:InvokeModelWithResponseStream`) and call Bedrock Runtime through the AWS SDK using the ECS task role (SigV4). Enable your chosen model IDs in the Bedrock console for the stack region before use. If the account is in an AWS Organization, also confirm **service control policies (SCPs)** allow those same foundation-model ARNs—an SCP explicit deny overrides the task role and surfaces as `AccessDeniedException` … `explicit deny in a service control policy`.
 </Callout>
 
 <Callout type="warn" title="Bedrock embeddings (Cohere only)">
-  When `MODEL_PROVIDER=bedrock`, embeddings use the native Bedrock Runtime API and currently support **Cohere** embed models only (default `cohere.embed-v4:0` on AWS CDK when `models.embedding` is omitted). Non-Cohere Bedrock embedding models are not supported yet.
+  When `MODEL_PROVIDER=bedrock`, embeddings use the native Bedrock Runtime API and currently support **Cohere** embed models only (default `cohere.embed-v4:0` on AWS CDK when `models.embedding` is omitted; inference-profile IDs such as `global.cohere.embed-v4:0` are fine). Non-Cohere Bedrock embedding models are not supported yet. SCP denies for profile IDs often still name the underlying `…/foundation-model/cohere.embed-v4:0` ARN.
 </Callout>
 
 ## Quick Start (OpenRouter)
@@ -85,7 +85,7 @@ When **`MODEL_PROVIDER=openrouter`** (or fully managed deployments that set it),
 **Important:** The embedding model must support **2000 dimensions**. The schema stores vectors in `vector(2000)`; incompatible models will fail.
 
 - **OpenAI-compatible providers** (OpenRouter, OpenAI, Vertex): Use models that accept a `dimensions` parameter, e.g. `openai/text-embedding-3-large` (3072 dims, truncates to 2000).
-- **Amazon Bedrock**: Use a **Cohere** embed model ID (for example `cohere.embed-v4:0`). Other Bedrock embed families are not supported yet.
+- **Amazon Bedrock**: Use a **Cohere** embed model ID (for example `cohere.embed-v4:0` or `global.cohere.embed-v4:0`). Other Bedrock embed families are not supported yet.
 - **Ollama**: Use models with native 2000-dim support, e.g. `qwen3-embedding`. Set `MODEL_PROVIDER_URL=http://host:11434/v1` and `MODEL_EMBEDDING_NAME=qwen3-embedding` (embeddings use `{MODEL_PROVIDER_URL}/embeddings`).
 
 All providers use the same OpenAI-compatible embeddings API; Ollama exposes it at `/v1/embeddings`.
@@ -115,8 +115,9 @@ MODEL_PROVIDER_URL=https://YOUR_RESOURCE.openai.azure.com/openai/deployments/YOU
 ```bash
 MODEL_PROVIDER=bedrock
 MODEL_BEDROCK_AWS_REGION=us-east-1
-MODEL_EMBEDDING_NAME=cohere.embed-v4:0  # Cohere embed models only on Bedrock
+MODEL_EMBEDDING_NAME=cohere.embed-v4:0  # or global.cohere.embed-v4:0; Cohere only on Bedrock
 # ECS task role / instance profile supplies AWS credentials; no MODEL_PROVIDER_URL or API key.
+# Org SCPs must allow the underlying foundation-model ARN (see AWS CDK Bedrock callout above).
 ```
 
 ### Ollama (local chat + embeddings)

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -111,9 +111,11 @@ modelProvider: {
 ### Bedrock console checklist
 
 1. Deploy the stack in an AWS region where Bedrock and your chosen models are available.
-2. In **Amazon Bedrock → Model access** (or **Foundation models**), enable each model ID you pass in `models.`* for that region.
+2. In **Amazon Bedrock → Model access** (or **Foundation models**), enable each model ID you pass in `models.*` for that region (chat tiers and embeddings).
 3. Confirm the stack region matches `modelProvider.region` when set (otherwise the construct uses the stack region).
 4. No `modelProvider` Secrets Manager secret is provisioned for bedrock; `modelProviderSecret` / `modelProviderSecretArn` outputs are omitted.
+5. **Organizations SCPs:** CDK grants `bedrock:InvokeModel` / `bedrock:InvokeModelWithResponseStream` on the ECS task roles, but an AWS Organizations **service control policy (SCP)** can still deny those calls. Task-role Allow is not enough when an SCP has an **explicit deny**. Failures look like `AccessDeniedException` … `explicit deny in a service control policy`. Ask your org admin to allow the foundation-model ARNs you use (for example `arn:aws:bedrock:*::foundation-model/cohere.embed-v4:0` and your chat model IDs). Inference-profile IDs such as `global.cohere.embed-v4:0` are often authorized as the underlying foundation-model ARN in deny messages—allow both forms if your SCP is resource-scoped.
+6. **Chat stream stalls are separate from SCP denies.** Errors like `Bedrock Converse stream timed out … without receiving a chunk` mean the Converse stream opened but no chunk arrived in time. Correlate CloudTrail `ConverseStream` `requestID` with completion events; do not treat this as a missing IAM Allow on the task role.
 
 ## Required props
 


### PR DESCRIPTION
## Summary
- Document that AWS Organizations SCPs can block Bedrock chat/embeddings even when `@ctxpipe/aws-cdk` grants task-role `InvokeModel` permissions.
- Clarify Cohere foundation-model vs `global.` inference-profile ARN behavior in deny messages.
- Note that Converse stream idle timeouts are separate from SCP AccessDenied and should be investigated via CloudTrail, not by widening task-role IAM.

## Context
Seen in a customer deploy: SCP explicit deny on `cohere.embed-v4:0`, plus intermittent Kimi `ConverseStream` idle timeouts. Embed ID handling for `global.cohere.*` is already on main; this PR is docs-only.

## Test plan
- [ ] Skim CDK README Bedrock checklist and self-hosting AWS/models pages for accuracy
- [ ] No runtime image bump required for this change

Made with [Cursor](https://cursor.com)