### PR TITLE
Harden backend DB pool against Neon idle disconnects

### DIFF
--- a/apps/backend/src/db/client.ts
+++ b/apps/backend/src/db/client.ts
@@ -4,12 +4,24 @@ import { drizzle } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import { log } from "../observability/logger.js"
 import { relations, schema } from "./schema.js"
+import { wrapPoolQueryWithTransientRetry } from "./transientDbRetry.js"
 
 function createDrizzleDb(connectionString: string) {
   const client = new Pool({
     connectionString,
-    idleTimeoutMillis: 300000,
+    keepAlive: true,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 10_000,
+    application_name: "ctxpipe-backend",
   })
+  client.on("error", (err) => {
+    log.error({
+      step: "db.pool",
+      message: "Unexpected pg pool error",
+      error: err instanceof Error ? err.message : String(err),
+    })
+  })
+  wrapPoolQueryWithTransientRetry(client)
   return drizzle({ client, schema, relations })
 }
 

--- a/apps/backend/src/db/transientDbRetry.test.ts
+++ b/apps/backend/src/db/transientDbRetry.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("../observability/logger.js", () => ({
+  log: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+import { log } from "../observability/logger.js"
+import {
+  isTransientDbConnectionError,
+  withTransientDbQueryRetry,
+  wrapPoolQueryWithTransientRetry,
+} from "./transientDbRetry.js"
+
+describe("isTransientDbConnectionError", () => {
+  it("matches Connection terminated unexpectedly", () => {
+    expect(
+      isTransientDbConnectionError(
+        new Error("Connection terminated unexpectedly"),
+      ),
+    ).toBe(true)
+  })
+
+  it("matches errno codes", () => {
+    const err = Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+    })
+    expect(isTransientDbConnectionError(err)).toBe(true)
+  })
+
+  it("matches postgres SQLSTATE on nested cause", () => {
+    const cause = Object.assign(new Error("terminating connection"), {
+      code: "57P01",
+    })
+    const err = new Error("Failed query: select 1", { cause })
+    expect(isTransientDbConnectionError(err)).toBe(true)
+  })
+
+  it("rejects unrelated errors", () => {
+    expect(isTransientDbConnectionError(new Error("unique violation"))).toBe(
+      false,
+    )
+  })
+})
+
+describe("withTransientDbQueryRetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it("retries once on connection terminated then succeeds", async () => {
+    let n = 0
+    const result = await withTransientDbQueryRetry(
+      async () => {
+        n += 1
+        if (n < 2) throw new Error("Connection terminated unexpectedly")
+        return "ok"
+      },
+      { baseDelayMs: 1 },
+    )
+    expect(result).toBe("ok")
+    expect(n).toBe(2)
+    expect(log.info).toHaveBeenCalledTimes(1)
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        step: "db.transient_connection_retry",
+        attempt: 1,
+        maxAttempts: 2,
+        message: "Connection terminated unexpectedly",
+      }),
+    )
+  })
+
+  it("does not retry non-transient errors", async () => {
+    let n = 0
+    await expect(
+      withTransientDbQueryRetry(async () => {
+        n += 1
+        throw new Error("unique violation")
+      }),
+    ).rejects.toThrow("unique violation")
+    expect(n).toBe(1)
+    expect(log.info).not.toHaveBeenCalled()
+  })
+
+  it("rethrows after exhausting retries", async () => {
+    let n = 0
+    await expect(
+      withTransientDbQueryRetry(
+        async () => {
+          n += 1
+          throw Object.assign(new Error("ECONNRESET"), { code: "ECONNRESET" })
+        },
+        { retries: 1, baseDelayMs: 1 },
+      ),
+    ).rejects.toMatchObject({ code: "ECONNRESET" })
+    expect(n).toBe(2)
+  })
+})
+
+describe("wrapPoolQueryWithTransientRetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("retries promise query once then succeeds", async () => {
+    let n = 0
+    const pool = {
+      query: vi.fn(async () => {
+        n += 1
+        if (n < 2) throw new Error("Connection terminated unexpectedly")
+        return { rows: [{ ok: true }] }
+      }),
+    }
+
+    wrapPoolQueryWithTransientRetry(
+      pool as unknown as import("pg").Pool,
+    )
+
+    const result = await (
+      pool.query as unknown as () => Promise<{ rows: { ok: boolean }[] }>
+    )()
+    expect(result).toEqual({ rows: [{ ok: true }] })
+    expect(n).toBe(2)
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ step: "db.transient_connection_retry" }),
+    )
+  })
+
+  it("leaves callback-style query unwrapped for retry", () => {
+    const underlying = vi.fn(
+      (_sql: string, cb: (err: Error | null, res?: unknown) => void) => {
+        cb(new Error("Connection terminated unexpectedly"))
+      },
+    )
+    const pool = { query: underlying }
+
+    wrapPoolQueryWithTransientRetry(
+      pool as unknown as import("pg").Pool,
+    )
+
+    const cb = vi.fn()
+    ;(pool.query as typeof underlying)("select 1", cb)
+    expect(underlying).toHaveBeenCalledTimes(1)
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(log.info).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/db/transientDbRetry.ts
+++ b/apps/backend/src/db/transientDbRetry.ts
@@ -1,0 +1,130 @@
+import type { Pool } from "pg"
+import { log } from "../observability/logger.js"
+
+const TRANSIENT_CONNECTION_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "57P01", // admin_shutdown
+  "57P02", // crash_shutdown
+  "57P03", // cannot_connect_now
+  "08000", // connection_exception
+  "08003", // connection_does_not_exist
+  "08006", // connection_failure
+  "08001", // sqlclient_unable_to_establish_sqlconnection
+])
+
+const TRANSIENT_CONNECTION_MESSAGE_RE =
+  /connection terminated|connection.*closed|server closed the connection|ssl connection has been closed|cannot connect|connection reset|ECONNRESET|admin_shutdown|cannot_connect_now/i
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const withCode = error as { code?: unknown }
+  return typeof withCode.code === "string" ? withCode.code : undefined
+}
+
+function collectErrors(error: unknown): unknown[] {
+  const out: unknown[] = []
+  let current: unknown = error
+  const seen = new Set<unknown>()
+  while (current != null && !seen.has(current)) {
+    seen.add(current)
+    out.push(current)
+    if (current instanceof Error && current.cause != null) {
+      current = current.cause
+      continue
+    }
+    if (
+      current &&
+      typeof current === "object" &&
+      "cause" in current &&
+      (current as { cause?: unknown }).cause != null
+    ) {
+      current = (current as { cause?: unknown }).cause
+      continue
+    }
+    break
+  }
+  return out
+}
+
+/** True for dead/reset Postgres connections suitable for a single reconnect retry. */
+export function isTransientDbConnectionError(error: unknown): boolean {
+  for (const err of collectErrors(error)) {
+    const code = errorCode(err)
+    if (code && TRANSIENT_CONNECTION_CODES.has(code)) return true
+    if (TRANSIENT_CONNECTION_MESSAGE_RE.test(errorMessage(err))) return true
+  }
+  return false
+}
+
+export type WithTransientDbQueryRetryOptions = {
+  /** Retries after the first attempt (default 1 → 2 attempts total). */
+  retries?: number
+  baseDelayMs?: number
+}
+
+/**
+ * Retries `run` once (by default) on transient Postgres connection failures
+ * (Neon idle disconnect, reset, admin shutdown), with a short delay so compute
+ * can finish waking.
+ */
+export async function withTransientDbQueryRetry<T>(
+  run: () => Promise<T>,
+  opts?: WithTransientDbQueryRetryOptions,
+): Promise<T> {
+  const retries = opts?.retries ?? 1
+  const baseDelayMs = opts?.baseDelayMs ?? 100
+  const maxAttempts = retries + 1
+  let last: unknown
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      return await run()
+    } catch (e) {
+      last = e
+      if (isTransientDbConnectionError(e) && attempt < maxAttempts - 1) {
+        const delayMs = baseDelayMs * 2 ** attempt
+        log.info({
+          step: "db.transient_connection_retry",
+          attempt: attempt + 1,
+          maxAttempts,
+          delayMs,
+          message: errorMessage(e),
+        })
+        await new Promise((r) => setTimeout(r, delayMs))
+        continue
+      }
+      throw e
+    }
+  }
+
+  throw last
+}
+
+/**
+ * Wrap `pool.query` so promise-based queries retry once on dead connections.
+ * Callback-style `query` is left unchanged (Drizzle uses the promise API).
+ */
+export function wrapPoolQueryWithTransientRetry(pool: Pool): void {
+  const originalQuery = pool.query.bind(pool) as (
+    ...args: unknown[]
+  ) => unknown
+
+  pool.query = ((...args: unknown[]) => {
+    const maybeCallback = args.find((a) => typeof a === "function")
+    if (maybeCallback) {
+      return originalQuery(...args)
+    }
+
+    return withTransientDbQueryRetry(() =>
+      Promise.resolve(originalQuery(...args)),
+    )
+  }) as typeof pool.query
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR preview logs showed Better Auth `INTERNAL_SERVER_ERROR` on session lookup with `Connection terminated unexpectedly`. That matches a **stale `pg` pool client** after Neon auto-suspend (~5 min idle), not necessarily Railway service sleep.

## Changes

- Harden main pool in `apps/backend/src/db/client.ts`: `keepAlive`, `idleTimeoutMillis: 30s`, `connectionTimeoutMillis: 10s`, `application_name`, `pool.on("error")`
- One-shot retry on transient connection errors via `wrapPoolQueryWithTransientRetry` so Better Auth / Drizzle promise queries recover on first post-idle use
- Unit tests for error detection, retry, and pool wrapper

Railway Serverless sleep is unchanged (no keep-warm pings). PR Neon pooler URL left out of scope.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-558eb7b9-1201-4c67-9b50-427874b7312c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-558eb7b9-1201-4c67-9b50-427874b7312c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

