### PR TITLE
fix(pr-deploy): make PR previews actually sleep (otel stop + worker idle-exit)

### DIFF
--- a/.agents/mcp.json
+++ b/.agents/mcp.json
@@ -16,6 +16,9 @@
         "memory",
         "mcp"
       ]
+    },
+    "railway": {
+      "url": "https://mcp.railway.com"
     }
   }
 }

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -192,7 +192,6 @@ jobs:
           WORKER_SERVICE_ID: ${{ vars.RAILWAY_WORKER_SERVICE_ID }}
           UI_SERVICE_ID: ${{ vars.RAILWAY_UI_SERVICE_ID }}
           CODESEARCH_SERVICE_ID: ${{ vars.RAILWAY_CODESEARCH_SERVICE_ID }}
-          OTELCOLLECTOR_SERVICE_ID: ${{ vars.RAILWAY_OTELCOLLECTOR_SERVICE_ID }}
           BACKEND_IMAGE: ghcr.io/ctxpipe-ai/backend:${{ env.IMAGE_TAG }}
           WORKER_IMAGE: ghcr.io/ctxpipe-ai/worker:${{ env.IMAGE_TAG }}
           UI_IMAGE: ghcr.io/ctxpipe-ai/ui:${{ env.IMAGE_TAG }}
@@ -247,6 +246,34 @@ jobs:
                 -H "Content-Type: application/json" \
                 -d "$(jq -nc --arg q "$query" --argjson v "$variables" '{query:$q,variables:$v}')" \
                 https://backboard.railway.com/graphql/v2
+            }
+
+            # Cache of name -> id from a single project services query (Terraform names).
+            SERVICE_IDS_BY_NAME_JSON=""
+
+            load_service_ids_by_name() {
+              if [[ -n "$SERVICE_IDS_BY_NAME_JSON" ]]; then
+                return 0
+              fi
+              local response
+              response="$(railway_graphql \
+                'query ProjectServices($id: String!) { project(id: $id) { services { edges { node { id name } } } } }' \
+                "$(jq -nc --arg id "$RAILWAY_PROJECT_ID" '{id:$id}')")"
+              if echo "$response" | jq -e '.errors | length > 0' >/dev/null 2>&1; then
+                echo "Failed to list Railway project services: $(echo "$response" | jq -r '.errors[].message' | paste -sd '; ' -)" >&2
+                exit 1
+              fi
+              SERVICE_IDS_BY_NAME_JSON="$(echo "$response" | jq -c '
+                [.data.project.services.edges[]?.node // empty | select(.name and .id) | {key: .name, value: .id}]
+                | from_entries
+              ')"
+              echo "Loaded Railway service name map ($(echo "$SERVICE_IDS_BY_NAME_JSON" | jq 'keys | length') services)" >&2
+            }
+
+            resolve_service_id_by_name() {
+              local name="$1"
+              load_service_ids_by_name
+              echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r --arg name "$name" '.[$name] // empty'
             }
 
             current_database_url() {
@@ -354,6 +381,14 @@ jobs:
                 "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" --arg img "$image" '{environmentId:$env, serviceId:$service, input:{source:{image:$img}, sleepApplication:true}}')"
             }
 
+            # Serverless only (no image change) — for infra images managed by Terraform (e.g. FalkorDB).
+            enable_serverless() {
+              local service_id="$1"
+              railway_graphql \
+                'mutation serviceInstanceUpdate($environmentId: String, $serviceId: String!, $input: ServiceInstanceUpdateInput!) { serviceInstanceUpdate(environmentId: $environmentId, serviceId: $serviceId, input: $input) }' \
+                "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{environmentId:$env, serviceId:$service, input:{sleepApplication:true}}')"
+            }
+
             deploy_service() {
               local service_id="$1"
               railway_graphql \
@@ -381,12 +416,23 @@ jobs:
             update_source_image "$CODESEARCH_SERVICE_ID" "$CODESEARCH_IMAGE" >/dev/null
             deploy_service "$CODESEARCH_SERVICE_ID" >/dev/null
 
-            if [[ -n "${OTELCOLLECTOR_SERVICE_ID:-}" ]]; then
+            # Terraform service names: otelcollector, falkordb (resolved via GraphQL; no GitHub vars).
+            OTELCOLLECTOR_SERVICE_ID="$(resolve_service_id_by_name otelcollector)"
+            if [[ -n "$OTELCOLLECTOR_SERVICE_ID" ]]; then
               update_source_image "$OTELCOLLECTOR_SERVICE_ID" "$OTELCOLLECTOR_IMAGE" >/dev/null
               deploy_service "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
-              echo "otel-collector updated and deployed"
+              echo "otel-collector ($OTELCOLLECTOR_SERVICE_ID) updated and deployed with serverless"
             else
-              echo "Skipping otel-collector: set repository variable RAILWAY_OTELCOLLECTOR_SERVICE_ID (Terraform: module.ctxpipe.railway_service_ids.otelcollector)"
+              echo "Warning: no Railway service named otelcollector in project $RAILWAY_PROJECT_ID; skipping"
+            fi
+
+            FALKORDB_SERVICE_ID="$(resolve_service_id_by_name falkordb)"
+            if [[ -n "$FALKORDB_SERVICE_ID" ]]; then
+              enable_serverless "$FALKORDB_SERVICE_ID" >/dev/null
+              deploy_service "$FALKORDB_SERVICE_ID" >/dev/null
+              echo "falkordb ($FALKORDB_SERVICE_ID) serverless enabled and deployed"
+            else
+              echo "Warning: no Railway service named falkordb in project $RAILWAY_PROJECT_ID; skipping"
             fi
 
             echo "All services updated and deployed with a single deploy per service"

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -370,8 +370,8 @@ jobs:
 
             upsert_preview_worker_idle_exit() {
               local service_id="$1"
-              # 180s idle → exit (supervisor min is 120). Shorter stale window so stuck
-              # ingestion rows from a previous wake do not block sleep for hours.
+              # Explicit OPENWORKFLOW_PR_IDLE_EXIT so supervisor idle-exits even if
+              # RAILWAY_ENVIRONMENT_NAME is missing. 180s idle; 1h stale window.
               railway_graphql \
                 'mutation variableCollectionUpsert($input: VariableCollectionUpsertInput!) { variableCollectionUpsert(input: $input) }' \
                 "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" --arg env "$ENV_ID" --arg service "$service_id" \
@@ -382,12 +382,13 @@ jobs:
                       serviceId: $service,
                       skipDeploys: true,
                       variables: {
+                        OPENWORKFLOW_PR_IDLE_EXIT: "true",
                         OPENWORKFLOW_IDLE_EXIT_SECONDS: "180",
                         OPENWORKFLOW_IDLE_STALE_AFTER_HOURS: "1"
                       }
                     }
                   }')"
