### PR TITLE
fix(backend): do not hold org DB tx across codesearch reindex

### DIFF
--- a/apps/backend/src/db/client.ts
+++ b/apps/backend/src/db/client.ts
@@ -10,6 +10,20 @@ function createDrizzleDb(connectionString: string) {
     connectionString,
     idleTimeoutMillis: 300000,
   })
+  // Idle clients can emit 'error' when Postgres closes them (e.g. 25P03
+  // idle_in_transaction). Without a listener, Node treats that as uncaught
+  // and can exit the OpenWorkflow worker process.
+  client.on("error", (err) => {
+    log.error({
+      step: "db.pool",
+      message: "Unexpected pg pool error",
+      error: err instanceof Error ? err.message : String(err),
+      code:
+        err && typeof err === "object" && "code" in err
+          ? String((err as { code: unknown }).code)
+          : undefined,
+    })
+  })
   return drizzle({ client, schema, relations })
 }
 

--- a/apps/backend/src/models/repositories.test.ts
+++ b/apps/backend/src/models/repositories.test.ts
@@ -35,6 +35,7 @@ import {
   listRepositoriesForGithubConnection,
   listRepositoriesForOrg,
   pruneGithubConnectionRepositoriesNotInGitUrls,
+  tryClaimRepositoryIndexingEnqueue,
 } from "./repositories.js"
 
 const orgId = "org_1"
@@ -271,5 +272,50 @@ describe("deleteRepository", () => {
       orgId,
       repositoryId,
     })
+  })
+})
+
+describe("tryClaimRepositoryIndexingEnqueue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns true when a row is claimed for enqueue", async () => {
+    const returning = vi.fn().mockResolvedValue([{ id: repositoryId }])
+    const where = vi.fn().mockReturnValue({ returning })
+    const set = vi.fn().mockReturnValue({ where })
+    const update = vi.fn().mockReturnValue({ set })
+    getOrgDbMock.mockReturnValue({ update })
+
+    await expect(
+      tryClaimRepositoryIndexingEnqueue({
+        repositoryId,
+        reason: "retry",
+      }),
+    ).resolves.toBe(true)
+
+    expect(update).toHaveBeenCalled()
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indexingStatus: "queued",
+        indexingReason: "retry",
+        indexReady: false,
+      }),
+    )
+  })
+
+  it("returns false when already queued or running (no row updated)", async () => {
+    const returning = vi.fn().mockResolvedValue([])
+    const where = vi.fn().mockReturnValue({ returning })
+    const set = vi.fn().mockReturnValue({ where })
+    const update = vi.fn().mockReturnValue({ set })
+    getOrgDbMock.mockReturnValue({ update })
+
+    await expect(
+      tryClaimRepositoryIndexingEnqueue({
+        repositoryId,
+        reason: null,
+      }),
+    ).resolves.toBe(false)
   })
 })

--- a/apps/backend/src/models/repositories.ts
+++ b/apps/backend/src/models/repositories.ts
@@ -1,4 +1,4 @@
-import { and, count, eq } from "drizzle-orm"
+import { and, count, eq, isNull, notInArray, or } from "drizzle-orm"
 import { requireCurrentOrgId, requireCurrentOrgSlug } from "../auth/context.js"
 import { type Db, getOrgDb, getSystemDb, withOrgDbContext } from "../db/client.js"
 import {
@@ -227,6 +227,40 @@ export async function markRepositoryIndexingPending(input: {
       updatedAt: new Date(),
     })
     .where(eq(repositories.id, input.repositoryId))
+}
+
+/**
+ * Marks a repository queued for a new ingestion orchestrator only when it is
+ * not already `queued` or `running` (single-flight per repo).
+ *
+ * @returns true when the caller should start a new orchestrator workflow.
+ */
+export async function tryClaimRepositoryIndexingEnqueue(input: {
+  repositoryId: string
+  reason: string | null
+}): Promise<boolean> {
+  const db = getOrgDb()
+  const updated = await db
+    .update(repositories)
+    .set({
+      indexReady: false,
+      indexingStatus: "queued",
+      indexingError: null,
+      indexingFailedAt: null,
+      indexingReason: input.reason,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(repositories.id, input.repositoryId),
+        or(
+          isNull(repositories.indexingStatus),
+          notInArray(repositories.indexingStatus, ["queued", "running"]),
+        ),
+      ),
+    )
+    .returning({ id: repositories.id })
+  return updated.length > 0
 }
 
 /** Marks a repository as mid-unindex for UI before background cleanup runs. */

