### PR TITLE
Add patch changeset for invitation onboarding fix

### DIFF
--- a/.changeset/fix-invitation-onboarding.md
+++ b/.changeset/fix-invitation-onboarding.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Fix invited-user onboarding so successful invitation acceptance joins the intended organization and failed acceptance remains visible instead of redirecting users to organization creation.


### PR DESCRIPTION
## Summary

Adds the missing patch changeset for the invited-user onboarding fix merged in #261.

## Why

PR #261 fixed invitation acceptance and its failure handling, but it was merged without release metadata and the changeset guard reported a failure. This follow-up records the fix as a patch release of `@ctxpipe/aws-cdk`, following the repository convention for changes that ship in the deployable service image.

## Validation

- `pnpm changeset status`
- `git diff --check origin/main...HEAD`

The branch contains only `.changeset/fix-invitation-onboarding.md`.