-              echo "Set OPENWORKFLOW_IDLE_EXIT_SECONDS=180 and STALE_AFTER_HOURS=1 for worker $service_id"
+              echo "Set OPENWORKFLOW_PR_IDLE_EXIT + IDLE_EXIT=180 + STALE_AFTER_HOURS=1 for worker $service_id"
             }
 
             update_source_image() {
@@ -406,8 +407,7 @@ jobs:
                 "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{environmentId:$env, serviceId:$service, input:{sleepApplication:true}}')"
             }
 
-            # Scale a service to zero replicas in this environment (no running containers).
-            # Uses multiRegionConfig when we can discover regions; falls back to numReplicas: 0.
+            # Scale a service to zero replicas in this environment (config only).
             scale_service_to_zero() {
               local service_id="$1"
               local response regions_json input_json
@@ -431,7 +431,33 @@ jobs:
               railway_graphql \
                 'mutation serviceInstanceUpdate($environmentId: String, $serviceId: String!, $input: ServiceInstanceUpdateInput!) { serviceInstanceUpdate(environmentId: $environmentId, serviceId: $serviceId, input: $input) }' \
                 "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" --argjson input "$input_json" '{environmentId:$env, serviceId:$service, input:$input}')"
-              echo "Scaled service $service_id to 0 replicas (no PR deploy)"
+              echo "Scaled service $service_id to 0 replicas (config)"
+            }
+
+            # Stop active deployments without creating a new one (no "Deploy" in UI).
+            stop_active_deployments() {
+              local service_id="$1"
+              local response dep_ids
+              response="$(railway_graphql \
+                'query deployments($input: DeploymentListInput!) { deployments(input: $input) { edges { node { id status } } } }' \
+                "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{input:{environmentId:$env, serviceId:$service}}')")"
+              dep_ids="$(echo "$response" | jq -r '
+                .data.deployments.edges[]?
+                | .node
+                | select(.status == "SUCCESS" or .status == "DEPLOYING" or .status == "INITIALIZING" or .status == "BUILDING" or .status == "WAITING")
+                | .id
+              ' 2>/dev/null || true)"
+              if [[ -z "$dep_ids" ]]; then
+                echo "No active deployments to stop for service $service_id"
+                return 0
+              fi
+              while IFS= read -r dep_id; do
+                [[ -z "$dep_id" ]] && continue
+                railway_graphql \
+                  'mutation deploymentStop($id: String!) { deploymentStop(id: $id) }' \
+                  "$(jq -nc --arg id "$dep_id" '{id:$id}')" >/dev/null || true
+                echo "Stopped deployment $dep_id for service $service_id"
+              done <<< "$dep_ids"
             }
 
             # Read back sleepApplication for deploy logs / debugging.
@@ -481,14 +507,13 @@ jobs:
             OTELCOLLECTOR_SERVICE_ID="$(echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r '.otelcollector // empty')"
             FALKORDB_SERVICE_ID="$(echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r '.falkordb // empty')"
 
-            # Never deploy otelcollector in PR: scale to 0 so the duplicated prod service
-            # has no running containers (Better Stack quota + sleep).
+            # Never deploy otelcollector in PR: scale to 0 and stop active deployments
+            # (no serviceInstanceDeployV2 — that was waking/starting containers).
             if [[ -n "$OTELCOLLECTOR_SERVICE_ID" ]]; then
               delete_service_variable "$OTELCOLLECTOR_SERVICE_ID" "BETTER_STACK_TOKEN"
               scale_service_to_zero "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
-              # Apply scale-down without starting a new image (0 replicas → stop).
-              deploy_service "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
-              echo "otel-collector ($OTELCOLLECTOR_SERVICE_ID) scaled to 0 replicas (not deployed in PR)"
+              stop_active_deployments "$OTELCOLLECTOR_SERVICE_ID"
+              echo "otel-collector ($OTELCOLLECTOR_SERVICE_ID) scaled to 0 and active deployments stopped (not deployed)"
               verify_sleep_application "otel-collector" "$OTELCOLLECTOR_SERVICE_ID"
             else
               echo "Warning: no Railway service named otelcollector in project $RAILWAY_PROJECT_ID; skipping"

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -39,8 +39,7 @@ jobs:
             dockerfile: apps/ui/Dockerfile
           - image: codesearch
             dockerfile: apps/codesearch/Dockerfile
-          - image: otel-collector
-            dockerfile: apps/otel-collector/Dockerfile
+          # otel-collector is not built/deployed for PR envs (keeps previews asleep; no Better Stack quota burn).
     steps:
       - name: Checkout repository
         uses: useblacksmith/checkout@v1
@@ -196,7 +195,6 @@ jobs:
           WORKER_IMAGE: ghcr.io/ctxpipe-ai/worker:${{ env.IMAGE_TAG }}
           UI_IMAGE: ghcr.io/ctxpipe-ai/ui:${{ env.IMAGE_TAG }}
           CODESEARCH_IMAGE: ghcr.io/ctxpipe-ai/codesearch:${{ env.IMAGE_TAG }}
-          OTELCOLLECTOR_IMAGE: ghcr.io/ctxpipe-ai/otel-collector:${{ env.IMAGE_TAG }}
         # Railway API/CLI calls can be flaky; retry once before failing.
         uses: nick-fields/retry@v3
         with:
@@ -301,7 +299,9 @@ jobs:
               echo "Updated DATABASE_URL for service $service_id with skipDeploys=true"
             }
 
-            # Preview-only: turn off LangSmith; duplicated prod keeps OTLP / Amplitude vars.
+            # Preview-only: turn off LangSmith and clear OTEL exporters so apps do not
+            # emit 60s metrics/logs (which keep Railway Serverless awake and wake otelcollector).
+            # Empty strings are treated as unset by apps/backend parseEnv.
             upsert_preview_service_variables() {
               local service_id="$1"
               railway_graphql \
@@ -314,11 +314,14 @@ jobs:
                       serviceId: $service,
                       skipDeploys: true,
                       variables: {
-                        ENABLE_LANGSMITH: "false"
+                        ENABLE_LANGSMITH: "false",
+                        OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "",
+                        OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "",
+                        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: ""
                       }
                     }
                   }')"
-              echo "Updated preview ENABLE_LANGSMITH for service $service_id"
+              echo "Updated preview ENABLE_LANGSMITH=false and cleared OTEL exporters for service $service_id"
             }
 
             # Backend: allow waking the worker after enqueue (Railway GraphQL deploy).