--- a/apps/backend/src/openworkflow/enqueue-repository-ingestion.test.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-ingestion.test.ts
@@ -4,14 +4,14 @@ const runWorkflowWithWorkerWakeMock = vi.hoisted(() => vi.fn())
 const withOrgDbContextMock = vi.hoisted(() =>
   vi.fn((_orgId: string, fn: () => unknown) => Promise.resolve(fn())),
 )
-const markPendingMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const tryClaimMock = vi.hoisted(() => vi.fn().mockResolvedValue(true))
 
 vi.mock("../db/client.js", () => ({
   withOrgDbContext: withOrgDbContextMock,
 }))
 
 vi.mock("../models/repositories.js", () => ({
-  markRepositoryIndexingPending: markPendingMock,
+  tryClaimRepositoryIndexingEnqueue: tryClaimMock,
 }))
 
 vi.mock("./client.js", () => ({
@@ -32,7 +32,7 @@ import {
 describe("enqueueRepositoryIngestionWorkflow", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    markPendingMock.mockResolvedValue(undefined)
+    tryClaimMock.mockResolvedValue(true)
     withOrgDbContextMock.mockImplementation(
       (_orgId: string, fn: () => unknown) => Promise.resolve(fn()),
     )
@@ -50,10 +50,25 @@ describe("enqueueRepositoryIngestionWorkflow", () => {
       log,
     )
 
-    expect(markPendingMock).toHaveBeenCalledWith({
+    expect(tryClaimMock).toHaveBeenCalledWith({
       repositoryId: "repo_1",
       reason: null,
     })
+    expect(runWorkflowWithWorkerWakeMock).toHaveBeenCalled()
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  it("skips orchestrator when indexing is already queued or running", async () => {
+    tryClaimMock.mockResolvedValue(false)
+    const log = { error: vi.fn() }
+
+    await enqueueRepositoryIngestionWorkflow(
+      { repositoryId: "repo_1", orgId: "org_1" },
+      log,
+    )
+
+    expect(tryClaimMock).toHaveBeenCalled()
+    expect(runWorkflowWithWorkerWakeMock).not.toHaveBeenCalled()
     expect(log.error).not.toHaveBeenCalled()
   })
 })
@@ -61,13 +76,13 @@ describe("enqueueRepositoryIngestionWorkflow", () => {
 describe("runRepositoryIngestionWorkflow", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    markPendingMock.mockResolvedValue(undefined)
+    tryClaimMock.mockResolvedValue(true)
     withOrgDbContextMock.mockImplementation(
       (_orgId: string, fn: () => unknown) => Promise.resolve(fn()),
     )
   })
 
-  it("does not await workflow result", async () => {
+  it("awaits workflow wake when claim succeeds", async () => {
     runWorkflowWithWorkerWakeMock.mockResolvedValue({
       result: vi.fn().mockRejectedValue(new Error("terminal failure")),
     })
@@ -78,6 +93,24 @@ describe("runRepositoryIngestionWorkflow", () => {
       log,
     )
 
+    expect(tryClaimMock).toHaveBeenCalledWith({
+      repositoryId: "repo_1",
+      reason: null,
+    })
+    expect(runWorkflowWithWorkerWakeMock).toHaveBeenCalled()
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  it("skips workflow when indexing is already queued or running", async () => {
+    tryClaimMock.mockResolvedValue(false)
+    const log = { error: vi.fn() }
+
+    await runRepositoryIngestionWorkflow(
+      { repositoryId: "repo_1", orgId: "org_1" },
+      log,
+    )
+
+    expect(runWorkflowWithWorkerWakeMock).not.toHaveBeenCalled()
     expect(log.error).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/openworkflow/enqueue-repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-ingestion.ts
@@ -1,7 +1,5 @@
 import { withOrgDbContext } from "../db/client.js"
-import {
-  markRepositoryIndexingPending,
-} from "../models/repositories.js"
+import { tryClaimRepositoryIndexingEnqueue } from "../models/repositories.js"
 import { runWorkflowWithWorkerWake } from "./client.js"
 import { repositoryIngestionOrchestrator } from "./workflows/repository-ingestion-orchestrator.js"
 
@@ -14,7 +12,8 @@ export type RepositoryIngestionEnqueueInput = {
 
 /**
  * Marks the repo as mid-ingestion for the UI, then enqueues repository-ingestion-orchestrator.
- * Awaits the DB update so callers can return HTTP 200 after the UI can poll status.
+ * Skips starting another orchestrator when indexing is already `queued` or `running`.
+ * Awaits the DB claim so callers can return HTTP 200 after the UI can poll status.
  * Does not await workflow completion; failures are handled inside the workflow.
  */
 export async function enqueueRepositoryIngestionWorkflow(
@@ -23,12 +22,15 @@ export async function enqueueRepositoryIngestionWorkflow(
 ): Promise<void> {
   // Enqueue is the network-level entry for webhooks (no request context), so
   // we establish org DB context here before calling the model.
-  await withOrgDbContext(input.orgId, () =>
-    markRepositoryIndexingPending({
+  const shouldEnqueue = await withOrgDbContext(input.orgId, () =>
+    tryClaimRepositoryIndexingEnqueue({
       repositoryId: input.repositoryId,
       reason: input.indexingReason ?? null,
     }),
   )
+  if (!shouldEnqueue) {
+    return
+  }
 
   void (async () => {
     try {
@@ -51,12 +53,15 @@ export async function runRepositoryIngestionWorkflow(
   input: RepositoryIngestionEnqueueInput,
   log: { error: (err: Error) => void },
 ): Promise<void> {
-  await withOrgDbContext(input.orgId, () =>
-    markRepositoryIndexingPending({
+  const shouldEnqueue = await withOrgDbContext(input.orgId, () =>
+    tryClaimRepositoryIndexingEnqueue({
       repositoryId: input.repositoryId,
       reason: input.indexingReason ?? null,
     }),
   )
+  if (!shouldEnqueue) {
+    return
+  }
 
   try {
     await runWorkflowWithWorkerWake(repositoryIngestionOrchestrator.spec, {

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.reindex-tx.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.reindex-tx.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const withOrgDbContextMock = vi.hoisted(() =>
+  vi.fn(async (_orgId: string, fn: (db: unknown) => unknown) => {
+    const db = {
+      query: {
+        repositories: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "repo_1",
+            orgId: "org_1",
+            lastIngestedHash: null,
+            githubConnectionId: "con_1",
+          }),
+        },
+      },
+    }
+    return fn(db)
+  }),
+)
+
+const reindexMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    indexedAt: "2026-01-01T00:00:00.000Z",
+    targetHash: "abc",
+    ingestMode: "full" as const,
+    changedPaths: [],
+    deletedPaths: [],
+    renames: [],
+  }),
+)
+
+vi.mock("../../db/client.js", () => ({
+  getSystemDb: () => ({
+    query: {
+      organizations: {
+        findFirst: vi.fn().mockResolvedValue({ id: "org_1", slug: "org" }),
+      },
+    },
+  }),
+  withOrgDbContext: withOrgDbContextMock,
+}))
+
+vi.mock("../../auth/withAuth.js", () => ({
+  withOrgIdContext: (_org: unknown, fn: () => unknown) => fn(),
+}))
+
+vi.mock("../../observability/logger.js", () => ({
+  createLogger: () => ({}),
+  withLogger: (_l: unknown, fn: () => unknown) => fn(),
+  getLogger: () => ({
+    set: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+  flushWorkflowLog: vi.fn(),
+}))
+
+vi.mock("../../observability/langfuse.js", () => ({
+  runWithLangfuseContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getLangfuseHandler: () => undefined,
+}))
+
+vi.mock("../../graphs/codeIngestionGraph/nodes/reindex.js", () => ({
+  reindex: reindexMock,
+}))
+
+vi.mock("../../graphs/codeIngestionGraph/nodes/retractStaleEvidence.js", () => ({
+  retractStaleEvidence: vi.fn().mockResolvedValue({
+    retractionStats: {},
+    retractionGraphEffects: {
+      deletedClaimIds: [],
+      refreshedClaimIds: [],
+      deletedObjectIds: [],
+    },
+  }),
+}))
+
+vi.mock("../../graphs/codeIngestionGraph/graph.js", () => ({
+  graph: { invoke: vi.fn().mockResolvedValue({}) },
+}))
+
+vi.mock("../../domain/codeIngestion/queue.js", () => ({
+  resolveRepositoryRef: vi
+    .fn()
+    .mockResolvedValue({ hash: "abc", branch: "main" }),
+}))
+
+vi.mock("../../models/repositories.js", () => ({
+  markRepositoryIndexingRunning: vi.fn().mockResolvedValue(undefined),
+  markRepositoryIndexingReady: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("../../retrieval/services/ingestionRetraction.js", () => ({
+  applyIngestionRetractionGraphEffects: vi.fn(),
+}))
+
+vi.mock("openworkflow", () => ({
+  defineWorkflow: (
+    _opts: unknown,
+    handler: (args: {
+      input: { repositoryId: string; orgId: string }
+      step: {
+        run: (
+          opts: { name: string; retryPolicy?: unknown },
+          fn: () => unknown,
+        ) => Promise<unknown>
+      }
+    }) => Promise<unknown>,
+  ) => ({
+    run: handler,
+    spec: { name: "repository-ingestion" },
+  }),
+}))
+
+import { repositoryIngestion } from "./repository-ingestion.js"
+
+describe("repository-ingestion reindex transaction boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("calls reindex outside withOrgDbContext and caps reindex retries", async () => {
+    let reindexRetryPolicy: { maximumAttempts?: number } | undefined
+    let withOrgCallsDuringReindex = 0
+
+    const step = {
+      run: async (
+        opts: { name: string; retryPolicy?: { maximumAttempts?: number } },
+        fn: () => unknown,
+      ) => {
+        if (opts.name === "reindexStep") {
+          reindexRetryPolicy = opts.retryPolicy
+          const before = withOrgDbContextMock.mock.calls.length
+          const result = await fn()
+          withOrgCallsDuringReindex =
+            withOrgDbContextMock.mock.calls.length - before
+          return result
+        }
+        return fn()
+      },
+    }
+
+    const wf = repositoryIngestion as unknown as {
+      run: (args: {
+        input: { repositoryId: string; orgId: string }
+        step: typeof step
+      }) => Promise<unknown>
+    }
+
+    await wf.run({
+      input: { repositoryId: "repo_1", orgId: "org_1" },
+      step,
+    })
+
+    expect(reindexMock).toHaveBeenCalledOnce()
+    expect(withOrgCallsDuringReindex).toBe(0)
+    expect(reindexRetryPolicy?.maximumAttempts).toBe(2)
+  })
+})

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -157,8 +157,20 @@ export const repositoryIngestion = defineWorkflow(
             targetHash: resolved.hash,
           })
 
-          const reindexState = await step.run({ name: "reindexStep" }, () =>
-            withOrgDbContext(input.orgId, () =>
+          // No withOrgDbContext: reindex awaits long codesearch /index HTTP.
+          // Holding an org transaction across that call hits idle_in_transaction
+          // (25P03) and can crash the worker via unhandled pg Client errors.
+          const reindexState = await step.run(
+            {
+              name: "reindexStep",
+              retryPolicy: {
+                maximumAttempts: 2,
+                initialInterval: "30s",
+                backoffCoefficient: 2,
+                maximumInterval: "2m",
+              },
+            },
+            () =>
               reindex({
                 repositoryId: input.repositoryId,
                 orgId: input.orgId,
@@ -166,7 +178,6 @@ export const repositoryIngestion = defineWorkflow(
                 fromHash: repository.lastIngestedHash ?? undefined,
                 targetHash: resolved.hash,
               }),
-            ),
           )
 
           logWorkflowMilestone("repository-ingestion.step.reindex.done", {
@@ -299,18 +310,17 @@ export const repositoryIngestion = defineWorkflow(
             effects.refreshedClaimIds.length > 0 ||
             effects.deletedObjectIds.length > 0
           ) {
-            await step.run({ name: "sync-retraction-graph" }, () =>
-              withOrgDbContext(input.orgId, async () => {
-                const graph =
-                  await applyIngestionRetractionGraphEffects(effects)
-                retractionResult.retractionStats.graphEdgesDeleted =
-                  graph.graphEdgesDeleted
-                retractionResult.retractionStats.graphClaimsRefreshed =
-                  graph.graphClaimsRefreshed
-                retractionResult.retractionStats.graphOrphanObjectsDeleted =
-                  graph.graphOrphanObjectsDeleted
-              }),
-            )
+            // Falkor graph sync must not hold an org PG transaction (external I/O).
+            await step.run({ name: "sync-retraction-graph" }, async () => {
+              const graph =
+                await applyIngestionRetractionGraphEffects(effects)
+              retractionResult.retractionStats.graphEdgesDeleted =
+                graph.graphEdgesDeleted
+              retractionResult.retractionStats.graphClaimsRefreshed =
+                graph.graphClaimsRefreshed
+              retractionResult.retractionStats.graphOrphanObjectsDeleted =
+                graph.graphOrphanObjectsDeleted
+            })
           }
 
           logWorkflowMilestone("repository-ingestion.step.mark-success.start", {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Preview Postgres has `idle_in_transaction_session_timeout = 5min`. `reindexStep` wrapped the long codesearch `POST /index` inside `withOrgDbContext`, which opens a real DB transaction. After ~5 minutes Postgres terminated the idle connection (`25P03`), the `pg` Client emitted an unhandled `'error'`, and the OpenWorkflow worker crashed. Durable steps resumed and restarted reindex in a loop—invalidating OOM testing for large repos.

## Fix

1. **`reindexStep` runs outside `withOrgDbContext`** — still awaits codesearch until finished; no open org transaction during that HTTP call. Cap retries at `maximumAttempts: 2`.
2. **`sync-retraction-graph` likewise unwound** — Falkor I/O must not hold an empty org PG transaction.
3. **`pool.on("error")` on the app DB pool** — log unexpected client errors instead of crashing the worker process.
4. **Single-flight enqueue** — `tryClaimRepositoryIndexingEnqueue` only marks queued / starts an orchestrator when status is not already `queued` or `running`.

## Impact

- Large-repo reindex can exceed 5 minutes safely (HTTP held open; DB tx not).
- Stops the 5-minute worker crash/replay loop.
- Duplicate enqueues while a repo is mid-index are coalesced.
- Does **not** raise Postgres idle-in-transaction timeout.

## Test plan

- [x] Enqueue single-flight unit tests
- [x] Reindex transaction-boundary unit test (`withOrgDbContext` not entered during `reindexStep`)
- [x] `tryClaimRepositoryIndexingEnqueue` model tests
- [ ] After deploy: stop any crash-looping preview ingest, then retry Kubernetes/LLVM once
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://ctxpipe.slack.com/archives/C0AMVSR0EBW/p1784619201377549?thread_ts=1784619201.377549&cid=C0AMVSR0EBW)

<div><a href="https://cursor.com/agents/bc-0bce6c75-8743-5e5a-8a61-8c393395d78b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bce6c75-8743-5e5a-8a61-8c393395d78b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

