### PR TITLE
Fix invitation acceptance for new users

### DIFF
--- a/apps/backend/src/auth/config.test.ts
+++ b/apps/backend/src/auth/config.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createBetterAuth } from "./config.js"
+
+describe("createBetterAuth", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("allows emailed invitations with opaque custom IDs to be accepted", () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://user:pass@localhost:5432/ctxpipe")
+    vi.stubEnv(
+      "AUTH_SECRET",
+      "test-only-auth-secret-with-at-least-32-characters",
+    )
+    vi.stubEnv("AUTH_BASE_URL", "http://localhost:3000")
+
+    const auth = createBetterAuth()
+    const organizationPlugin = auth.options.plugins?.find(
+      (plugin) => plugin.id === "organization",
+    )
+
+    expect(organizationPlugin).toBeDefined()
+    expect(organizationPlugin?.options).toMatchObject({
+      requireEmailVerificationOnInvitation: false,
+    })
+  })
+})

--- a/apps/backend/src/auth/config.ts
+++ b/apps/backend/src/auth/config.ts
@@ -161,6 +161,9 @@ export function createBetterAuth() {
       jwt(),
       twoFactor(),
       organization({
+        // Invitation IDs are opaque UUIDv7 values delivered by email; the
+        // accepting session must still match the exact invited email address.
+        requireEmailVerificationOnInvitation: false,
         organizationHooks: {
           async beforeDeleteOrganization({ organization }) {
             const { withOrgDbContext } = await import("../db/client.js")

--- a/apps/ui/src/features/auth/accept-invitation.test.ts
+++ b/apps/ui/src/features/auth/accept-invitation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest"
+import { acceptInvitationThenRedirect } from "./accept-invitation"
+
+describe("acceptInvitationThenRedirect", () => {
+  it("redirects after invitation acceptance succeeds", async () => {
+    const acceptInvitation = vi.fn().mockResolvedValue(undefined)
+    const redirect = vi.fn()
+
+    await acceptInvitationThenRedirect(acceptInvitation, redirect)
+
+    expect(acceptInvitation).toHaveBeenCalledOnce()
+    expect(redirect).toHaveBeenCalledOnce()
+  })
+
+  it("does not redirect when invitation acceptance fails", async () => {
+    const error = new Error("Invitation could not be accepted")
+    const acceptInvitation = vi.fn().mockRejectedValue(error)
+    const redirect = vi.fn()
+
+    await expect(
+      acceptInvitationThenRedirect(acceptInvitation, redirect),
+    ).rejects.toBe(error)
+    expect(redirect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/ui/src/features/auth/accept-invitation.ts
+++ b/apps/ui/src/features/auth/accept-invitation.ts
@@ -1,0 +1,7 @@
+export async function acceptInvitationThenRedirect(
+  acceptInvitation: () => Promise<unknown>,
+  redirect: () => void,
+): Promise<void> {
+  await acceptInvitation()
+  redirect()
+}

--- a/apps/ui/src/routes/[.]auth.$authView.tsx
+++ b/apps/ui/src/routes/[.]auth.$authView.tsx
@@ -4,6 +4,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import type { FormEvent } from "react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { betterAuthAuthViewClassNames } from "@/features/auth/betterAuthShellClassNames"
+import { acceptInvitationThenRedirect } from "@/features/auth/accept-invitation"
 import { Button } from "@/components/ui/Button"
 import { Spinner } from "@/components/ui/spinner"
 import { getAuthContinuationProps } from "@/lib/auth-continuation"
@@ -95,6 +96,7 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
 
   const signUpMutation = useMutation({
     mutationFn: async (input: { email: string; name: string; password: string }) => {
+      autoAcceptAttemptedRef.current = true
       await authClient.signUp.email({
         email: input.email,
         password: input.password,
@@ -103,8 +105,10 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
           currentLocation,
         fetchOptions: { throw: true },
       })
-      await acceptInviteMutation.mutateAsync(invitationId)
-      window.location.assign(redirectTo)
+      await acceptInvitationThenRedirect(
+        () => acceptInviteMutation.mutateAsync(invitationId),
+        () => window.location.assign(redirectTo),
+      )
     },
     onError: (err) => setError(extractErrorMessage(err)),
   })
@@ -117,15 +121,12 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
     }
     if (autoAcceptAttemptedRef.current) return
     autoAcceptAttemptedRef.current = true
-    void (async () => {
-      try {
-        await acceptInviteMutation.mutateAsync(invitationId)
-      } catch (err) {
-        setError(extractErrorMessage(err))
-      } finally {
-        window.location.assign(redirectTo)
-      }
-    })()
+    void acceptInvitationThenRedirect(
+      () => acceptInviteMutation.mutateAsync(invitationId),
+      () => window.location.assign(redirectTo),
+    ).catch((err) => {
+      setError(extractErrorMessage(err))
+    })
   }, [
     session,
     sessionPending,
@@ -135,6 +136,9 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
   ])
 
   if (sessionPending) return null
+  if (session && error) {
+    return <p className="text-sm text-red-400">{error}</p>
+  }
   if (session || signUpMutation.isPending || acceptInviteMutation.isPending) {
     return <AuthStatusMessage message="Accepting organisation invite…" />
   }


### PR DESCRIPTION
## Summary

Fix the organisation invitation flow for newly-created email/password accounts.

- explicitly allow acceptance of emailed invitations generated with ctxpipe's opaque UUIDv7 IDs
- redirect to onboarding only after Better Auth confirms acceptance
- prevent signup and the signed-in effect from racing to accept the same invitation twice
- show the acceptance error instead of silently classifying the user as a new organisation owner

No email-domain matching is introduced. Organisation ownership and membership continue to use the exact normalized invitation email and Better Auth membership records.

## Root cause

Production showed a valid pending invitation and matching user account, but no membership. The acceptance endpoint returned `403`.

ctxpipe supplies a custom Better Auth ID generator. Better Auth therefore defaults `requireEmailVerificationOnInvitation` to its strict posture because it cannot determine whether custom invitation IDs are opaque. New ctxpipe email/password accounts are unverified, and ctxpipe does not currently provide a verification-email flow, so acceptance was blocked.

The UI then redirected from a `finally` block even when acceptance failed. `/onboarding` saw no organisation membership and selected the organisation-creation flow.

## Security assessment

This PR opts into Better Auth's documented emailed bearer-invitation model:

- invitation IDs are UUIDv7 values encoded in base32 (74 random bits plus timestamp)
- links are delivered to the invited email address and expire after Better Auth's configured/default invitation lifetime
- Better Auth still requires the signed-in session email to exactly match the invitation email
- invitation status and membership creation remain server-side Better Auth operations

Reviewer decision point: confirm that the emailed bearer-link model and UUIDv7 entropy are acceptable for ctxpipe's current threat model. The stricter alternative is a larger change: implement verification-email delivery and continuation, require verification before session/membership creation, and resume the original invitation after verification.

## User impact

An organisation owner can invite users at any email domain. A new invitee can create an account using the exact invited address and enters the joiner onboarding flow after membership creation. Failed or expired invitations remain on the invitation screen with an error instead of falling through to organisation creation.

## Validation

- `pnpm --filter @ctxpipe/backend exec vitest run src/auth/config.test.ts`
- `pnpm --filter @ctxpipe/ui test` — 50 tests passed
- `pnpm --filter @ctxpipe/ui build`
- targeted Biome lint on all changed files

The repository-wide backend TypeScript build still reports existing errors in unrelated routes/services; none reference the changed auth files.