@@ -437,10 +440,24 @@ jobs:
             OTELCOLLECTOR_SERVICE_ID="$(echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r '.otelcollector // empty')"
             FALKORDB_SERVICE_ID="$(echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r '.falkordb // empty')"
 
+            # Do not push a PR otelcollector image. Enable serverless, clear Better Stack token
+            # (avoids 402 quota hammer if something still wakes it), then deploy once.
             if [[ -n "$OTELCOLLECTOR_SERVICE_ID" ]]; then
-              update_source_image "$OTELCOLLECTOR_SERVICE_ID" "$OTELCOLLECTOR_IMAGE" >/dev/null
+              railway_graphql \
+                'mutation variableCollectionUpsert($input: VariableCollectionUpsertInput!) { variableCollectionUpsert(input: $input) }' \
+                "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" --arg env "$ENV_ID" --arg service "$OTELCOLLECTOR_SERVICE_ID" \
+                  '{
+                    input: {
+                      projectId: $project,
+                      environmentId: $env,
+                      serviceId: $service,
+                      skipDeploys: true,
+                      variables: { BETTER_STACK_TOKEN: "" }
+                    }
+                  }')" >/dev/null
+              enable_serverless "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
               deploy_service "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
-              echo "otel-collector ($OTELCOLLECTOR_SERVICE_ID) updated and deployed with serverless"
+              echo "otel-collector ($OTELCOLLECTOR_SERVICE_ID) serverless-only (no PR image); cleared BETTER_STACK_TOKEN"
               verify_sleep_application "otel-collector" "$OTELCOLLECTOR_SERVICE_ID"
             else
               echo "Warning: no Railway service named otelcollector in project $RAILWAY_PROJECT_ID; skipping"

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -7,9 +7,17 @@ on:
       - reopened
       - synchronize
       - closed
+  # Cloud-agent git pushes often do not emit pull_request synchronize. Manual
+  # redeploy: Actions → PR Deploy → Run workflow → enter PR number.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to deploy (e.g. 255)"
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('pr-{0}', inputs.pr_number) || github.ref }}
 
 permissions:
   contents: read
@@ -17,14 +25,40 @@ permissions:
   pull-requests: write
 
 jobs:
-  build_pr_images:
-    name: Build and Publish PR GHCR Images
+  resolve_pr:
+    name: Resolve PR number and head SHA
     if: |
+      github.event_name == 'workflow_dispatch' || (
       github.event_name == 'pull_request' && (
       github.event.action == 'synchronize'
       || github.event.action == 'opened'
       || github.event.action == 'reopened') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+    steps:
+      - name: Resolve
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            HEAD_SHA="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq .head.sha)"
+          else
+            PR_NUMBER="${{ github.event.number }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR #$PR_NUMBER @ $HEAD_SHA"
+
+  build_pr_images:
+    name: Build and Publish PR GHCR Images
+    needs: [resolve_pr]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
@@ -43,6 +77,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: useblacksmith/checkout@v1
+        with:
+          ref: ${{ needs.resolve_pr.outputs.head_sha }}
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
@@ -63,28 +99,25 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           tags: |
-            ghcr.io/ctxpipe-ai/${{ matrix.image }}:pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
-            ghcr.io/ctxpipe-ai/${{ matrix.image }}:${{ github.event.pull_request.head.sha }}
+            ghcr.io/ctxpipe-ai/${{ matrix.image }}:pr-${{ needs.resolve_pr.outputs.pr_number }}-${{ needs.resolve_pr.outputs.head_sha }}
+            ghcr.io/ctxpipe-ai/${{ matrix.image }}:${{ needs.resolve_pr.outputs.head_sha }}
 
   deploy_pr_environment:
     name: Deploy PR environment (Railway + Neon)
-    needs: [build_pr_images]
-    if: |
-      github.event_name == 'pull_request' && (
-      github.event.action == 'synchronize'
-      || github.event.action == 'opened'
-      || github.event.action == 'reopened') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    needs: [resolve_pr, build_pr_images]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
-      PR_ENV: pr-${{ github.event.number }}
-      IMAGE_TAG: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+      PR_ENV: pr-${{ needs.resolve_pr.outputs.pr_number }}
+      IMAGE_TAG: pr-${{ needs.resolve_pr.outputs.pr_number }}-${{ needs.resolve_pr.outputs.head_sha }}
+      PR_NUMBER: ${{ needs.resolve_pr.outputs.pr_number }}
     outputs:
       env_id: ${{ steps.railway_env.outputs.env_id }}
     steps:
       - name: Checkout repository
         uses: useblacksmith/checkout@v1
+        with:
+          ref: ${{ needs.resolve_pr.outputs.head_sha }}
 
       - name: Mount pnpm store sticky disk
         uses: useblacksmith/stickydisk@v1
@@ -141,7 +174,7 @@ jobs:
         uses: neondatabase/create-branch-action@v6
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch_name: preview/pr-${{ github.event.number }}
+          branch_name: preview/pr-${{ needs.resolve_pr.outputs.pr_number }}
           parent_branch: production
           api_key: ${{ secrets.NEON_API_KEY }}
           expires_at: ${{ steps.neon_expires.outputs.expires_at }}
@@ -166,7 +199,7 @@ jobs:
           max_attempts: 2
           command: |
             set -euo pipefail
-            ENV_NAME="pr-${{ github.event.number }}"
+            ENV_NAME="pr-${{ needs.resolve_pr.outputs.pr_number }}"
             # Query for environment ID by name
             ENV_ID=$(curl -fsS -X POST \
               -H "Authorization: Bearer ${RAILWAY_API_TOKEN}" \
@@ -590,7 +623,7 @@ jobs:
         id: find-preview-comment
         uses: peter-evans/find-comment@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ needs.resolve_pr.outputs.pr_number }}
           comment-author: "github-actions[bot]"
           body-includes: "## PR Preview Environment"
 
@@ -600,7 +633,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.find-preview-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ needs.resolve_pr.outputs.pr_number }}
           body-path: pr-deploy-comment.md
           edit-mode: replace
 

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -389,6 +389,21 @@ jobs:
                 "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{environmentId:$env, serviceId:$service, input:{sleepApplication:true}}')"
             }
 
