### PR TITLE
Mitigate Bedrock ingest stalls (non-streaming + stronger retry)

### DIFF
--- a/.changeset/steady-bridges-glow.md
+++ b/.changeset/steady-bridges-glow.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Mitigate Bedrock repository-ingestion stalls by using non-streaming chat models for code-ingestion agents and hardening the ingest OpenWorkflow step retry (3 attempts with backoff). Conversation/MCP UI streaming is unchanged.

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/extractInstructionUnits.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/extractInstructionUnits.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../domain/codeIngestion/codesearchClient.js"
 import { isUnderDependencyVendorPath } from "../../../domain/codeIngestion/dependencyVendorPaths.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import type {
   CodeIngestionState,
   ExtractedClaim,
@@ -394,7 +394,7 @@ async function extractUnitsFromFileContent(input: {
     return { units: [] }
   }
 
-  const model = getModel("medium", { temperature: 0.1 })
+  const model = getIngestionModel("medium", { temperature: 0.1 })
   const structured = model.withStructuredOutput(LlmUnitsResponseSchema, {
     name: "instruction_units",
   })

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/extractInstructionUnits.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/extractInstructionUnits.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../domain/codeIngestion/codesearchClient.js"
 import { isUnderDependencyVendorPath } from "../../../domain/codeIngestion/dependencyVendorPaths.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import type {
   CodeIngestionState,
   ExtractedClaim,
@@ -394,7 +394,7 @@ async function extractUnitsFromFileContent(input: {
     return { units: [] }
   }
 
-  const model = getIngestionModel("medium", { temperature: 0.1 })
+  const model = getModel("medium", { streaming: false, temperature: 0.1 })
   const structured = model.withStructuredOutput(LlmUnitsResponseSchema, {
     name: "instruction_units",
   })

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/extractKindAmbiguousPackageAgent.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/extractKindAmbiguousPackageAgent.ts
@@ -4,7 +4,7 @@ import { getConfig } from "@langchain/langgraph"
 import { tool } from "langchain"
 import { z } from "zod/v3"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import { getFileTool } from "../../../tools/getFile.js"
 import { createAgent } from "../../createAgent.js"
 
@@ -53,7 +53,7 @@ export async function classifyAmbiguousPackageKindAgent(input: {
       : ""
 
   const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
+    model: getIngestionModel("medium", { temperature: 0.1 }),
     tools: [getFileTool, submitPackageKindTool],
     contextMiddleware: {
       clearToolUsesTriggerTokens: 100_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/extractKindAmbiguousPackageAgent.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/extractKindAmbiguousPackageAgent.ts
@@ -4,7 +4,7 @@ import { getConfig } from "@langchain/langgraph"
 import { tool } from "langchain"
 import { z } from "zod/v3"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import { getFileTool } from "../../../tools/getFile.js"
 import { createAgent } from "../../createAgent.js"
 
@@ -53,7 +53,7 @@ export async function classifyAmbiguousPackageKindAgent(input: {
       : ""
 
   const agent = createAgent({
-    model: getIngestionModel("medium", { temperature: 0.1 }),
+    model: getModel("medium", { streaming: false, temperature: 0.1 }),
     tools: [getFileTool, submitPackageKindTool],
     contextMiddleware: {
       clearToolUsesTriggerTokens: 100_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIClients.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIClients.ts
@@ -18,7 +18,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -133,7 +133,7 @@ export async function identifyAPIClients(
   const capturedClients: { value: SubmittedApiClient[] } = { value: [] }
   const tools = createIdentifyAPIClientsTools(capturedClients)
   const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
+    model: getIngestionModel("medium", { temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIClients.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIClients.ts
@@ -18,7 +18,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -133,7 +133,7 @@ export async function identifyAPIClients(
   const capturedClients: { value: SubmittedApiClient[] } = { value: [] }
   const tools = createIdentifyAPIClientsTools(capturedClients)
   const agent = createAgent({
-    model: getIngestionModel("medium", { temperature: 0.1 }),
+    model: getModel("medium", { streaming: false, temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIs.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIs.ts
@@ -5,7 +5,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -203,7 +203,7 @@ export async function identifyAPIs(
   if (rootsNeedingLlm.length > 0) {
     const tools = createIdentifyAPIsTools(capturedApis)
     const agent = createAgent({
-      model: getIngestionModel("medium", { temperature: 0.1 }),
+      model: getModel("medium", { streaming: false, temperature: 0.1 }),
       tools,
       contextMiddleware: {
         clearToolUsesTriggerTokens: 160_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIs.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyAPIs.ts
@@ -5,7 +5,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -203,7 +203,7 @@ export async function identifyAPIs(
   if (rootsNeedingLlm.length > 0) {
     const tools = createIdentifyAPIsTools(capturedApis)
     const agent = createAgent({
-      model: getModel("medium", { temperature: 0.1 }),
+      model: getIngestionModel("medium", { temperature: 0.1 }),
       tools,
       contextMiddleware: {
         clearToolUsesTriggerTokens: 160_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
@@ -5,7 +5,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -143,7 +143,7 @@ export async function identifyDatabases(
   const capturedDbs: { value: SubmittedDatabase[] } = { value: [] }
   const tools = createIdentifyDatabasesTools(capturedDbs)
   const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
+    model: getIngestionModel("medium", { temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyDatabases.ts
@@ -5,7 +5,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -143,7 +143,7 @@ export async function identifyDatabases(
   const capturedDbs: { value: SubmittedDatabase[] } = { value: [] }
   const tools = createIdentifyDatabasesTools(capturedDbs)
   const agent = createAgent({
-    model: getIngestionModel("medium", { temperature: 0.1 }),
+    model: getModel("medium", { streaming: false, temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructure.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructure.ts
@@ -12,7 +12,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -113,7 +113,7 @@ export async function identifyInfrastructure(
   const capturedInfra: { value: SubmittedInfrastructure[] } = { value: [] }
   const tools = createIdentifyInfrastructureTools(capturedInfra)
   const agent = createAgent({
-    model: getIngestionModel("medium", { temperature: 0.1 }),
+    model: getModel("medium", { streaming: false, temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructure.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyInfrastructure.ts
@@ -12,7 +12,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -113,7 +113,7 @@ export async function identifyInfrastructure(
   const capturedInfra: { value: SubmittedInfrastructure[] } = { value: [] }
   const tools = createIdentifyInfrastructureTools(capturedInfra)
   const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
+    model: getIngestionModel("medium", { temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
@@ -17,7 +17,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -173,7 +173,7 @@ export async function identifyLibraries(
   const capturedLibraries: { value: SubmittedLibrary[] } = { value: [] }
   const tools = createIdentifyLibrariesTools(capturedLibraries)
   const agent = createAgent({
-    model: getIngestionModel("medium", { temperature: 0.1 }),
+    model: getModel("medium", { streaming: false, temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 160_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyLibraries.ts
@@ -17,7 +17,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -173,7 +173,7 @@ export async function identifyLibraries(
   const capturedLibraries: { value: SubmittedLibrary[] } = { value: [] }
   const tools = createIdentifyLibrariesTools(capturedLibraries)
   const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
+    model: getIngestionModel("medium", { temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 160_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyPatterns.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyPatterns.ts
@@ -20,7 +20,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -169,7 +169,7 @@ export async function identifyPatterns(
   const capturedPatterns: { value: SubmittedPattern[] } = { value: [] }
   const tools = createIdentifyPatternsTools(capturedPatterns)
   const agent = createAgent({
-    model: getIngestionModel("medium", { temperature: 0.1 }),
+    model: getModel("medium", { streaming: false, temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 160_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyPatterns.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyPatterns.ts
@@ -20,7 +20,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -169,7 +169,7 @@ export async function identifyPatterns(
   const capturedPatterns: { value: SubmittedPattern[] } = { value: [] }
   const tools = createIdentifyPatternsTools(capturedPatterns)
   const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
+    model: getIngestionModel("medium", { temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 160_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyRootsAmbiguousAgent.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyRootsAmbiguousAgent.ts
@@ -4,7 +4,7 @@ import { getConfig } from "@langchain/langgraph"
 import { tool } from "langchain"
 import { z } from "zod/v3"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import { getFileTool } from "../../../tools/getFile.js"
 import { listFilesTool } from "../../../tools/listFiles.js"
 import { createAgent } from "../../createAgent.js"
@@ -61,7 +61,7 @@ export async function identifyRootsAmbiguousAgent(input: {
   const submitRootsTool = createRootsTool(capturedRoots)
 
   const agent = createAgent({
-    model: getIngestionModel("fast", { temperature: 0.1 }),
+    model: getModel("fast", { streaming: false, temperature: 0.1 }),
     tools: [listFilesTool, getFileTool, submitRootsTool],
     systemPrompt: `You are resolving repository roots when deterministic parsing is ambiguous.
 

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyRootsAmbiguousAgent.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyRootsAmbiguousAgent.ts
@@ -4,7 +4,7 @@ import { getConfig } from "@langchain/langgraph"
 import { tool } from "langchain"
 import { z } from "zod/v3"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import { getFileTool } from "../../../tools/getFile.js"
 import { listFilesTool } from "../../../tools/listFiles.js"
 import { createAgent } from "../../createAgent.js"
@@ -61,7 +61,7 @@ export async function identifyRootsAmbiguousAgent(input: {
   const submitRootsTool = createRootsTool(capturedRoots)
 
   const agent = createAgent({
-    model: getModel("fast", { temperature: 0.1 }),
+    model: getIngestionModel("fast", { temperature: 0.1 }),
     tools: [listFilesTool, getFileTool, submitRootsTool],
     systemPrompt: `You are resolving repository roots when deterministic parsing is ambiguous.
 

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyServiceDependencies.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyServiceDependencies.ts
@@ -22,7 +22,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -118,7 +118,7 @@ export async function identifyServiceDependencies(
   const capturedDeps: { value: SubmittedDependency[] } = { value: [] }
   const tools = createIdentifyServiceDependenciesTools(capturedDeps)
   const agent = createAgent({
-    model: getIngestionModel("medium", { temperature: 0.1 }),
+    model: getModel("medium", { streaming: false, temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyServiceDependencies.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyServiceDependencies.ts
@@ -22,7 +22,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -118,7 +118,7 @@ export async function identifyServiceDependencies(
   const capturedDeps: { value: SubmittedDependency[] } = { value: [] }
   const tools = createIdentifyServiceDependenciesTools(capturedDeps)
   const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
+    model: getIngestionModel("medium", { temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreams.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreams.ts
@@ -15,7 +15,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
+import { getModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -118,7 +118,7 @@ export async function identifyStreams(
   const capturedStreams: { value: SubmittedStream[] } = { value: [] }
   const tools = createIdentifyStreamsTools(capturedStreams)
   const agent = createAgent({
-    model: getIngestionModel("medium", { temperature: 0.1 }),
+    model: getModel("medium", { streaming: false, temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreams.ts
+++ b/apps/backend/src/graphs/codeIngestionGraph/nodes/identifyStreams.ts
@@ -15,7 +15,7 @@ import { tool } from "langchain"
 import { z } from "zod/v3"
 import { requireCurrentOrgId } from "../../../auth/context.js"
 import { getLogger } from "../../../observability/logger.js"
-import { getModel } from "../../../retrieval/services/modelProvider.js"
+import { getIngestionModel } from "../../../retrieval/services/modelProvider.js"
 import {
   REPO_EXPLORER_TOOLS_HINT,
   standardRepoExplorerTools,
@@ -118,7 +118,7 @@ export async function identifyStreams(
   const capturedStreams: { value: SubmittedStream[] } = { value: [] }
   const tools = createIdentifyStreamsTools(capturedStreams)
   const agent = createAgent({
-    model: getModel("medium", { temperature: 0.1 }),
+    model: getIngestionModel("medium", { temperature: 0.1 }),
     tools,
     contextMiddleware: {
       clearToolUsesTriggerTokens: 140_000,

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -212,7 +212,15 @@ export const repositoryIngestion = defineWorkflow(
           })
 
           await step.run(
-            { name: "ingest", retryPolicy: { maximumAttempts: 2 } },
+            {
+              name: "ingest",
+              retryPolicy: {
+                maximumAttempts: 3,
+                initialInterval: "30s",
+                backoffCoefficient: 2,
+                maximumInterval: "2m",
+              },
+            },
             () =>
               runWithLangfuseContext(
                 {

--- a/apps/backend/src/retrieval/services/modelProvider.test.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.test.ts
@@ -345,15 +345,15 @@ describe("modelProvider", () => {
     expect(call?.streaming).toBe(true)
   })
 
-  it("getIngestionModel forces streaming false on Bedrock", async () => {
+  it("getModel with streaming false forces non-streaming on Bedrock", async () => {
     process.env.MODEL_PROVIDER = "bedrock"
     delete process.env.MODEL_PROVIDER_API_KEY
     delete process.env.MODEL_PROVIDER_URL
     process.env.MODEL_BEDROCK_AWS_REGION = "us-east-1"
     process.env.MODEL_MEDIUM_NAME = "moonshotai.kimi-k2.5"
     vi.resetModules()
-    const { getIngestionModel } = await import("./modelProvider.js")
-    getIngestionModel("medium", { temperature: 0.1 })
+    const { getModel } = await import("./modelProvider.js")
+    getModel("medium", { streaming: false, temperature: 0.1 })
 
     const call = chatBedrockConverseConstructor.mock.calls[0]?.[0] as {
       streaming?: boolean
@@ -363,14 +363,14 @@ describe("modelProvider", () => {
     expect(call?.temperature).toBe(0.1)
   })
 
-  it("getIngestionModel forces streaming false on openai-like", async () => {
+  it("getModel with streaming false forces non-streaming on openai-like", async () => {
     process.env.MODEL_PROVIDER = "openai-like"
     process.env.MODEL_PROVIDER_API_KEY = "k"
     process.env.MODEL_PROVIDER_URL = "https://api.openai.com/v1"
     process.env.MODEL_MEDIUM_NAME = "openai/gpt-5.5"
     vi.resetModules()
-    const { getIngestionModel } = await import("./modelProvider.js")
-    getIngestionModel("medium")
+    const { getModel } = await import("./modelProvider.js")
+    getModel("medium", { streaming: false })
 
     const call = chatOpenAIConstructor.mock.calls[0]?.[0] as {
       streaming?: boolean

--- a/apps/backend/src/retrieval/services/modelProvider.test.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.test.ts
@@ -329,6 +329,70 @@ describe("modelProvider", () => {
     expect(call?.modelKwargs?.reasoning_effort).toBe("none")
   })
 
+  it("getModel defaults to streaming true on Bedrock", async () => {
+    process.env.MODEL_PROVIDER = "bedrock"
+    delete process.env.MODEL_PROVIDER_API_KEY
+    delete process.env.MODEL_PROVIDER_URL
+    process.env.MODEL_BEDROCK_AWS_REGION = "us-east-1"
+    process.env.MODEL_MEDIUM_NAME = "moonshotai.kimi-k2.5"
+    vi.resetModules()
+    const { getModel } = await import("./modelProvider.js")
+    getModel("medium")
+
+    const call = chatBedrockConverseConstructor.mock.calls[0]?.[0] as {
+      streaming?: boolean
+    }
+    expect(call?.streaming).toBe(true)
+  })
+
+  it("getIngestionModel forces streaming false on Bedrock", async () => {
+    process.env.MODEL_PROVIDER = "bedrock"
+    delete process.env.MODEL_PROVIDER_API_KEY
+    delete process.env.MODEL_PROVIDER_URL
+    process.env.MODEL_BEDROCK_AWS_REGION = "us-east-1"
+    process.env.MODEL_MEDIUM_NAME = "moonshotai.kimi-k2.5"
+    vi.resetModules()
+    const { getIngestionModel } = await import("./modelProvider.js")
+    getIngestionModel("medium", { temperature: 0.1 })
+
+    const call = chatBedrockConverseConstructor.mock.calls[0]?.[0] as {
+      streaming?: boolean
+      temperature?: number
+    }
+    expect(call?.streaming).toBe(false)
+    expect(call?.temperature).toBe(0.1)
+  })
+
+  it("getIngestionModel forces streaming false on openai-like", async () => {
+    process.env.MODEL_PROVIDER = "openai-like"
+    process.env.MODEL_PROVIDER_API_KEY = "k"
+    process.env.MODEL_PROVIDER_URL = "https://api.openai.com/v1"
+    process.env.MODEL_MEDIUM_NAME = "openai/gpt-5.5"
+    vi.resetModules()
+    const { getIngestionModel } = await import("./modelProvider.js")
+    getIngestionModel("medium")
+
+    const call = chatOpenAIConstructor.mock.calls[0]?.[0] as {
+      streaming?: boolean
+    }
+    expect(call?.streaming).toBe(false)
+  })
+
+  it("getModel with streaming false forces non-streaming on OpenRouter", async () => {
+    process.env.MODEL_PROVIDER = "openrouter"
+    process.env.MODEL_PROVIDER_API_KEY = "k"
+    process.env.MODEL_PROVIDER_URL = "https://openrouter.ai/api/v1"
+    process.env.MODEL_MEDIUM_NAME = "openai/gpt-5.5"
+    vi.resetModules()
+    const { getModel } = await import("./modelProvider.js")
+    getModel("medium", { streaming: false })
+
+    const call = chatOpenAIConstructor.mock.calls[0]?.[0] as {
+      streaming?: boolean
+    }
+    expect(call?.streaming).toBe(false)
+  })
+
   it("generateEmbedding strips query params from embedding model name", async () => {
     process.env.MODEL_PROVIDER = "openai-like"
     process.env.MODEL_PROVIDER_API_KEY = "k"

--- a/apps/backend/src/retrieval/services/modelProvider.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.ts
@@ -178,18 +178,6 @@ export function getModel(
 }
 
 /**
- * Chat model for code-ingestion agents. Forces non-streaming transport so
- * Bedrock uses Converse (not ConverseStream) and avoids stream-idle watchdogs.
- * Conversation / MCP / UI must keep using {@link getModel} (default streaming).
- */
-export function getIngestionModel(
-  tier: ModelTier,
-  options?: Omit<GetModelOptions, "streaming">,
-): BaseChatModel {
-  return getModel(tier, { ...options, streaming: false })
-}
-
-/**
  * Generates a 2000-dimensional embedding for text using an OpenAI-compatible
  * embeddings API (OpenRouter, OpenAI, Vertex, Bedrock, Ollama /v1/embeddings, etc.).
  */

--- a/apps/backend/src/retrieval/services/modelProvider.ts
+++ b/apps/backend/src/retrieval/services/modelProvider.ts
@@ -77,6 +77,12 @@ export type GetModelOptions = {
   temperature?: number
   /** When false, merges reasoning.effort=none over the tier model spec. */
   reasoning?: boolean
+  /**
+   * Whether the chat model uses streaming transport.
+   * Defaults to `true` (conversation / MCP / UI). Pass `false` for
+   * invoke-only ingestion to use non-stream Converse / chat completions.
+   */
+  streaming?: boolean
 }
 
 function uniqueModelChain(ids: string[]): string[] {
@@ -153,6 +159,7 @@ export function getModel(
     modelParams,
     apiKey: env.MODEL_PROVIDER_API_KEY?.trim() ?? "",
     temperature: options?.temperature,
+    streaming: options?.streaming,
     env: {
       MODEL_PROVIDER_URL: env.MODEL_PROVIDER_URL,
       MODEL_BEDROCK_AWS_REGION: env.MODEL_BEDROCK_AWS_REGION,
@@ -168,6 +175,18 @@ export function getModel(
   const { chat } = providerFn(callOpts)
 
   return chat
+}
+
+/**
+ * Chat model for code-ingestion agents. Forces non-streaming transport so
+ * Bedrock uses Converse (not ConverseStream) and avoids stream-idle watchdogs.
+ * Conversation / MCP / UI must keep using {@link getModel} (default streaming).
+ */
+export function getIngestionModel(
+  tier: ModelTier,
+  options?: Omit<GetModelOptions, "streaming">,
+): BaseChatModel {
+  return getModel(tier, { ...options, streaming: false })
 }
 
 /**

--- a/apps/backend/src/retrieval/services/providers/azureModelProvider.ts
+++ b/apps/backend/src/retrieval/services/providers/azureModelProvider.ts
@@ -31,7 +31,7 @@ export function azureModelProvider(opts: ProviderCallOpts): ProviderCallResult {
       model: primary,
       apiKey: opts.apiKey,
       temperature: opts.temperature,
-      streaming: true,
+      streaming: opts.streaming ?? true,
       ...(modelKwargs ? { modelKwargs } : {}),
       configuration: { baseURL, fetch: fetchFn },
     }),

--- a/apps/backend/src/retrieval/services/providers/bedrockModelProvider.ts
+++ b/apps/backend/src/retrieval/services/providers/bedrockModelProvider.ts
@@ -81,7 +81,7 @@ export function bedrockModelProvider(
       model: primary,
       region,
       temperature: opts.temperature,
-      streaming: true,
+      streaming: opts.streaming ?? true,
       ...(converseParams?.maxTokens !== undefined
         ? { maxTokens: converseParams.maxTokens }
         : {}),

--- a/apps/backend/src/retrieval/services/providers/openAILikeModelProvider.ts
+++ b/apps/backend/src/retrieval/services/providers/openAILikeModelProvider.ts
@@ -76,7 +76,7 @@ export function openAILikeModelProvider(
       model: primary,
       apiKey: opts.apiKey,
       temperature: opts.temperature,
-      streaming: true,
+      streaming: opts.streaming ?? true,
       ...(modelKwargs ? { modelKwargs } : {}),
       configuration: { baseURL },
     }),

--- a/apps/backend/src/retrieval/services/providers/openrouterModelProvider.ts
+++ b/apps/backend/src/retrieval/services/providers/openrouterModelProvider.ts
@@ -100,7 +100,7 @@ export function openrouterModelProvider(
       model: primary,
       apiKey: opts.apiKey,
       temperature: opts.temperature,
-      streaming: true,
+      streaming: opts.streaming ?? true,
       modelKwargs,
       configuration: { baseURL },
     }),

--- a/apps/backend/src/retrieval/services/providers/providerTypes.ts
+++ b/apps/backend/src/retrieval/services/providers/providerTypes.ts
@@ -30,6 +30,12 @@ export type ProviderCallOpts = {
   env: ProviderCallEnv
   /** Passed into chat model constructors; omit or `undefined` for embeddings. */
   temperature?: number
+  /**
+   * Whether the chat model uses streaming transport.
+   * Defaults to `true`. Set `false` for invoke-only paths (e.g. code ingestion)
+   * to avoid ConverseStream idle watchdogs.
+   */
+  streaming?: boolean
 }
 
 export type ProviderCallResult = {


### PR DESCRIPTION
## Summary
- Code-ingestion LLM calls now use `getIngestionModel` with `streaming: false`, so Bedrock uses Converse instead of ConverseStream and avoids the 60s stream-idle watchdog that failed hung Kimi streams.
- Conversation agent/graph (UI + MCP) is unchanged: still `getModel` with default `streaming: true`.
- Ingest OpenWorkflow step retry hardened: `maximumAttempts: 3` with `30s` / coeff `2` / `2m` backoff. OpenWorkflow retries all thrown step errors (no special error-type mapping needed).

## Test plan
- [x] `pnpm --filter @ctxpipe/backend exec vitest run src/retrieval/services/modelProvider.test.ts` (18 passed)
- [ ] Canary **worker** image with this commit on a Bedrock+Kimi env and re-run multi-repo ingest
- [ ] Confirm UI/MCP chat still streams tokens
- [ ] Confirm Cohere embed SCP remains a separate customer org-policy issue (unchanged here)


Made with [Cursor](https://cursor.com)