+            # Read back sleepApplication for deploy logs / debugging.
+            verify_sleep_application() {
+              local label="$1"
+              local service_id="$2"
+              local response sleep_val
+              response="$(railway_graphql \
+                'query serviceInstanceSleep($environmentId: String!, $serviceId: String!) { serviceInstance(environmentId: $environmentId, serviceId: $serviceId) { sleepApplication } }' \
+                "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{environmentId:$env, serviceId:$service}')")"
+              sleep_val="$(echo "$response" | jq -r '.data.serviceInstance.sleepApplication // empty')"
+              echo "$label ($service_id) sleepApplication=$( [[ -n "$sleep_val" ]] && echo "$sleep_val" || echo "unknown" ) raw=$(echo "$response" | jq -c '{data,errors}')"
+              if [[ "$sleep_val" != "true" ]]; then
+                echo "Warning: expected sleepApplication=true for $label but got '$sleep_val'"
+              fi
+            }
+
             deploy_service() {
               local service_id="$1"
               railway_graphql \
@@ -417,20 +432,25 @@ jobs:
             deploy_service "$CODESEARCH_SERVICE_ID" >/dev/null
 
             # Terraform service names: otelcollector, falkordb (resolved via GraphQL; no GitHub vars).
-            OTELCOLLECTOR_SERVICE_ID="$(resolve_service_id_by_name otelcollector)"
+            # Resolve in parent shell so the name→id cache is shared (command substitution is a subshell).
+            load_service_ids_by_name
+            OTELCOLLECTOR_SERVICE_ID="$(echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r '.otelcollector // empty')"
+            FALKORDB_SERVICE_ID="$(echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r '.falkordb // empty')"
+
             if [[ -n "$OTELCOLLECTOR_SERVICE_ID" ]]; then
               update_source_image "$OTELCOLLECTOR_SERVICE_ID" "$OTELCOLLECTOR_IMAGE" >/dev/null
               deploy_service "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
               echo "otel-collector ($OTELCOLLECTOR_SERVICE_ID) updated and deployed with serverless"
+              verify_sleep_application "otel-collector" "$OTELCOLLECTOR_SERVICE_ID"
             else
               echo "Warning: no Railway service named otelcollector in project $RAILWAY_PROJECT_ID; skipping"
             fi
 
-            FALKORDB_SERVICE_ID="$(resolve_service_id_by_name falkordb)"
             if [[ -n "$FALKORDB_SERVICE_ID" ]]; then
               enable_serverless "$FALKORDB_SERVICE_ID" >/dev/null
               deploy_service "$FALKORDB_SERVICE_ID" >/dev/null
               echo "falkordb ($FALKORDB_SERVICE_ID) serverless enabled and deployed"
+              verify_sleep_application "falkordb" "$FALKORDB_SERVICE_ID"
             else
               echo "Warning: no Railway service named falkordb in project $RAILWAY_PROJECT_ID; skipping"
             fi

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -299,9 +299,17 @@ jobs:
               echo "Updated DATABASE_URL for service $service_id with skipDeploys=true"
             }
 
-            # Preview-only: turn off LangSmith and clear OTEL exporters so apps do not
+            # Preview-only: turn off LangSmith and delete OTEL exporters so apps do not
             # emit 60s metrics/logs (which keep Railway Serverless awake and wake otelcollector).
-            # Empty strings are treated as unset by apps/backend parseEnv.
+            delete_service_variable() {
+              local service_id="$1"
+              local name="$2"
+              railway_graphql \
+                'mutation variableDelete($input: VariableDeleteInput!) { variableDelete(input: $input) }' \
+                "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" --arg env "$ENV_ID" --arg service "$service_id" --arg name "$name" \
+                  '{input:{projectId:$project, environmentId:$env, serviceId:$service, name:$name}}')" >/dev/null 2>&1 || true
+            }
+
             upsert_preview_service_variables() {
               local service_id="$1"
               railway_graphql \
@@ -314,14 +322,15 @@ jobs:
                       serviceId: $service,
                       skipDeploys: true,
                       variables: {
-                        ENABLE_LANGSMITH: "false",
-                        OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "",
-                        OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "",
-                        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: ""
+                        ENABLE_LANGSMITH: "false"
                       }
                     }
                   }')"
-              echo "Updated preview ENABLE_LANGSMITH=false and cleared OTEL exporters for service $service_id"
+              # Delete (not empty-string upsert) so Railway truly unsets OTEL endpoints.
+              delete_service_variable "$service_id" "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+              delete_service_variable "$service_id" "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
+              delete_service_variable "$service_id" "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+              echo "Updated preview ENABLE_LANGSMITH=false and deleted OTEL exporters for service $service_id"
             }
 
             # Backend: allow waking the worker after enqueue (Railway GraphQL deploy).
@@ -361,6 +370,8 @@ jobs:
 
             upsert_preview_worker_idle_exit() {
               local service_id="$1"
+              # 180s idle → exit (supervisor min is 120). Shorter stale window so stuck
+              # ingestion rows from a previous wake do not block sleep for hours.
               railway_graphql \
                 'mutation variableCollectionUpsert($input: VariableCollectionUpsertInput!) { variableCollectionUpsert(input: $input) }' \
                 "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" --arg env "$ENV_ID" --arg service "$service_id" \
@@ -370,10 +381,13 @@ jobs:
                       environmentId: $env,
                       serviceId: $service,
                       skipDeploys: true,
-                      variables: { OPENWORKFLOW_IDLE_EXIT_SECONDS: "660" }
+                      variables: {
+                        OPENWORKFLOW_IDLE_EXIT_SECONDS: "180",
+                        OPENWORKFLOW_IDLE_STALE_AFTER_HOURS: "1"
+                      }
                     }
                   }')"
-              echo "Set OPENWORKFLOW_IDLE_EXIT_SECONDS for worker service $service_id"
+              echo "Set OPENWORKFLOW_IDLE_EXIT_SECONDS=180 and STALE_AFTER_HOURS=1 for worker $service_id"
             }
 
             update_source_image() {
@@ -390,6 +404,34 @@ jobs:
               railway_graphql \
                 'mutation serviceInstanceUpdate($environmentId: String, $serviceId: String!, $input: ServiceInstanceUpdateInput!) { serviceInstanceUpdate(environmentId: $environmentId, serviceId: $serviceId, input: $input) }' \
                 "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{environmentId:$env, serviceId:$service, input:{sleepApplication:true}}')"
+            }
+
+            # Scale a service to zero replicas in this environment (no running containers).
+            # Uses multiRegionConfig when we can discover regions; falls back to numReplicas: 0.
+            scale_service_to_zero() {
+              local service_id="$1"
+              local response regions_json input_json
+              response="$(railway_graphql \
+                'query serviceInstanceRegions($environmentId: String!, $serviceId: String!) { serviceInstance(environmentId: $environmentId, serviceId: $serviceId) { regions { name numReplicas } } }' \
+                "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{environmentId:$env, serviceId:$service}')")"
+              regions_json="$(echo "$response" | jq -c '
+                [.data.serviceInstance.regions[]? | select(.name != null) | {key: .name, value: {numReplicas: 0}}]
+                | from_entries
+              ' 2>/dev/null || echo "{}")"
+              if [[ "$(echo "$regions_json" | jq 'length')" -gt 0 ]]; then
+                input_json="$(jq -nc --argjson mrc "$regions_json" '{sleepApplication:true, multiRegionConfig:$mrc, numReplicas:0}')"
+              else
+                # Terraform default region for this project (see infra/module/ctxpipe/railway.tf locals).
+                input_json="$(jq -nc '{
+                  sleepApplication: true,
+                  numReplicas: 0,
+                  multiRegionConfig: {"asia-southeast1-eqsg3a": {"numReplicas": 0}}
+                }')"
+              fi
+              railway_graphql \
+                'mutation serviceInstanceUpdate($environmentId: String, $serviceId: String!, $input: ServiceInstanceUpdateInput!) { serviceInstanceUpdate(environmentId: $environmentId, serviceId: $serviceId, input: $input) }' \
+                "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" --argjson input "$input_json" '{environmentId:$env, serviceId:$service, input:$input}')"
+              echo "Scaled service $service_id to 0 replicas (no PR deploy)"
             }
 
             # Read back sleepApplication for deploy logs / debugging.
@@ -435,29 +477,18 @@ jobs:
             deploy_service "$CODESEARCH_SERVICE_ID" >/dev/null
 
             # Terraform service names: otelcollector, falkordb (resolved via GraphQL; no GitHub vars).
-            # Resolve in parent shell so the name→id cache is shared (command substitution is a subshell).
             load_service_ids_by_name
             OTELCOLLECTOR_SERVICE_ID="$(echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r '.otelcollector // empty')"
             FALKORDB_SERVICE_ID="$(echo "$SERVICE_IDS_BY_NAME_JSON" | jq -r '.falkordb // empty')"
 
-            # Do not push a PR otelcollector image. Enable serverless, clear Better Stack token
-            # (avoids 402 quota hammer if something still wakes it), then deploy once.
+            # Never deploy otelcollector in PR: scale to 0 so the duplicated prod service
+            # has no running containers (Better Stack quota + sleep).
             if [[ -n "$OTELCOLLECTOR_SERVICE_ID" ]]; then
-              railway_graphql \
-                'mutation variableCollectionUpsert($input: VariableCollectionUpsertInput!) { variableCollectionUpsert(input: $input) }' \
-                "$(jq -nc --arg project "$RAILWAY_PROJECT_ID" --arg env "$ENV_ID" --arg service "$OTELCOLLECTOR_SERVICE_ID" \
-                  '{
-                    input: {
-                      projectId: $project,
-                      environmentId: $env,
-                      serviceId: $service,
-                      skipDeploys: true,
-                      variables: { BETTER_STACK_TOKEN: "" }
-                    }
-                  }')" >/dev/null
-              enable_serverless "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
+              delete_service_variable "$OTELCOLLECTOR_SERVICE_ID" "BETTER_STACK_TOKEN"
+              scale_service_to_zero "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
+              # Apply scale-down without starting a new image (0 replicas → stop).
               deploy_service "$OTELCOLLECTOR_SERVICE_ID" >/dev/null
-              echo "otel-collector ($OTELCOLLECTOR_SERVICE_ID) serverless-only (no PR image); cleared BETTER_STACK_TOKEN"
+              echo "otel-collector ($OTELCOLLECTOR_SERVICE_ID) scaled to 0 replicas (not deployed in PR)"
               verify_sleep_application "otel-collector" "$OTELCOLLECTOR_SERVICE_ID"
             else
               echo "Warning: no Railway service named otelcollector in project $RAILWAY_PROJECT_ID; skipping"

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Ensure Railway PR environment exists
         # Railway API/CLI calls can be flaky; retry once before failing.
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 12
           max_attempts: 2
@@ -193,7 +193,7 @@ jobs:
         env:
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
         # Railway API/CLI calls can be flaky; retry once before failing.
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 2
@@ -229,7 +229,7 @@ jobs:
           UI_IMAGE: ghcr.io/ctxpipe-ai/ui:${{ env.IMAGE_TAG }}
           CODESEARCH_IMAGE: ghcr.io/ctxpipe-ai/codesearch:${{ env.IMAGE_TAG }}
         # Railway API/CLI calls can be flaky; retry once before failing.
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 2
@@ -272,11 +272,22 @@ jobs:
             railway_graphql() {
               local query="$1"
               local variables="$2"
-              curl -fsS \
+              local raw http_code body
+              # Capture body + status so GraphQL validation/400s are visible in logs
+              # (curl -f alone only prints "returned error: 400").
+              raw="$(curl -sS -w '\n%{http_code}' \
                 -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
                 -H "Content-Type: application/json" \
                 -d "$(jq -nc --arg q "$query" --argjson v "$variables" '{query:$q,variables:$v}')" \
-                https://backboard.railway.com/graphql/v2
+                https://backboard.railway.com/graphql/v2)" || return $?
+              http_code="$(printf '%s' "$raw" | tail -n1)"
+              body="$(printf '%s' "$raw" | sed '$d')"
+              if [[ "$http_code" != "200" ]]; then
+                echo "Railway GraphQL HTTP $http_code for query: ${query:0:120}…" >&2
+                echo "$body" >&2
+                return 22
+              fi
+              printf '%s' "$body"
             }
 
             # Cache of name -> id from a single project services query (Terraform names).
@@ -441,30 +452,26 @@ jobs:
             }
 
             # Scale a service to zero replicas in this environment (config only).
+            # Use multiRegionConfig only — top-level numReplicas is deprecated, and
+            # serviceInstance has no `regions` field (that query returned HTTP 400).
+            # Region matches Terraform default in infra/module/ctxpipe/railway.tf.
+            # Non-fatal: deploymentStop below is what actually stops running containers.
             scale_service_to_zero() {
               local service_id="$1"
-              local response regions_json input_json
-              response="$(railway_graphql \
-                'query serviceInstanceRegions($environmentId: String!, $serviceId: String!) { serviceInstance(environmentId: $environmentId, serviceId: $serviceId) { regions { name numReplicas } } }' \
-                "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{environmentId:$env, serviceId:$service}')")"
-              regions_json="$(echo "$response" | jq -c '
-                [.data.serviceInstance.regions[]? | select(.name != null) | {key: .name, value: {numReplicas: 0}}]
-                | from_entries
-              ' 2>/dev/null || echo "{}")"
-              if [[ "$(echo "$regions_json" | jq 'length')" -gt 0 ]]; then
-                input_json="$(jq -nc --argjson mrc "$regions_json" '{sleepApplication:true, multiRegionConfig:$mrc, numReplicas:0}')"
-              else
-                # Terraform default region for this project (see infra/module/ctxpipe/railway.tf locals).
-                input_json="$(jq -nc '{
-                  sleepApplication: true,
-                  numReplicas: 0,
-                  multiRegionConfig: {"asia-southeast1-eqsg3a": {"numReplicas": 0}}
-                }')"
-              fi
-              railway_graphql \
+              if railway_graphql \
                 'mutation serviceInstanceUpdate($environmentId: String, $serviceId: String!, $input: ServiceInstanceUpdateInput!) { serviceInstanceUpdate(environmentId: $environmentId, serviceId: $serviceId, input: $input) }' \
-                "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" --argjson input "$input_json" '{environmentId:$env, serviceId:$service, input:$input}')"
-              echo "Scaled service $service_id to 0 replicas (config)"
+                "$(jq -nc --arg env "$ENV_ID" --arg service "$service_id" '{
+                  environmentId: $env,
+                  serviceId: $service,
+                  input: {
+                    sleepApplication: true,
+                    multiRegionConfig: {"asia-southeast1-eqsg3a": {"numReplicas": 0}}
+                  }
+                }')" >/dev/null; then
+                echo "Scaled service $service_id to 0 replicas (config)"
+              else
+                echo "Warning: failed to scale service $service_id to 0 replicas (continuing with deploymentStop)" >&2
+              fi
             }
 
             # Stop active deployments without creating a new one (no "Deploy" in UI).
@@ -571,7 +578,7 @@ jobs:
           ENV_ID: ${{ steps.railway_env.outputs.env_id }}
           BACKEND_SERVICE_ID: ${{ vars.RAILWAY_BACKEND_SERVICE_ID }}
         # Railway API/CLI calls can be flaky; retry once before failing.
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 2
@@ -669,7 +676,7 @@ jobs:
 
       - name: Delete Railway environment
         # Railway API/CLI calls can be flaky; retry once before failing.
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 2

--- a/.github/workflows/terraform-plan-pr.yaml
+++ b/.github/workflows/terraform-plan-pr.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Agent instructions are **distributed**: this file covers repo-wide rules; apps a
 - **apps/docs**: [apps/docs/AGENTS.md](apps/docs/AGENTS.md) — Fumadocs documentation site (Next.js 15, Shiki, forced-dark, deploys to docs.ctxpipe.ai).
 - **examples/**: runnable consumer examples for ctxpipe packages (manual e2e tests against real infra). See [examples/README.md](examples/README.md); first entry is [examples/aws-cdk-self-host](examples/aws-cdk-self-host) for `@ctxpipe-ai/aws-cdk` on AWS.
 
-**MCP (project-scoped):** [.agents/mcp.json](.agents/mcp.json) includes the backend and **Storybook** (server `ctxpipe-storybook` at `http://127.0.0.1:6006/mcp` when Storybook is running; start with `pnpm --filter @ctxpipe/ui storybook`). For story conventions, component-vs-page patterns, and how to use the Storybook tools, read [.agents/skills/storybook/SKILL.md](.agents/skills/storybook/SKILL.md) together with [apps/ui/AGENTS.md](apps/ui/AGENTS.md).
+**MCP (project-scoped):** [.agents/mcp.json](.agents/mcp.json) includes the backend, **Storybook** (server `ctxpipe-storybook` at `http://127.0.0.1:6006/mcp` when Storybook is running; start with `pnpm --filter @ctxpipe/ui storybook`), and **Railway** (remote MCP at `https://mcp.railway.com` — OAuth in the client). For story conventions, component-vs-page patterns, and how to use the Storybook tools, read [.agents/skills/storybook/SKILL.md](.agents/skills/storybook/SKILL.md) together with [apps/ui/AGENTS.md](apps/ui/AGENTS.md).
 
 **Host dev (agents):** Run **`pnpm`** from the repo root; follow **Agent runbook — host dev** under [Local development](#local-development) (install → `.env.local` → `dev:infra` → `dev`).
 

--- a/apps/backend/src/db/client.ts
+++ b/apps/backend/src/db/client.ts
@@ -5,10 +5,17 @@ import { Pool } from "pg"
 import { log } from "../observability/logger.js"
 import { relations, schema } from "./schema.js"
 
+function isRailwayPrPreview(): boolean {
+  return Boolean(process.env.RAILWAY_ENVIRONMENT_NAME?.trim().startsWith("pr-"))
+}
+
 function createDrizzleDb(connectionString: string) {
+  // Railway Serverless sleeps after ~10m with no outbound. Long-lived idle
+  // Neon connections (and TCP keepalives) prevent that window in PR previews.
   const client = new Pool({
     connectionString,
-    idleTimeoutMillis: 300000,
+    idleTimeoutMillis: isRailwayPrPreview() ? 10_000 : 300_000,
+    allowExitOnIdle: isRailwayPrPreview(),
   })
   return drizzle({ client, schema, relations })
 }

--- a/apps/backend/src/graphs/conversationGraph/graph.ts
+++ b/apps/backend/src/graphs/conversationGraph/graph.ts
@@ -43,11 +43,17 @@ const workflow = new StateGraph(ConversationGraphStateSchema)
 
 let checkpointer: PostgresSaver | undefined
 if (process.env.DATABASE_URL) {
+  const isPrPreview = Boolean(
+    process.env.RAILWAY_ENVIRONMENT_NAME?.trim().startsWith("pr-"),
+  )
+  // keepAlive + long-lived pools block Railway Serverless (outbound resets the
+  // 10m idle timer). PR previews close idle clients quickly with keepAlive off.
   const checkpointPool = new Pool({
     connectionString: process.env.DATABASE_URL,
-    max: 10,
-    keepAlive: true,
-    idleTimeoutMillis: 30_000,
+    max: isPrPreview ? 2 : 10,
+    keepAlive: !isPrPreview,
+    idleTimeoutMillis: isPrPreview ? 10_000 : 30_000,
+    allowExitOnIdle: isPrPreview,
     connectionTimeoutMillis: 5_000,
     application_name: "ctxpipe-checkpointer",
   })

--- a/apps/backend/src/openworkflow/worker-supervisor.ts
+++ b/apps/backend/src/openworkflow/worker-supervisor.ts
@@ -83,6 +83,19 @@ function isRailwayPrPreview(): boolean {
   return Boolean(name?.startsWith("pr-"))
 }
 
+/**
+ * Idle-exit when PR deploy opts in. Prefer explicit flags over Railway env name:
+ * RAILWAY_ENVIRONMENT_NAME is not always present, which previously left the
+ * worker running forever and blocked Serverless sleep.
+ */
+function shouldIdleExitOnEmptyQueue(): boolean {
+  return (
+    process.env.OPENWORKFLOW_PR_IDLE_EXIT === "true" ||
+    process.env.OPENWORKFLOW_IDLE_EXIT_SECONDS != null ||
+    isRailwayPrPreview()
+  )
+}
+
 function runOpenworkflowWorkerDirect(backendRoot: string): ChildProcess {
   return spawn("bunx", ["@openworkflow/cli", "worker", "start"], {
     cwd: backendRoot,
@@ -99,7 +112,7 @@ async function main() {
     "..",
   )
 
-  if (!isRailwayPrPreview()) {
+  if (!shouldIdleExitOnEmptyQueue()) {
     const child = runOpenworkflowWorkerDirect(backendRoot)
     await new Promise<void>((resolvePromise, reject) => {
       child.on("error", reject)

--- a/infra/README.md
+++ b/infra/README.md
@@ -97,13 +97,13 @@ Production deploys are driven by `.github/workflows/deploy.yaml`:
 
 PR deploys are driven by `.github/workflows/pr-deploy.yaml`:
 
-- Build/push PR images tagged `pr-<number>-<sha>` for **backend, worker, ui, codesearch** only (**not** otel-collector — skipping collector deploys keeps previews asleep and avoids Better Stack quota burn)
+- Build/push PR images tagged `pr-<number>-<sha>` for **backend, worker, ui, codesearch** only (**not** otel-collector)
 - Update Railway PR environment service instances to those image tags via Railway GraphQL API
 - Trigger deployments for backend, worker, ui, and codesearch in the PR environment
-- Sets preview-only variables: `ENABLE_LANGSMITH=false`; **clears `OTEL_EXPORTER_OTLP_{TRACES,LOGS,METRICS}_ENDPOINT`** on backend/worker/ui so apps do not emit periodic OTLP (60s metrics / log drains keep Railway Serverless awake); worker `OPENWORKFLOW_IDLE_EXIT_SECONDS`; backend `RAILWAY_TOKEN` when `RAILWAY_ENVIRONMENT_NAME` starts with `pr-` to wake the `openworkflow` service after enqueue. Amplitude may still be duplicated from production (request-scoped only)
-- Enable **Serverless** (`sleepApplication: true`) on backend, ui, codesearch, openworkflow worker, **otelcollector**, and **FalkorDB** in the PR environment via GraphQL (**production** defaults stay as configured in Terraform / dashboard — typically off). otelcollector and FalkorDB IDs are resolved by Terraform service name at deploy time — no extra GitHub variables. otelcollector gets **serverless-only** (no PR image) and `BETTER_STACK_TOKEN` cleared
-- **Langfuse in PR**: prefer sleep over collector OTLP→Langfuse. In-app `@langfuse/langchain` remains request-scoped when keys exist; do not run the collector Langfuse pipeline in PR just to keep traces flowing
-- For the PR **openworkflow worker**, single `serviceInstanceUpdate` sets image, **Serverless**, and **restart on failure only** (`restartPolicyType: ON_FAILURE`) so idle supervisor exits (status 0) are not auto-restarted — that exit is what lets the worker stay down until woken
+- Sets preview-only variables: `ENABLE_LANGSMITH=false`; **deletes** `OTEL_EXPORTER_OTLP_{TRACES,LOGS,METRICS}_ENDPOINT` on backend/worker/ui (so no periodic OTLP); worker `OPENWORKFLOW_IDLE_EXIT_SECONDS=180` + `OPENWORKFLOW_IDLE_STALE_AFTER_HOURS=1`; backend `RAILWAY_TOKEN` to wake `openworkflow` after enqueue. PR backends also use short pg pool idle timeouts / no TCP keepAlive so Neon connections do not block Railway’s ~10m sleep window
+- Enable **Serverless** on backend, ui, codesearch, openworkflow, and **FalkorDB**. **otelcollector is scaled to 0 replicas** in PR (duplicated from prod but not run — no Better Stack traffic)
+- **Langfuse in PR**: prefer sleep over collector OTLP→Langfuse; in-app SDK remains request-scoped if keys exist
+- For the PR **openworkflow worker**, image + Serverless + `restartPolicyType: ON_FAILURE` so idle supervisor exits (status 0) stay down until woken
 
 ## PR Terraform plans (GitHub Actions)
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -101,7 +101,7 @@ PR deploys are driven by `.github/workflows/pr-deploy.yaml`:
 - Update Railway PR environment service instances to those image tags via Railway GraphQL API
 - Trigger deployments for backend, worker, ui, and codesearch in the PR environment
 - Sets preview-only variables: `ENABLE_LANGSMITH=false` (OTLP and Amplitude vars stay as duplicated from production); worker `OPENWORKFLOW_IDLE_EXIT_SECONDS`; backend `RAILWAY_TOKEN` when `RAILWAY_ENVIRONMENT_NAME` starts with `pr-` to wake the `openworkflow` service after enqueue
-- Enable **Serverless** (`sleepApplication: true`) on backend, ui, codesearch, and otel-collector in the PR environment via GraphQL (**production** defaults stay as configured in Terraform / dashboard — typically off)
+- Enable **Serverless** (`sleepApplication: true`) on backend, ui, codesearch, openworkflow worker, **otel-collector**, and **FalkorDB** in the PR environment via GraphQL (**production** defaults stay as configured in Terraform / dashboard — typically off). otel-collector and FalkorDB service IDs are resolved by Terraform service name (`otelcollector`, `falkordb`) from the Railway project at deploy time — no extra GitHub variables
 - For the PR **openworkflow worker**, single `serviceInstanceUpdate` sets image, **Serverless**, and **restart on failure only** (`restartPolicyType: ON_FAILURE`) so idle supervisor exits (status 0) are not auto-restarted
 
 ## PR Terraform plans (GitHub Actions)

--- a/infra/README.md
+++ b/infra/README.md
@@ -100,8 +100,8 @@ PR deploys are driven by `.github/workflows/pr-deploy.yaml`:
 - Build/push PR images tagged `pr-<number>-<sha>` for **backend, worker, ui, codesearch** only (**not** otel-collector)
 - Update Railway PR environment service instances to those image tags via Railway GraphQL API
 - Trigger deployments for backend, worker, ui, and codesearch in the PR environment
-- Sets preview-only variables: `ENABLE_LANGSMITH=false`; **deletes** `OTEL_EXPORTER_OTLP_{TRACES,LOGS,METRICS}_ENDPOINT` on backend/worker/ui (so no periodic OTLP); worker `OPENWORKFLOW_IDLE_EXIT_SECONDS=180` + `OPENWORKFLOW_IDLE_STALE_AFTER_HOURS=1`; backend `RAILWAY_TOKEN` to wake `openworkflow` after enqueue. PR backends also use short pg pool idle timeouts / no TCP keepAlive so Neon connections do not block Railway’s ~10m sleep window
-- Enable **Serverless** on backend, ui, codesearch, openworkflow, and **FalkorDB**. **otelcollector is scaled to 0 replicas** in PR (duplicated from prod but not run — no Better Stack traffic)
+- Sets preview-only variables: `ENABLE_LANGSMITH=false`; **deletes** `OTEL_EXPORTER_OTLP_{TRACES,LOGS,METRICS}_ENDPOINT` on backend/worker/ui (so no periodic OTLP); worker `OPENWORKFLOW_PR_IDLE_EXIT=true` + `OPENWORKFLOW_IDLE_EXIT_SECONDS=180` + `OPENWORKFLOW_IDLE_STALE_AFTER_HOURS=1`; backend `RAILWAY_TOKEN` to wake `openworkflow` after enqueue. PR backends also use short pg pool idle timeouts / no TCP keepAlive so Neon connections do not block Railway’s ~10m sleep window
+- Enable **Serverless** on backend, ui, codesearch, openworkflow, and **FalkorDB**. **otelcollector is not deployed in PR**: scale to 0 replicas and `deploymentStop` active deployments (no `serviceInstanceDeployV2` — that was briefly starting the collector)
 - **Langfuse in PR**: prefer sleep over collector OTLP→Langfuse; in-app SDK remains request-scoped if keys exist
 - For the PR **openworkflow worker**, image + Serverless + `restartPolicyType: ON_FAILURE` so idle supervisor exits (status 0) stay down until woken
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -97,12 +97,13 @@ Production deploys are driven by `.github/workflows/deploy.yaml`:
 
 PR deploys are driven by `.github/workflows/pr-deploy.yaml`:
 
-- Build/push PR images tagged `pr-<number>-<sha>`
+- Build/push PR images tagged `pr-<number>-<sha>` for **backend, worker, ui, codesearch** only (**not** otel-collector — skipping collector deploys keeps previews asleep and avoids Better Stack quota burn)
 - Update Railway PR environment service instances to those image tags via Railway GraphQL API
 - Trigger deployments for backend, worker, ui, and codesearch in the PR environment
-- Sets preview-only variables: `ENABLE_LANGSMITH=false` (OTLP and Amplitude vars stay as duplicated from production); worker `OPENWORKFLOW_IDLE_EXIT_SECONDS`; backend `RAILWAY_TOKEN` when `RAILWAY_ENVIRONMENT_NAME` starts with `pr-` to wake the `openworkflow` service after enqueue
-- Enable **Serverless** (`sleepApplication: true`) on backend, ui, codesearch, openworkflow worker, **otel-collector**, and **FalkorDB** in the PR environment via GraphQL (**production** defaults stay as configured in Terraform / dashboard — typically off). otel-collector and FalkorDB service IDs are resolved by Terraform service name (`otelcollector`, `falkordb`) from the Railway project at deploy time — no extra GitHub variables
-- For the PR **openworkflow worker**, single `serviceInstanceUpdate` sets image, **Serverless**, and **restart on failure only** (`restartPolicyType: ON_FAILURE`) so idle supervisor exits (status 0) are not auto-restarted
+- Sets preview-only variables: `ENABLE_LANGSMITH=false`; **clears `OTEL_EXPORTER_OTLP_{TRACES,LOGS,METRICS}_ENDPOINT`** on backend/worker/ui so apps do not emit periodic OTLP (60s metrics / log drains keep Railway Serverless awake); worker `OPENWORKFLOW_IDLE_EXIT_SECONDS`; backend `RAILWAY_TOKEN` when `RAILWAY_ENVIRONMENT_NAME` starts with `pr-` to wake the `openworkflow` service after enqueue. Amplitude may still be duplicated from production (request-scoped only)
+- Enable **Serverless** (`sleepApplication: true`) on backend, ui, codesearch, openworkflow worker, **otelcollector**, and **FalkorDB** in the PR environment via GraphQL (**production** defaults stay as configured in Terraform / dashboard — typically off). otelcollector and FalkorDB IDs are resolved by Terraform service name at deploy time — no extra GitHub variables. otelcollector gets **serverless-only** (no PR image) and `BETTER_STACK_TOKEN` cleared
+- **Langfuse in PR**: prefer sleep over collector OTLP→Langfuse. In-app `@langfuse/langchain` remains request-scoped when keys exist; do not run the collector Langfuse pipeline in PR just to keep traces flowing
+- For the PR **openworkflow worker**, single `serviceInstanceUpdate` sets image, **Serverless**, and **restart on failure only** (`restartPolicyType: ON_FAILURE`) so idle supervisor exits (status 0) are not auto-restarted — that exit is what lets the worker stay down until woken
 
 ## PR Terraform plans (GitHub Actions)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR Serverless was on, but services stayed awake due to outbound traffic. This PR makes previews actually sleep.

### Root causes
1. OTEL metrics every 60s → otelcollector → Better Stack 402 loop
2. We still **deployed** otelcollector (woke it) even after skipping the PR image
3. Neon pg pools with long idle + keepAlive blocked Railway’s ~10m sleep window
4. openworkflow idle-exit was 660s / could skip idle path without env name
5. **Deploy failure (latest):** `scale_service_to_zero` queried invalid `serviceInstance.regions` → Railway HTTP **400** (the Node 20 line was only a warning from `nick-fields/retry@v3`)

### Fixes
- Delete `OTEL_EXPORTER_OTLP_*` on PR backend/worker/ui
- otelcollector: `multiRegionConfig` scale-to-0 + `deploymentStop` (no deploy); GraphQL errors logged
- PR short pg pool idle + no checkpointer keepAlive
- Worker: `OPENWORKFLOW_PR_IDLE_EXIT` + idle 180s / stale 1h
- `nick-fields/retry@v4` (Node 24) in PR Deploy / terraform-plan-pr

### Verify after PR Deploy succeeds
1. Logs: otel scaled/stopped; no Better Stack spam; no GraphQL 400
2. ~3–4 min idle → worker exits; ~10+ min quiet → backend sleeps

Production OTEL / Better Stack / pool defaults unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90888a62-a4b8-4f40-a36d-16d423e2b469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90888a62-a4b8-4f40-a36d-16d423e2b469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

