### PR TITLE
codesearch: Zoekt hot/cold shards to cut webserver RSS

### DIFF
--- a/apps/codesearch/AGENTS.md
+++ b/apps/codesearch/AGENTS.md
@@ -11,6 +11,11 @@ These instructions supplement the repository-root `AGENTS.md`.
 - Keep OpenAPI route schemas collocated with routes and use Zod validation.
 - Use the fixed repository-cache and index path helpers rather than introducing
   new path conventions.
+- **Zoekt hot/cold:** Durable shards live in `ZOEKT_INDEX_DIR` (cold).
+  `zoekt-webserver` watches the sibling `zoekt-hot` directory (derived in
+  `src/config/paths.ts` — no separate env var). Bun pins repos by symlink on
+  `/search` and unloads after ~5 minutes idle. Do not write real shard files
+  into hot.
 
 ## Testing
 
@@ -24,12 +29,15 @@ These instructions supplement the repository-root `AGENTS.md`.
   pnpm --filter @ctxpipe/codesearch test:manual:kubernetes-memory
   ```
 
-  Significant changes include Zoekt invocation, SCIP indexer selection or
-  concurrency, child-process/log handling, clone/checkout behavior, and index
-  artifact creation. This expensive networked gate is intentionally excluded
-  from the default test command. It must exit 0 without OOM/137 and produce
-  non-empty merged and language-specific `.scip` artifacts.
+  Significant changes include Zoekt invocation, hot/cold pin management, SCIP
+  indexer selection or concurrency, child-process/log handling, clone/checkout
+  behavior, and index artifact creation. This expensive networked gate is
+  intentionally excluded from the default test command. It must exit 0 without
+  OOM/137, produce non-empty merged and language-specific `.scip` artifacts,
+  write kubernetes shards only under cold `ZOEKT_INDEX_DIR`, and leave `zoekt-hot`
+  empty (ingest must not pin).
 
 - The gate locks `MEMORY_MAX=5670m` from a calibrated kubernetes@v1.36.3 run
-  (cgroup peak ~5158 MiB + 512 MiB headroom). Do not raise it silently after
-  ingest changes — re-run the gate, then re-calibrate if the peak regressed.
+  under empty-hot + sequential Zoekt-then-SCIP + `GOMAXPROCS=2` (prior peak
+  ~5158 MiB + 512 MiB headroom). Do not raise it silently after ingest
+  changes — re-run the gate, then re-calibrate if the peak regressed.

--- a/apps/codesearch/AGENTS.md
+++ b/apps/codesearch/AGENTS.md
@@ -37,7 +37,8 @@ These instructions supplement the repository-root `AGENTS.md`.
   write kubernetes shards only under cold `ZOEKT_INDEX_DIR`, and leave `zoekt-hot`
   empty (ingest must not pin).
 
-- The gate locks `MEMORY_MAX=5670m` from a calibrated kubernetes@v1.36.3 run
-  under empty-hot + sequential Zoekt-then-SCIP + `GOMAXPROCS=2` (prior peak
-  ~5158 MiB + 512 MiB headroom). Do not raise it silently after ingest
-  changes — re-run the gate, then re-calibrate if the peak regressed.
+- The gate currently keeps provisional `MEMORY_MAX=5670m` from the prior
+  kubernetes@v1.36.3 calibration (~5158 MiB peak + 512 MiB headroom). Re-run the
+  gate after hot/cold or ingest changes and update the ceiling from the
+  printed peak before raising it — do not treat 5670m as a new-model
+  calibration until that re-run lands.

--- a/apps/codesearch/scripts/manual-kubernetes-ingest-memory.sh
+++ b/apps/codesearch/scripts/manual-kubernetes-ingest-memory.sh
@@ -3,18 +3,22 @@ set -euo pipefail
 
 # Manual, intentionally expensive memory regression gate. This is not part of
 # the default test suite; run it after significant changes to repository ingest,
-# Zoekt invocation, SCIP process orchestration, or index artifact handling.
+# Zoekt invocation, SCIP process orchestration, hot/cold pin management, or
+# index artifact handling.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 IMAGE="ctxpipe-codesearch:kubernetes-memory-gate"
 KUBERNETES_REPOSITORY="https://github.com/kubernetes/kubernetes.git"
 KUBERNETES_SHA="0f29094e5b73085e3802ecc1298ecae13866bfe6" # v1.36.3
 
-# Calibrated ceiling for kubernetes/kubernetes@0f29094 (v1.36.3), full Zoekt + SCIP
-# ingest with SCIP_INDEXER_CONCURRENCY=2 (Go shard only on this tree).
-# Measured cgroup peak: 5408182272 bytes (~5158 MiB). Locked at peak + 512 MiB
-# headroom (the smaller of +10–15% vs ≤512 MiB). Re-calibrate after significant
-# ingest/indexer changes before raising this value.
+# Calibrated ceiling for kubernetes/kubernetes@0f29094 (v1.36.3) under the
+# hot/cold Zoekt model: empty zoekt-hot (webserver not holding unrelated shards),
+# durable shards in ZOEKT_INDEX_DIR (cold), sequential Zoekt-then-SCIP, and
+# GOMAXPROCS=2 / GOGC=50 on index children. SCIP_INDEXER_CONCURRENCY=2.
+#
+# Prior cold-only calibration (pre hot/cold): cgroup peak ~5158 MiB → 5670m.
+# Re-run this script after ingest/hot-cold changes and update MEMORY_MAX from
+# the printed peak (+ ≤512 MiB headroom) before raising the ceiling.
 MEMORY_MAX="5670m"
 
 for command in docker git; do
@@ -32,7 +36,10 @@ WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ctxpipe-kubernetes-memory.XXXXXX")"
 CONTAINER_NAME="ctxpipe-kubernetes-memory-$$"
 CHECKOUT_DIR="${WORK_DIR}/data/repo-cache/org_manual/repo_kubernetes/checkouts/default"
 SCIP_DIR="$(dirname "${CHECKOUT_DIR}")"
+# Cold durable shards (zoekt-index writes here). Hot is a sibling directory of
+# symlinks only — same derivation as apps/codesearch/src/config/paths.ts.
 ZOEKT_DIR="${WORK_DIR}/data/zoekt-index"
+ZOEKT_HOT_DIR="${WORK_DIR}/data/zoekt-hot"
 
 cleanup() {
   docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
@@ -40,7 +47,13 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-mkdir -p "${SCIP_DIR}" "${ZOEKT_DIR}"
+mkdir -p "${SCIP_DIR}" "${ZOEKT_DIR}" "${ZOEKT_HOT_DIR}"
+
+# Seed an unrelated cold shard so the gate proves ingest does not copy/load it
+# into hot (zoekt-webserver is not started here; Bun must not write real files
+# into zoekt-hot during index).
+printf 'unrelated-cold-shard\n' >"${ZOEKT_DIR}/other%2Frepo_v16.00000.zoekt"
+
 git init --quiet "${CHECKOUT_DIR}"
 git -C "${CHECKOUT_DIR}" remote add origin "${KUBERNETES_REPOSITORY}"
 git -C "${CHECKOUT_DIR}" fetch --quiet --depth=1 origin "${KUBERNETES_SHA}"
@@ -58,6 +71,7 @@ git -C "${CHECKOUT_DIR}" config remote.origin.fetch \
 cat >"${WORK_DIR}/run-ingest.ts" <<EOF
 import { cloneAndIndexRepository } from "/app/apps/codesearch/src/domain/indexing/service.ts"
 import { SCIP_INDEXER_CONCURRENCY } from "/app/apps/codesearch/src/domain/indexing/indexerPool.ts"
+import { withIndexerGoLimits } from "/app/apps/codesearch/src/domain/indexing/indexerChildEnv.ts"
 
 const noOpDb = {
   update: () => ({
@@ -68,7 +82,14 @@ const noOpDb = {
 }
 
 if (SCIP_INDEXER_CONCURRENCY !== 2) {
-  throw new Error(\`Memory gate requires SCIP_INDEXER_CONCURRENCY===2 (Zoekt + up to 2 SCIP procs); configured \${SCIP_INDEXER_CONCURRENCY}\`)
+  throw new Error(\`Memory gate requires SCIP_INDEXER_CONCURRENCY===2; configured \${SCIP_INDEXER_CONCURRENCY}\`)
+}
+
+const goEnv = withIndexerGoLimits()
+if (goEnv.GOMAXPROCS !== "2" || goEnv.GOGC !== "50") {
+  throw new Error(
+    \`Memory gate requires default indexer GOMAXPROCS=2 GOGC=50; got GOMAXPROCS=\${goEnv.GOMAXPROCS} GOGC=\${goEnv.GOGC}\`,
+  )
 }
 
 const result = await cloneAndIndexRepository({
@@ -141,7 +162,7 @@ docker build \
   -t "${IMAGE}" \
   "${ROOT}"
 
-echo "manual-kubernetes-memory: indexing ${KUBERNETES_SHA} with ${MEMORY_MAX} limit"
+echo "manual-kubernetes-memory: indexing ${KUBERNETES_SHA} with ${MEMORY_MAX} limit (cold=${ZOEKT_DIR}, hot=${ZOEKT_HOT_DIR})"
 set +e
 docker run \
   --name "${CONTAINER_NAME}" \
@@ -192,11 +213,28 @@ for shard in "${scip_shards[@]}"; do
   fi
 done
 
-if ! compgen -G "${ZOEKT_DIR}/*" >/dev/null; then
-  echo "manual-kubernetes-memory: FAIL: no Zoekt index artifacts under ${ZOEKT_DIR}" >&2
+if ! compgen -G "${ZOEKT_DIR}/kubernetes%2Fkubernetes_*.zoekt" >/dev/null; then
+  echo "manual-kubernetes-memory: FAIL: no kubernetes Zoekt shards under ${ZOEKT_DIR}" >&2
+  exit 1
+fi
+
+# Ingest must not pin/search, so hot should stay empty (only cold grows).
+hot_entries=("${ZOEKT_HOT_DIR}"/*)
+if (( ${#hot_entries[@]} > 0 )) && [[ -e "${hot_entries[0]}" ]]; then
+  echo "manual-kubernetes-memory: FAIL: expected empty hot dir, found: ${hot_entries[*]}" >&2
+  exit 1
+fi
+
+# Unrelated cold shard must still be present (not deleted) and not copied to hot.
+if [[ ! -f "${ZOEKT_DIR}/other%2Frepo_v16.00000.zoekt" ]]; then
+  echo "manual-kubernetes-memory: FAIL: unrelated cold shard was removed" >&2
+  exit 1
+fi
+if [[ -e "${ZOEKT_HOT_DIR}/other%2Frepo_v16.00000.zoekt" ]]; then
+  echo "manual-kubernetes-memory: FAIL: unrelated cold shard appeared in hot" >&2
   exit 1
 fi
 
 peak_bytes="$(<"${WORK_DIR}/peak-memory-bytes")"
-echo "manual-kubernetes-memory: PASS: exit 0, Zoekt index and ${#scip_shards[@]} SCIP shard(s) present"
+echo "manual-kubernetes-memory: PASS: exit 0, Zoekt cold index and ${#scip_shards[@]} SCIP shard(s); hot empty"
 echo "manual-kubernetes-memory: peak=${peak_bytes} bytes (ceiling MEMORY_MAX=${MEMORY_MAX})"

--- a/apps/codesearch/scripts/manual-kubernetes-ingest-memory.sh
+++ b/apps/codesearch/scripts/manual-kubernetes-ingest-memory.sh
@@ -11,14 +11,12 @@ IMAGE="ctxpipe-codesearch:kubernetes-memory-gate"
 KUBERNETES_REPOSITORY="https://github.com/kubernetes/kubernetes.git"
 KUBERNETES_SHA="0f29094e5b73085e3802ecc1298ecae13866bfe6" # v1.36.3
 
-# Calibrated ceiling for kubernetes/kubernetes@0f29094 (v1.36.3) under the
-# hot/cold Zoekt model: empty zoekt-hot (webserver not holding unrelated shards),
-# durable shards in ZOEKT_INDEX_DIR (cold), sequential Zoekt-then-SCIP, and
-# GOMAXPROCS=2 / GOGC=50 on index children. SCIP_INDEXER_CONCURRENCY=2.
-#
-# Prior cold-only calibration (pre hot/cold): cgroup peak ~5158 MiB → 5670m.
-# Re-run this script after ingest/hot-cold changes and update MEMORY_MAX from
-# the printed peak (+ ≤512 MiB headroom) before raising the ceiling.
+# Provisional MEMORY_MAX carried from the pre-hot/cold kubernetes@v1.36.3
+# calibration (cgroup peak ~5158 MiB → 5670m). The gate now exercises empty
+# zoekt-hot, cold-only shard writes, sequential Zoekt-then-SCIP, and
+# GOMAXPROCS=2 / GOGC=50 — re-run this script where Docker is available and
+# update MEMORY_MAX from the printed peak (+ ≤512 MiB headroom) before raising
+# the ceiling. Do not treat 5670m as a new-model calibration.
 MEMORY_MAX="5670m"
 
 for command in docker git; do
@@ -219,9 +217,11 @@ if ! compgen -G "${ZOEKT_DIR}/kubernetes%2Fkubernetes_*.zoekt" >/dev/null; then
 fi
 
 # Ingest must not pin/search, so hot should stay empty (only cold grows).
-hot_entries=("${ZOEKT_HOT_DIR}"/*)
-if (( ${#hot_entries[@]} > 0 )) && [[ -e "${hot_entries[0]}" ]]; then
-  echo "manual-kubernetes-memory: FAIL: expected empty hot dir, found: ${hot_entries[*]}" >&2
+# Use find -P so dangling symlinks still count as non-empty.
+hot_count="$(find -P "${ZOEKT_HOT_DIR}" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')"
+if [[ "${hot_count}" != "0" ]]; then
+  echo "manual-kubernetes-memory: FAIL: expected empty hot dir, found ${hot_count} entr(y/ies)" >&2
+  find -P "${ZOEKT_HOT_DIR}" -mindepth 1 -maxdepth 1 -print >&2 || true
   exit 1
 fi
 

--- a/apps/codesearch/src/config/paths.test.ts
+++ b/apps/codesearch/src/config/paths.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { zoektHotDirFromIndexDir } from "./paths.js"
+
+describe("zoektHotDirFromIndexDir", () => {
+  it("derives a sibling zoekt-hot directory from the cold index path", () => {
+    expect(zoektHotDirFromIndexDir("/data/zoekt-index")).toBe("/data/zoekt-hot")
+    expect(zoektHotDirFromIndexDir("/var/lib/ctxpipe/zoekt-index")).toBe(
+      "/var/lib/ctxpipe/zoekt-hot",
+    )
+  })
+
+  it("does not invent a new env-driven path — only dirname + zoekt-hot", () => {
+    expect(zoektHotDirFromIndexDir("/tmp/worktree/.data/zoekt-index")).toBe(
+      "/tmp/worktree/.data/zoekt-hot",
+    )
+  })
+})

--- a/apps/codesearch/src/config/paths.ts
+++ b/apps/codesearch/src/config/paths.ts
@@ -1,14 +1,27 @@
+import { dirname, join } from "node:path"
+
 /**
  * Zoekt index and git clone cache directories.
  *
  * Defaults match production Docker (`/data/...`). Host dev sets `ZOEKT_INDEX_DIR`
  * and `REPO_CACHE_DIR` (see `scripts/dev-apps.sh`) to writable paths under
  * `apps/codesearch/.data/`.
+ *
+ * Durable Zoekt shards live in `ZOEKT_INDEX_DIR` (cold). `zoekt-webserver`
+ * watches `ZOEKT_HOT_DIR` (sibling `zoekt-hot`), which holds only symlinks to
+ * pinned cold shards. Hot is derived from the cold path — no separate env var.
  */
 export const ZOEKT_INDEX_DIR =
   process.env["ZOEKT_INDEX_DIR"] ?? "/data/zoekt-index"
 export const REPO_CACHE_DIR =
   process.env["REPO_CACHE_DIR"] ?? "/data/repo-cache"
+
+/** Hot symlink dir for zoekt-webserver: sibling `zoekt-hot` of the cold index. */
+export function zoektHotDirFromIndexDir(indexDir: string): string {
+  return join(dirname(indexDir), "zoekt-hot")
+}
+
+export const ZOEKT_HOT_DIR = zoektHotDirFromIndexDir(ZOEKT_INDEX_DIR)
 
 /**
  * Zoekt webserver base URL. In Docker Compose this is the service name; in

--- a/apps/codesearch/src/domain/indexing/indexerChildEnv.test.ts
+++ b/apps/codesearch/src/domain/indexing/indexerChildEnv.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { withIndexerGoLimits } from "./indexerChildEnv.js"
+
+const originalMax = process.env.GOMAXPROCS
+const originalGogc = process.env.GOGC
+
+afterEach(() => {
+  if (originalMax === undefined) delete process.env.GOMAXPROCS
+  else process.env.GOMAXPROCS = originalMax
+  if (originalGogc === undefined) delete process.env.GOGC
+  else process.env.GOGC = originalGogc
+})
+
+describe("withIndexerGoLimits", () => {
+  it("defaults GOMAXPROCS=2 and GOGC=50 when unset", () => {
+    delete process.env.GOMAXPROCS
+    delete process.env.GOGC
+    const env = withIndexerGoLimits()
+    expect(env.GOMAXPROCS).toBe("2")
+    expect(env.GOGC).toBe("50")
+  })
+
+  it("does not override explicit caller or process values", () => {
+    process.env.GOMAXPROCS = "8"
+    process.env.GOGC = "100"
+    expect(withIndexerGoLimits().GOMAXPROCS).toBe("8")
+    expect(withIndexerGoLimits({ GOMAXPROCS: "4" }).GOMAXPROCS).toBe("4")
+    expect(withIndexerGoLimits({ GOGC: "25" }).GOGC).toBe("25")
+  })
+})

--- a/apps/codesearch/src/domain/indexing/indexerChildEnv.ts
+++ b/apps/codesearch/src/domain/indexing/indexerChildEnv.ts
@@ -1,6 +1,7 @@
 /**
  * Env for memory-heavy Go indexers (zoekt-index, scip-go, etc.).
- * Caps parallelism / GC overhead unless the caller already set the vars.
+ * Caps process parallelism (`GOMAXPROCS=2`) and trades some GC CPU for a
+ * smaller heap (`GOGC=50`) unless the caller already set those vars.
  */
 export function withIndexerGoLimits(
   env?: Record<string, string | undefined>,

--- a/apps/codesearch/src/domain/indexing/indexerChildEnv.ts
+++ b/apps/codesearch/src/domain/indexing/indexerChildEnv.ts
@@ -1,0 +1,19 @@
+/**
+ * Env for memory-heavy Go indexers (zoekt-index, scip-go, etc.).
+ * Caps parallelism / GC overhead unless the caller already set the vars.
+ */
+export function withIndexerGoLimits(
+  env?: Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  const merged: Record<string, string | undefined> = {
+    ...process.env,
+    ...env,
+  }
+  if (merged.GOMAXPROCS == null || merged.GOMAXPROCS === "") {
+    merged.GOMAXPROCS = "2"
+  }
+  if (merged.GOGC == null || merged.GOGC === "") {
+    merged.GOGC = "50"
+  }
+  return merged
+}

--- a/apps/codesearch/src/domain/indexing/scipIndexers.ts
+++ b/apps/codesearch/src/domain/indexing/scipIndexers.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto"
 import { copyFile, mkdir, rename, rm, stat } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
 import type { ScipIndexerId } from "./detectLanguages.js"
+import { withIndexerGoLimits } from "./indexerChildEnv.js"
 import { INDEX_CHILD_LOG_TAIL_BYTES, readStreamTail } from "./streamTail.js"
 
 /**
@@ -111,7 +112,7 @@ async function runIndexerProcess(input: {
     try {
       return Bun.spawn(input.argv, {
         cwd: input.checkoutPath,
-        env: input.env ? { ...process.env, ...input.env } : undefined,
+        env: withIndexerGoLimits(input.env),
         stdout: "pipe",
         stderr: "pipe",
       })

--- a/apps/codesearch/src/domain/indexing/service.test.ts
+++ b/apps/codesearch/src/domain/indexing/service.test.ts
@@ -6,35 +6,31 @@ import { decodeScipIndex, encodeScipIndex } from "../graph/scipProto.js"
 import { settleIndexPhases, writeMergedScipIndex } from "./service.js"
 
 describe("settleIndexPhases", () => {
-  it("waits for both phases and reports both failures", async () => {
-    let rejectScip: (reason: Error) => void = () => {
-      throw new Error("SCIP rejection was not initialized")
-    }
-    const scipPhase = new Promise<void>((_resolve, reject) => {
-      rejectScip = reject
-    })
+  it("runs Zoekt before SCIP (sequential) and reports both failures", async () => {
+    const order: string[] = []
+    let scipStartedBeforeZoektFinished = false
+
     const result = settleIndexPhases(
-      Promise.reject(new Error("Zoekt failed")),
-      scipPhase,
-    )
-    let resultSettled = false
-    void result.then(
-      () => {
-        resultSettled = true
+      async () => {
+        order.push("zoekt-start")
+        await new Promise((r) => setTimeout(r, 30))
+        order.push("zoekt-end")
+        throw new Error("Zoekt failed")
       },
-      () => {
-        resultSettled = true
+      async () => {
+        if (!order.includes("zoekt-end")) {
+          scipStartedBeforeZoektFinished = true
+        }
+        order.push("scip")
+        throw new Error("SCIP failed")
       },
     )
 
-    await Promise.resolve()
-    expect(resultSettled).toBe(false)
-
-    rejectScip(new Error("SCIP failed"))
     await expect(result).rejects.toThrow(
       "Repository indexing failed:\nZoekt: Zoekt failed\nSCIP: SCIP failed",
     )
-    expect(resultSettled).toBe(true)
+    expect(scipStartedBeforeZoektFinished).toBe(false)
+    expect(order).toEqual(["zoekt-start", "zoekt-end", "scip"])
   })
 })
 

--- a/apps/codesearch/src/domain/indexing/service.ts
+++ b/apps/codesearch/src/domain/indexing/service.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path"
 import { and, eq } from "drizzle-orm"
 import { ZOEKT_INDEX_DIR } from "../../config/paths.js"
 import { refreshPinnedRepo } from "../zoekt/pinManager.js"
+import { withIndexerGoLimits } from "./indexerChildEnv.js"
 import type { Db } from "../../db/client.js"
 import { repositoryCheckouts } from "../../db/schema.js"
 import { authenticatedGitUrl } from "../../utils/git.js"
@@ -331,7 +332,10 @@ async function indexRepository(params: {
         metaPath,
         params.clonePath,
       ],
-      { outputTailBytes: INDEX_CHILD_LOG_TAIL_BYTES },
+      {
+        outputTailBytes: INDEX_CHILD_LOG_TAIL_BYTES,
+        env: withIndexerGoLimits(),
+      },
     )
   } finally {
     await rm(metaPath, { force: true })
@@ -357,32 +361,27 @@ async function readGitHead(clonePath: string): Promise<string | null> {
   return sha.length > 0 ? sha : null
 }
 
+/**
+ * Run Zoekt then SCIP sequentially (reduces peak RSS vs parallel phases).
+ * Still attempts SCIP after a Zoekt failure so both errors can be reported.
+ */
 export async function settleIndexPhases(
-  zoektPhase: Promise<void>,
-  scipPhase: Promise<void>,
+  zoektPhase: () => Promise<void>,
+  scipPhase: () => Promise<void>,
 ): Promise<void> {
-  const [zoektResult, scipResult] = await Promise.allSettled([
-    zoektPhase,
-    scipPhase,
-  ])
-
   const failures: string[] = []
-  if (zoektResult.status === "rejected") {
+  try {
+    await zoektPhase()
+  } catch (reason) {
     failures.push(
-      `Zoekt: ${
-        zoektResult.reason instanceof Error
-          ? zoektResult.reason.message
-          : String(zoektResult.reason)
-      }`,
+      `Zoekt: ${reason instanceof Error ? reason.message : String(reason)}`,
     )
   }
-  if (scipResult.status === "rejected") {
+  try {
+    await scipPhase()
+  } catch (reason) {
     failures.push(
-      `SCIP: ${
-        scipResult.reason instanceof Error
-          ? scipResult.reason.message
-          : String(scipResult.reason)
-      }`,
+      `SCIP: ${reason instanceof Error ? reason.message : String(reason)}`,
     )
   }
   if (failures.length > 0) {
@@ -571,22 +570,24 @@ async function cloneAndIndexRepositoryInner(
   await checkoutCommit(input.clonePath, resolvedTarget)
 
   await settleIndexPhases(
-    indexRepository({
-      clonePath: input.clonePath,
-      zoektRepoId: input.zoektRepoId,
-      repoName: input.repoName,
-      repoUrl: input.repoUrl,
-    }),
-    runScipIndexPhase({
-      clonePath: input.clonePath,
-      scipIndexPath: input.scipIndexPath,
-      orgId: input.orgId,
-      repoId: input.repoId,
-      ingestMode,
-      changedPaths,
-      deletedPaths,
-      renames,
-    }),
+    () =>
+      indexRepository({
+        clonePath: input.clonePath,
+        zoektRepoId: input.zoektRepoId,
+        repoName: input.repoName,
+        repoUrl: input.repoUrl,
+      }),
+    () =>
+      runScipIndexPhase({
+        clonePath: input.clonePath,
+        scipIndexPath: input.scipIndexPath,
+        orgId: input.orgId,
+        repoId: input.repoId,
+        ingestMode,
+        changedPaths,
+        deletedPaths,
+        renames,
+      }),
   )
 
   const head = await readGitHead(input.clonePath)

--- a/apps/codesearch/src/domain/indexing/service.ts
+++ b/apps/codesearch/src/domain/indexing/service.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { and, eq } from "drizzle-orm"
 import { ZOEKT_INDEX_DIR } from "../../config/paths.js"
+import { refreshPinnedRepo } from "../zoekt/pinManager.js"
 import type { Db } from "../../db/client.js"
 import { repositoryCheckouts } from "../../db/schema.js"
 import { authenticatedGitUrl } from "../../utils/git.js"
@@ -335,6 +336,12 @@ async function indexRepository(params: {
   } finally {
     await rm(metaPath, { force: true })
   }
+  // If this repo is currently hot-pinned, refresh symlinks so zoekt-webserver
+  // reloads the new cold shard generation.
+  await refreshPinnedRepo({
+    zoektRepoId: params.zoektRepoId,
+    repoName: params.repoName,
+  })
 }
 
 async function readGitHead(clonePath: string): Promise<string | null> {

--- a/apps/codesearch/src/domain/repositories/purge.test.ts
+++ b/apps/codesearch/src/domain/repositories/purge.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises"
+import { lstat, mkdir, mkdtemp, readdir, readlink, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -6,21 +6,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 vi.mock("../../config/paths.js", () => ({
   REPO_CACHE_DIR: "",
   ZOEKT_INDEX_DIR: "",
+  ZOEKT_HOT_DIR: "",
 }))
 
 import * as paths from "../../config/paths.js"
+import { pinRepos, resetPinManagerForTests } from "../zoekt/pinManager.js"
+import { zoektShardFilePrefix } from "../zoekt/shardPrefix.js"
 import { purgeRepositoryFromDisk } from "./purge.js"
 
 let tmpDir: string
 let repoCacheDir: string
 let zoektIndexDir: string
+let zoektHotDir: string
 
 beforeEach(async () => {
+  resetPinManagerForTests()
   tmpDir = await mkdtemp(join(tmpdir(), "purge-test-"))
   repoCacheDir = join(tmpDir, "repo-cache")
   zoektIndexDir = join(tmpDir, "zoekt-index")
+  zoektHotDir = join(tmpDir, "zoekt-hot")
   await mkdir(repoCacheDir, { recursive: true })
   await mkdir(zoektIndexDir, { recursive: true })
+  await mkdir(zoektHotDir, { recursive: true })
   Object.defineProperty(paths, "REPO_CACHE_DIR", {
     value: repoCacheDir,
     writable: true,
@@ -29,9 +36,14 @@ beforeEach(async () => {
     value: zoektIndexDir,
     writable: true,
   })
+  Object.defineProperty(paths, "ZOEKT_HOT_DIR", {
+    value: zoektHotDir,
+    writable: true,
+  })
 })
 
 afterEach(async () => {
+  resetPinManagerForTests()
   await rm(tmpDir, { recursive: true, force: true })
 })
 
@@ -97,5 +109,33 @@ describe("purgeRepositoryFromDisk", () => {
         zoektRepoId: 42,
       }),
     ).resolves.toBeUndefined()
+  })
+
+  it("removes hot symlinks and pin state for the repo", async () => {
+    const repoName = "owner/repo"
+    const basename = `${zoektShardFilePrefix(repoName)}v16.00000.zoekt`
+    await writeFile(join(zoektIndexDir, basename), "cold")
+    await pinRepos([{ zoektRepoId: 42, repoName }], {
+      coldDir: zoektIndexDir,
+      hotDir: zoektHotDir,
+      idleTtlMs: 60_000,
+    })
+    expect(await readlink(join(zoektHotDir, basename))).toBe(
+      join(zoektIndexDir, basename),
+    )
+
+    await purgeRepositoryFromDisk({
+      orgId: "org_1",
+      repoId: "repo_abc",
+      repoName,
+      zoektRepoId: 42,
+    })
+
+    await expect(lstat(join(zoektHotDir, basename))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
+    await expect(lstat(join(zoektIndexDir, basename))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
   })
 })

--- a/apps/codesearch/src/domain/repositories/purge.test.ts
+++ b/apps/codesearch/src/domain/repositories/purge.test.ts
@@ -52,10 +52,10 @@ describe("purgeRepositoryFromDisk", () => {
     expect(entries).not.toContain("repo_abc")
   })
 
-  it("deletes shards matching the repo name prefix", async () => {
-    await writeFile(join(zoektIndexDir, "owner_repo_v16.00000.zoekt"), "")
-    await writeFile(join(zoektIndexDir, "owner_repo_v16.00001.zoekt"), "")
-    await writeFile(join(zoektIndexDir, "other_repo_v16.00000.zoekt"), "")
+  it("deletes shards matching the zoekt QueryEscape repo name prefix", async () => {
+    await writeFile(join(zoektIndexDir, "owner%2Frepo_v16.00000.zoekt"), "")
+    await writeFile(join(zoektIndexDir, "owner%2Frepo_v16.00001.zoekt"), "")
+    await writeFile(join(zoektIndexDir, "other%2Frepo_v16.00000.zoekt"), "")
 
     await purgeRepositoryFromDisk({
       orgId: "org_1",
@@ -65,12 +65,15 @@ describe("purgeRepositoryFromDisk", () => {
     })
 
     const remaining = await readdir(zoektIndexDir)
-    expect(remaining).toEqual(["other_repo_v16.00000.zoekt"])
+    expect(remaining).toEqual(["other%2Frepo_v16.00000.zoekt"])
   })
 
   it("does not false-match shards with similar prefixes", async () => {
-    await writeFile(join(zoektIndexDir, "owner_repo-fork_v16.00000.zoekt"), "")
-    await writeFile(join(zoektIndexDir, "owner_repo_v16.00000.zoekt"), "")
+    await writeFile(
+      join(zoektIndexDir, "owner%2Frepo-fork_v16.00000.zoekt"),
+      "",
+    )
+    await writeFile(join(zoektIndexDir, "owner%2Frepo_v16.00000.zoekt"), "")
 
     await purgeRepositoryFromDisk({
       orgId: "org_1",
@@ -80,7 +83,7 @@ describe("purgeRepositoryFromDisk", () => {
     })
 
     const remaining = await readdir(zoektIndexDir)
-    expect(remaining).toEqual(["owner_repo-fork_v16.00000.zoekt"])
+    expect(remaining).toEqual(["owner%2Frepo-fork_v16.00000.zoekt"])
   })
 
   it("handles missing zoekt index directory gracefully", async () => {

--- a/apps/codesearch/src/domain/repositories/purge.ts
+++ b/apps/codesearch/src/domain/repositories/purge.ts
@@ -1,14 +1,11 @@
-import { readdir, rm } from "node:fs/promises"
+import { rm } from "node:fs/promises"
 import { join } from "node:path"
-import { REPO_CACHE_DIR, ZOEKT_INDEX_DIR } from "../../config/paths.js"
-import { unpinRepo } from "../zoekt/pinManager.js"
-import { isZoektShardBasenameForRepo } from "../zoekt/shardPrefix.js"
+import { REPO_CACHE_DIR } from "../../config/paths.js"
+import { purgeZoektShardsForRepo } from "../zoekt/pinManager.js"
 
 /**
  * Removes git checkout cache and Zoekt index shards for a repository.
- * Drops hot symlinks/pin state first, then deletes cold shard files.
- * Shard matching uses the repo-name prefix that `zoekt-index` embeds in
- * filenames (e.g. `owner%2Frepo_v16.00000.zoekt`).
+ * Hot symlinks/pin state and cold shard files are removed under one lock.
  */
 export async function purgeRepositoryFromDisk(params: {
   orgId: string
@@ -21,17 +18,5 @@ export async function purgeRepositoryFromDisk(params: {
   const repoRoot = join(REPO_CACHE_DIR, orgId, repoId)
   await rm(repoRoot, { recursive: true, force: true })
 
-  await unpinRepo({ zoektRepoId, repoName })
-
-  let entries: string[] = []
-  try {
-    entries = await readdir(ZOEKT_INDEX_DIR)
-  } catch {
-    return
-  }
-
-  for (const name of entries) {
-    if (!isZoektShardBasenameForRepo(name, repoName)) continue
-    await rm(join(ZOEKT_INDEX_DIR, name), { force: true })
-  }
+  await purgeZoektShardsForRepo({ zoektRepoId, repoName })
 }

--- a/apps/codesearch/src/domain/repositories/purge.ts
+++ b/apps/codesearch/src/domain/repositories/purge.ts
@@ -1,19 +1,12 @@
 import { readdir, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { REPO_CACHE_DIR, ZOEKT_INDEX_DIR } from "../../config/paths.js"
-
-/**
- * Derive the shard filename prefix that `zoekt-index` produces from a repo name.
- * Zoekt replaces `/` with `_` in the `Name` metadata field to form the prefix.
- */
-function shardPrefix(repoName: string): string {
-  return `${repoName.replaceAll("/", "_")}_`
-}
+import { isZoektShardBasenameForRepo } from "../zoekt/shardPrefix.js"
 
 /**
  * Removes git checkout cache and Zoekt index shards for a repository.
  * Shard matching uses the repo-name prefix that `zoekt-index` embeds in
- * filenames (e.g. `owner_repo_v16.00000.zoekt`).
+ * filenames (e.g. `owner%2Frepo_v16.00000.zoekt`).
  */
 export async function purgeRepositoryFromDisk(params: {
   orgId: string
@@ -33,9 +26,8 @@ export async function purgeRepositoryFromDisk(params: {
     return
   }
 
-  const prefix = shardPrefix(repoName)
   for (const name of entries) {
-    if (!name.endsWith(".zoekt") || !name.startsWith(prefix)) continue
+    if (!isZoektShardBasenameForRepo(name, repoName)) continue
     await rm(join(ZOEKT_INDEX_DIR, name), { force: true })
   }
 }

--- a/apps/codesearch/src/domain/repositories/purge.ts
+++ b/apps/codesearch/src/domain/repositories/purge.ts
@@ -1,10 +1,12 @@
 import { readdir, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { REPO_CACHE_DIR, ZOEKT_INDEX_DIR } from "../../config/paths.js"
+import { unpinRepo } from "../zoekt/pinManager.js"
 import { isZoektShardBasenameForRepo } from "../zoekt/shardPrefix.js"
 
 /**
  * Removes git checkout cache and Zoekt index shards for a repository.
+ * Drops hot symlinks/pin state first, then deletes cold shard files.
  * Shard matching uses the repo-name prefix that `zoekt-index` embeds in
  * filenames (e.g. `owner%2Frepo_v16.00000.zoekt`).
  */
@@ -14,10 +16,12 @@ export async function purgeRepositoryFromDisk(params: {
   repoName: string
   zoektRepoId: number
 }): Promise<void> {
-  const { orgId, repoId, repoName } = params
+  const { orgId, repoId, repoName, zoektRepoId } = params
 
   const repoRoot = join(REPO_CACHE_DIR, orgId, repoId)
   await rm(repoRoot, { recursive: true, force: true })
+
+  await unpinRepo({ zoektRepoId, repoName })
 
   let entries: string[] = []
   try {

--- a/apps/codesearch/src/domain/zoekt/pinManager.test.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.test.ts
@@ -1,0 +1,149 @@
+import { lstat, mkdir, mkdtemp, readlink, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  isRepoPinned,
+  pinRepos,
+  resetPinManagerForTests,
+  unpinRepo,
+} from "./pinManager.js"
+import { zoektShardFilePrefix } from "./shardPrefix.js"
+
+let tmpDir: string
+let coldDir: string
+let hotDir: string
+
+beforeEach(async () => {
+  resetPinManagerForTests()
+  tmpDir = await mkdtemp(join(tmpdir(), "pin-manager-"))
+  coldDir = join(tmpDir, "zoekt-index")
+  hotDir = join(tmpDir, "zoekt-hot")
+  await mkdir(coldDir, { recursive: true })
+  await mkdir(hotDir, { recursive: true })
+})
+
+afterEach(async () => {
+  resetPinManagerForTests()
+  vi.useRealTimers()
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+async function writeColdShard(repoName: string, shardNum = 0): Promise<string> {
+  const basename = `${zoektShardFilePrefix(repoName)}v16.${String(shardNum).padStart(5, "0")}.zoekt`
+  const path = join(coldDir, basename)
+  await writeFile(path, `shard-${shardNum}`)
+  return basename
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean> | boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return
+    await new Promise((r) => setTimeout(r, 20))
+  }
+  throw new Error("waitFor timed out")
+}
+
+describe("pinRepos", () => {
+  it("creates hot symlinks to cold shards", async () => {
+    const repoName = "owner/repo"
+    const basename = await writeColdShard(repoName)
+    await writeFile(join(coldDir, `${basename}.meta`), "meta")
+
+    await pinRepos([{ zoektRepoId: 7, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 60_000,
+    })
+
+    expect(await readlink(join(hotDir, basename))).toBe(join(coldDir, basename))
+    expect(await readlink(join(hotDir, `${basename}.meta`))).toBe(
+      join(coldDir, `${basename}.meta`),
+    )
+    expect(isRepoPinned(7)).toBe(true)
+  })
+
+  it("resets idle TTL on a second pin so unload is deferred", async () => {
+    const repoName = "owner/repo"
+    const basename = await writeColdShard(repoName)
+
+    await pinRepos([{ zoektRepoId: 1, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 120,
+    })
+
+    await new Promise((r) => setTimeout(r, 70))
+    await pinRepos([{ zoektRepoId: 1, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 120,
+    })
+    await new Promise((r) => setTimeout(r, 70))
+
+    // Still pinned: second pin deferred unload past the first TTL
+    expect((await lstat(join(hotDir, basename))).isSymbolicLink()).toBe(true)
+    expect(isRepoPinned(1)).toBe(true)
+
+    await waitFor(async () => {
+      try {
+        await lstat(join(hotDir, basename))
+        return false
+      } catch {
+        return !isRepoPinned(1)
+      }
+    })
+
+    await expect(lstat(join(hotDir, basename))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
+  })
+
+  it("unloads hot symlinks after idle TTL", async () => {
+    const repoName = "owner/repo"
+    const basename = await writeColdShard(repoName)
+
+    await pinRepos([{ zoektRepoId: 2, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 80,
+    })
+
+    await waitFor(async () => {
+      try {
+        await lstat(join(hotDir, basename))
+        return false
+      } catch {
+        return !isRepoPinned(2)
+      }
+    })
+
+    await expect(lstat(join(hotDir, basename))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
+    await expect(lstat(join(coldDir, basename))).resolves.toBeTruthy()
+  })
+})
+
+describe("unpinRepo", () => {
+  it("removes hot symlinks immediately", async () => {
+    const repoName = "owner/repo"
+    const basename = await writeColdShard(repoName)
+    await pinRepos([{ zoektRepoId: 3, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 60_000,
+    })
+
+    await unpinRepo({ zoektRepoId: 3, repoName }, { coldDir, hotDir })
+
+    await expect(lstat(join(hotDir, basename))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
+    expect(isRepoPinned(3)).toBe(false)
+  })
+})

--- a/apps/codesearch/src/domain/zoekt/pinManager.test.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   isRepoPinned,
   pinRepos,
+  refreshPinnedRepo,
   resetPinManagerForTests,
   unpinRepo,
 } from "./pinManager.js"
@@ -209,5 +210,36 @@ describe("pinRepos safety", () => {
     await new Promise((r) => setTimeout(r, 80))
     expect((await lstat(join(hotDir, basename))).isSymbolicLink()).toBe(true)
     expect(isRepoPinned(6)).toBe(true)
+  })
+
+  it("refreshPinnedRepo links newly written cold shards when pinned", async () => {
+    const repoName = "owner/repo"
+    const first = await writeColdShard(repoName, 0)
+    await pinRepos([{ zoektRepoId: 8, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 60_000,
+    })
+    const second = await writeColdShard(repoName, 1)
+
+    await refreshPinnedRepo(
+      { zoektRepoId: 8, repoName },
+      { coldDir, hotDir, idleTtlMs: 60_000 },
+    )
+
+    expect(await readlink(join(hotDir, first))).toBe(join(coldDir, first))
+    expect(await readlink(join(hotDir, second))).toBe(join(coldDir, second))
+  })
+
+  it("refreshPinnedRepo is a no-op when the repo is not pinned", async () => {
+    const repoName = "owner/repo"
+    const basename = await writeColdShard(repoName)
+    await refreshPinnedRepo(
+      { zoektRepoId: 9, repoName },
+      { coldDir, hotDir, idleTtlMs: 60_000 },
+    )
+    await expect(lstat(join(hotDir, basename))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
   })
 })

--- a/apps/codesearch/src/domain/zoekt/pinManager.test.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.test.ts
@@ -147,3 +147,67 @@ describe("unpinRepo", () => {
     expect(isRepoPinned(3)).toBe(false)
   })
 })
+
+describe("pinRepos safety", () => {
+  it("refuses to replace a regular file in the hot dir", async () => {
+    const repoName = "owner/repo"
+    const basename = await writeColdShard(repoName)
+    await writeFile(join(hotDir, basename), "not-a-symlink")
+
+    await expect(
+      pinRepos([{ zoektRepoId: 4, repoName }], {
+        coldDir,
+        hotDir,
+        idleTtlMs: 60_000,
+      }),
+    ).rejects.toThrow(/not a symlink/)
+  })
+
+  it("keeps shards when concurrent pins race on the same repo", async () => {
+    const repoName = "owner/repo"
+    const basename = await writeColdShard(repoName)
+
+    await Promise.all([
+      pinRepos([{ zoektRepoId: 5, repoName }], {
+        coldDir,
+        hotDir,
+        idleTtlMs: 60_000,
+      }),
+      pinRepos([{ zoektRepoId: 5, repoName }], {
+        coldDir,
+        hotDir,
+        idleTtlMs: 60_000,
+      }),
+      pinRepos([{ zoektRepoId: 5, repoName }], {
+        coldDir,
+        hotDir,
+        idleTtlMs: 60_000,
+      }),
+    ])
+
+    expect(await readlink(join(hotDir, basename))).toBe(join(coldDir, basename))
+    expect(isRepoPinned(5)).toBe(true)
+  })
+
+  it("does not unload after a re-pin that races an expiring TTL", async () => {
+    const repoName = "owner/repo"
+    const basename = await writeColdShard(repoName)
+
+    await pinRepos([{ zoektRepoId: 6, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 80,
+    })
+
+    await new Promise((r) => setTimeout(r, 60))
+    await pinRepos([{ zoektRepoId: 6, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 200,
+    })
+
+    await new Promise((r) => setTimeout(r, 80))
+    expect((await lstat(join(hotDir, basename))).isSymbolicLink()).toBe(true)
+    expect(isRepoPinned(6)).toBe(true)
+  })
+})

--- a/apps/codesearch/src/domain/zoekt/pinManager.test.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.test.ts
@@ -231,6 +231,28 @@ describe("pinRepos safety", () => {
     expect(await readlink(join(hotDir, second))).toBe(join(coldDir, second))
   })
 
+  it("refreshPinnedRepo drops stale hot shards and recreates links", async () => {
+    const repoName = "owner/repo"
+    const first = await writeColdShard(repoName, 0)
+    const second = await writeColdShard(repoName, 1)
+    await pinRepos([{ zoektRepoId: 10, repoName }], {
+      coldDir,
+      hotDir,
+      idleTtlMs: 60_000,
+    })
+    await rm(join(coldDir, second), { force: true })
+
+    await refreshPinnedRepo(
+      { zoektRepoId: 10, repoName },
+      { coldDir, hotDir, idleTtlMs: 60_000 },
+    )
+
+    expect(await readlink(join(hotDir, first))).toBe(join(coldDir, first))
+    await expect(lstat(join(hotDir, second))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
+  })
+
   it("refreshPinnedRepo is a no-op when the repo is not pinned", async () => {
     const repoName = "owner/repo"
     const basename = await writeColdShard(repoName)

--- a/apps/codesearch/src/domain/zoekt/pinManager.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.ts
@@ -203,8 +203,15 @@ export async function refreshPinnedRepo(
   repo: { zoektRepoId: number; repoName: string },
   options?: { coldDir?: string; hotDir?: string; idleTtlMs?: number },
 ): Promise<void> {
-  if (!pins.has(repo.zoektRepoId)) return
-  await pinRepos([repo], options)
+  const coldDir = options?.coldDir ?? ZOEKT_INDEX_DIR
+  const hotDir = options?.hotDir ?? ZOEKT_HOT_DIR
+  const idleTtlMs = options?.idleTtlMs ?? PIN_IDLE_TTL_MS
+  await mkdir(hotDir, { recursive: true })
+  await mkdir(coldDir, { recursive: true })
+  await withRepoLock(repo.zoektRepoId, async () => {
+    if (!pins.has(repo.zoektRepoId)) return
+    await pinRepoLocked(repo, coldDir, hotDir, idleTtlMs)
+  })
 }
 
 /** Drop pin state and hot symlinks for a repo immediately (purge). */

--- a/apps/codesearch/src/domain/zoekt/pinManager.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.ts
@@ -44,13 +44,13 @@ async function withRepoLock<T>(
   }
 }
 
-async function listColdBasenames(
+async function listDirBasenamesForRepo(
   repoName: string,
-  coldDir: string,
+  dir: string,
 ): Promise<string[]> {
   let entries: string[]
   try {
-    entries = await readdir(coldDir)
+    entries = await readdir(dir)
   } catch (error) {
     if (isErrnoException(error) && error.code === "ENOENT") return []
     throw error
@@ -58,6 +58,7 @@ async function listColdBasenames(
   return entries.filter((name) => isZoektShardBasenameForRepo(name, repoName))
 }
 
+/** Create or reuse an already-correct symlink (normal pin path). */
 async function ensureSymlink(hotPath: string, coldPath: string): Promise<void> {
   try {
     const st = await lstat(hotPath)
@@ -87,31 +88,45 @@ async function ensureSymlink(hotPath: string, coldPath: string): Promise<void> {
   }
 }
 
-async function removeHotSymlinks(
+/**
+ * Always recreate the symlink so its mtime changes and zoekt-webserver's
+ * DirectoryWatcher reloads the shard after a cold-file replace.
+ */
+async function forceRecreateSymlink(
+  hotPath: string,
+  coldPath: string,
+): Promise<void> {
+  try {
+    const st = await lstat(hotPath)
+    if (!st.isSymbolicLink()) {
+      throw new Error(
+        `hot path is not a symlink (refusing to replace): ${hotPath}`,
+      )
+    }
+    await rm(hotPath, { force: true })
+  } catch (error) {
+    if (!(isErrnoException(error) && error.code === "ENOENT")) {
+      throw error
+    }
+  }
+  await symlink(coldPath, hotPath)
+}
+
+/** Remove every hot-dir entry for the repo (symlink or stray file). */
+async function removeHotEntries(repoName: string, hotDir: string): Promise<void> {
+  const fromHot = await listDirBasenamesForRepo(repoName, hotDir)
+  for (const basename of fromHot) {
+    await rm(join(hotDir, basename), { force: true })
+  }
+}
+
+async function removeColdEntries(
   repoName: string,
   coldDir: string,
-  hotDir: string,
 ): Promise<void> {
-  const fromCold = await listColdBasenames(repoName, coldDir)
-  let fromHot: string[] = []
-  try {
-    fromHot = (await readdir(hotDir)).filter((name) =>
-      isZoektShardBasenameForRepo(name, repoName),
-    )
-  } catch (error) {
-    if (!(isErrnoException(error) && error.code === "ENOENT")) throw error
-  }
-  const basenames = new Set([...fromCold, ...fromHot])
-  for (const basename of basenames) {
-    const hotPath = join(hotDir, basename)
-    try {
-      const st = await lstat(hotPath)
-      if (st.isSymbolicLink()) {
-        await rm(hotPath, { force: true })
-      }
-    } catch (error) {
-      if (!(isErrnoException(error) && error.code === "ENOENT")) throw error
-    }
+  const fromCold = await listDirBasenamesForRepo(repoName, coldDir)
+  for (const basename of fromCold) {
+    await rm(join(coldDir, basename), { force: true })
   }
 }
 
@@ -132,9 +147,8 @@ function armIdleTimer(
       if (!current || current.generation !== generation) return
       pins.delete(zoektRepoId)
       try {
-        await removeHotSymlinks(repoName, coldDir, hotDir)
+        await removeHotEntries(repoName, hotDir)
       } catch (error) {
-        // Keep process alive; next pin/refresh can repair hot dir.
         console.error(
           `[zoekt-pin] failed to unload repo ${zoektRepoId}:`,
           error,
@@ -158,11 +172,30 @@ async function pinRepoLocked(
   coldDir: string,
   hotDir: string,
   idleTtlMs: number,
+  mode: "pin" | "refresh",
 ): Promise<PinResult> {
-  const basenames = await listColdBasenames(repo.repoName, coldDir)
-  for (const basename of basenames) {
-    await ensureSymlink(join(hotDir, basename), join(coldDir, basename))
+  const coldBasenames = await listDirBasenamesForRepo(repo.repoName, coldDir)
+  const coldSet = new Set(coldBasenames)
+
+  if (mode === "refresh") {
+    const hotBasenames = await listDirBasenamesForRepo(repo.repoName, hotDir)
+    for (const basename of hotBasenames) {
+      if (!coldSet.has(basename)) {
+        await rm(join(hotDir, basename), { force: true })
+      }
+    }
+    for (const basename of coldBasenames) {
+      await forceRecreateSymlink(
+        join(hotDir, basename),
+        join(coldDir, basename),
+      )
+    }
+  } else {
+    for (const basename of coldBasenames) {
+      await ensureSymlink(join(hotDir, basename), join(coldDir, basename))
+    }
   }
+
   const previous = pins.get(repo.zoektRepoId)
   const generation = (previous?.generation ?? 0) + 1
   if (previous) clearTimeout(previous.timer)
@@ -174,7 +207,9 @@ async function pinRepoLocked(
     coldDir,
     hotDir,
   )
-  const shardCount = basenames.filter((name) => name.endsWith(".zoekt")).length
+  const shardCount = coldBasenames.filter((name) =>
+    name.endsWith(".zoekt"),
+  ).length
   return { zoektRepoId: repo.zoektRepoId, repoName: repo.repoName, shardCount }
 }
 
@@ -201,7 +236,7 @@ export async function pinRepos(
   for (const repo of repos) {
     results.push(
       await withRepoLock(repo.zoektRepoId, () =>
-        pinRepoLocked(repo, coldDir, hotDir, idleTtlMs),
+        pinRepoLocked(repo, coldDir, hotDir, idleTtlMs, "pin"),
       ),
     )
   }
@@ -210,7 +245,8 @@ export async function pinRepos(
 
 /**
  * Re-link hot symlinks for a repo that is currently pinned (e.g. after reindex).
- * No-op if the repo is not pinned.
+ * Drops stale hot entries, force-recreates symlinks (mtime bump for Zoekt),
+ * and resets the idle TTL. No-op if the repo is not pinned.
  */
 export async function refreshPinnedRepo(
   repo: { zoektRepoId: number; repoName: string },
@@ -223,12 +259,31 @@ export async function refreshPinnedRepo(
   await mkdir(coldDir, { recursive: true })
   await withRepoLock(repo.zoektRepoId, async () => {
     if (!pins.has(repo.zoektRepoId)) return
-    await pinRepoLocked(repo, coldDir, hotDir, idleTtlMs)
+    await pinRepoLocked(repo, coldDir, hotDir, idleTtlMs, "refresh")
   })
 }
 
-/** Drop pin state and hot symlinks for a repo immediately (purge). */
+/** Drop pin state and hot entries for a repo immediately. */
 export async function unpinRepo(
+  repo: { zoektRepoId: number; repoName: string },
+  options?: { coldDir?: string; hotDir?: string },
+): Promise<void> {
+  const hotDir = options?.hotDir ?? ZOEKT_HOT_DIR
+  await withRepoLock(repo.zoektRepoId, async () => {
+    const existing = pins.get(repo.zoektRepoId)
+    if (existing) {
+      clearTimeout(existing.timer)
+      pins.delete(repo.zoektRepoId)
+    }
+    await removeHotEntries(repo.repoName, hotDir)
+  })
+}
+
+/**
+ * Under one per-repo lock: clear pin, remove hot entries, delete cold shards.
+ * Prevents a concurrent search from re-pinning between unpin and cold delete.
+ */
+export async function purgeZoektShardsForRepo(
   repo: { zoektRepoId: number; repoName: string },
   options?: { coldDir?: string; hotDir?: string },
 ): Promise<void> {
@@ -240,7 +295,8 @@ export async function unpinRepo(
       clearTimeout(existing.timer)
       pins.delete(repo.zoektRepoId)
     }
-    await removeHotSymlinks(repo.repoName, coldDir, hotDir)
+    await removeHotEntries(repo.repoName, hotDir)
+    await removeColdEntries(repo.repoName, coldDir)
   })
 }
 

--- a/apps/codesearch/src/domain/zoekt/pinManager.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readdir, rm, symlink } from "node:fs/promises"
+import { lstat, mkdir, readlink, readdir, rm, symlink } from "node:fs/promises"
 import { join } from "node:path"
 import { ZOEKT_HOT_DIR, ZOEKT_INDEX_DIR } from "../../config/paths.js"
 import { isZoektShardBasenameForRepo } from "./shardPrefix.js"
@@ -9,12 +9,39 @@ export const PIN_IDLE_TTL_MS = 5 * 60 * 1000
 type PinEntry = {
   repoName: string
   timer: ReturnType<typeof setTimeout>
+  /** Bumped on every pin so stale unload callbacks cannot clear a newer pin. */
+  generation: number
 }
 
 const pins = new Map<number, PinEntry>()
 
+/** Per-repo async mutex so pin/unpin/unload never interleave on the same id. */
+const repoQueues = new Map<number, Promise<void>>()
+
 function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error
+}
+
+async function withRepoLock(
+  zoektRepoId: number,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const previous = repoQueues.get(zoektRepoId) ?? Promise.resolve()
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const next = previous.catch(() => {}).then(() => gate)
+  repoQueues.set(zoektRepoId, next)
+  await previous.catch(() => {})
+  try {
+    await fn()
+  } finally {
+    release()
+    if (repoQueues.get(zoektRepoId) === next) {
+      repoQueues.delete(zoektRepoId)
+    }
+  }
 }
 
 async function listColdBasenames(
@@ -39,15 +66,25 @@ async function ensureSymlink(hotPath: string, coldPath: string): Promise<void> {
         `hot path is not a symlink (refusing to replace): ${hotPath}`,
       )
     }
+    const current = await readlink(hotPath)
+    if (current === coldPath) return
     await rm(hotPath, { force: true })
   } catch (error) {
-    if (isErrnoException(error) && error.code === "ENOENT") {
-      // create below
-    } else {
+    if (!(isErrnoException(error) && error.code === "ENOENT")) {
       throw error
     }
   }
-  await symlink(coldPath, hotPath)
+  try {
+    await symlink(coldPath, hotPath)
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "EEXIST") {
+      const st = await lstat(hotPath)
+      if (st.isSymbolicLink() && (await readlink(hotPath)) === coldPath) {
+        return
+      }
+    }
+    throw error
+  }
 }
 
 async function removeHotSymlinks(
@@ -81,6 +118,7 @@ async function removeHotSymlinks(
 function armIdleTimer(
   zoektRepoId: number,
   repoName: string,
+  generation: number,
   idleTtlMs: number,
   coldDir: string,
   hotDir: string,
@@ -89,13 +127,46 @@ function armIdleTimer(
   if (existing) clearTimeout(existing.timer)
 
   const timer = setTimeout(() => {
-    const current = pins.get(zoektRepoId)
-    if (!current || current.timer !== timer) return
-    pins.delete(zoektRepoId)
-    void removeHotSymlinks(repoName, coldDir, hotDir)
+    void withRepoLock(zoektRepoId, async () => {
+      const current = pins.get(zoektRepoId)
+      if (!current || current.generation !== generation) return
+      pins.delete(zoektRepoId)
+      try {
+        await removeHotSymlinks(repoName, coldDir, hotDir)
+      } catch (error) {
+        // Keep process alive; next pin/refresh can repair hot dir.
+        console.error(
+          `[zoekt-pin] failed to unload repo ${zoektRepoId}:`,
+          error,
+        )
+      }
+    })
   }, idleTtlMs)
 
-  pins.set(zoektRepoId, { repoName, timer })
+  pins.set(zoektRepoId, { repoName, timer, generation })
+}
+
+async function pinRepoLocked(
+  repo: { zoektRepoId: number; repoName: string },
+  coldDir: string,
+  hotDir: string,
+  idleTtlMs: number,
+): Promise<void> {
+  const basenames = await listColdBasenames(repo.repoName, coldDir)
+  for (const basename of basenames) {
+    await ensureSymlink(join(hotDir, basename), join(coldDir, basename))
+  }
+  const previous = pins.get(repo.zoektRepoId)
+  const generation = (previous?.generation ?? 0) + 1
+  if (previous) clearTimeout(previous.timer)
+  armIdleTimer(
+    repo.zoektRepoId,
+    repo.repoName,
+    generation,
+    idleTtlMs,
+    coldDir,
+    hotDir,
+  )
 }
 
 /**
@@ -118,11 +189,9 @@ export async function pinRepos(
   await mkdir(coldDir, { recursive: true })
 
   for (const repo of repos) {
-    const basenames = await listColdBasenames(repo.repoName, coldDir)
-    for (const basename of basenames) {
-      await ensureSymlink(join(hotDir, basename), join(coldDir, basename))
-    }
-    armIdleTimer(repo.zoektRepoId, repo.repoName, idleTtlMs, coldDir, hotDir)
+    await withRepoLock(repo.zoektRepoId, () =>
+      pinRepoLocked(repo, coldDir, hotDir, idleTtlMs),
+    )
   }
 }
 
@@ -145,12 +214,14 @@ export async function unpinRepo(
 ): Promise<void> {
   const coldDir = options?.coldDir ?? ZOEKT_INDEX_DIR
   const hotDir = options?.hotDir ?? ZOEKT_HOT_DIR
-  const existing = pins.get(repo.zoektRepoId)
-  if (existing) {
-    clearTimeout(existing.timer)
-    pins.delete(repo.zoektRepoId)
-  }
-  await removeHotSymlinks(repo.repoName, coldDir, hotDir)
+  await withRepoLock(repo.zoektRepoId, async () => {
+    const existing = pins.get(repo.zoektRepoId)
+    if (existing) {
+      clearTimeout(existing.timer)
+      pins.delete(repo.zoektRepoId)
+    }
+    await removeHotSymlinks(repo.repoName, coldDir, hotDir)
+  })
 }
 
 export function isRepoPinned(zoektRepoId: number): boolean {
@@ -161,4 +232,5 @@ export function isRepoPinned(zoektRepoId: number): boolean {
 export function resetPinManagerForTests(): void {
   for (const entry of pins.values()) clearTimeout(entry.timer)
   pins.clear()
+  repoQueues.clear()
 }

--- a/apps/codesearch/src/domain/zoekt/pinManager.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.ts
@@ -22,10 +22,10 @@ function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error
 }
 
-async function withRepoLock(
+async function withRepoLock<T>(
   zoektRepoId: number,
-  fn: () => Promise<void>,
-): Promise<void> {
+  fn: () => Promise<T>,
+): Promise<T> {
   const previous = repoQueues.get(zoektRepoId) ?? Promise.resolve()
   let release!: () => void
   const gate = new Promise<void>((resolve) => {
@@ -35,7 +35,7 @@ async function withRepoLock(
   repoQueues.set(zoektRepoId, next)
   await previous.catch(() => {})
   try {
-    await fn()
+    return await fn()
   } finally {
     release()
     if (repoQueues.get(zoektRepoId) === next) {
@@ -146,12 +146,19 @@ function armIdleTimer(
   pins.set(zoektRepoId, { repoName, timer, generation })
 }
 
+export type PinResult = {
+  zoektRepoId: number
+  repoName: string
+  /** Number of cold `.zoekt` shard files linked (excludes `.meta`). */
+  shardCount: number
+}
+
 async function pinRepoLocked(
   repo: { zoektRepoId: number; repoName: string },
   coldDir: string,
   hotDir: string,
   idleTtlMs: number,
-): Promise<void> {
+): Promise<PinResult> {
   const basenames = await listColdBasenames(repo.repoName, coldDir)
   for (const basename of basenames) {
     await ensureSymlink(join(hotDir, basename), join(coldDir, basename))
@@ -167,6 +174,8 @@ async function pinRepoLocked(
     coldDir,
     hotDir,
   )
+  const shardCount = basenames.filter((name) => name.endsWith(".zoekt")).length
+  return { zoektRepoId: repo.zoektRepoId, repoName: repo.repoName, shardCount }
 }
 
 /**
@@ -180,7 +189,7 @@ export async function pinRepos(
     hotDir?: string
     idleTtlMs?: number
   },
-): Promise<void> {
+): Promise<PinResult[]> {
   const coldDir = options?.coldDir ?? ZOEKT_INDEX_DIR
   const hotDir = options?.hotDir ?? ZOEKT_HOT_DIR
   const idleTtlMs = options?.idleTtlMs ?? PIN_IDLE_TTL_MS
@@ -188,11 +197,15 @@ export async function pinRepos(
   await mkdir(hotDir, { recursive: true })
   await mkdir(coldDir, { recursive: true })
 
+  const results: PinResult[] = []
   for (const repo of repos) {
-    await withRepoLock(repo.zoektRepoId, () =>
-      pinRepoLocked(repo, coldDir, hotDir, idleTtlMs),
+    results.push(
+      await withRepoLock(repo.zoektRepoId, () =>
+        pinRepoLocked(repo, coldDir, hotDir, idleTtlMs),
+      ),
     )
   }
+  return results
 }
 
 /**

--- a/apps/codesearch/src/domain/zoekt/pinManager.ts
+++ b/apps/codesearch/src/domain/zoekt/pinManager.ts
@@ -1,0 +1,164 @@
+import { lstat, mkdir, readdir, rm, symlink } from "node:fs/promises"
+import { join } from "node:path"
+import { ZOEKT_HOT_DIR, ZOEKT_INDEX_DIR } from "../../config/paths.js"
+import { isZoektShardBasenameForRepo } from "./shardPrefix.js"
+
+/** Idle time after last pin before hot symlinks for a repo are removed. */
+export const PIN_IDLE_TTL_MS = 5 * 60 * 1000
+
+type PinEntry = {
+  repoName: string
+  timer: ReturnType<typeof setTimeout>
+}
+
+const pins = new Map<number, PinEntry>()
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error
+}
+
+async function listColdBasenames(
+  repoName: string,
+  coldDir: string,
+): Promise<string[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(coldDir)
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") return []
+    throw error
+  }
+  return entries.filter((name) => isZoektShardBasenameForRepo(name, repoName))
+}
+
+async function ensureSymlink(hotPath: string, coldPath: string): Promise<void> {
+  try {
+    const st = await lstat(hotPath)
+    if (!st.isSymbolicLink()) {
+      throw new Error(
+        `hot path is not a symlink (refusing to replace): ${hotPath}`,
+      )
+    }
+    await rm(hotPath, { force: true })
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") {
+      // create below
+    } else {
+      throw error
+    }
+  }
+  await symlink(coldPath, hotPath)
+}
+
+async function removeHotSymlinks(
+  repoName: string,
+  coldDir: string,
+  hotDir: string,
+): Promise<void> {
+  const fromCold = await listColdBasenames(repoName, coldDir)
+  let fromHot: string[] = []
+  try {
+    fromHot = (await readdir(hotDir)).filter((name) =>
+      isZoektShardBasenameForRepo(name, repoName),
+    )
+  } catch (error) {
+    if (!(isErrnoException(error) && error.code === "ENOENT")) throw error
+  }
+  const basenames = new Set([...fromCold, ...fromHot])
+  for (const basename of basenames) {
+    const hotPath = join(hotDir, basename)
+    try {
+      const st = await lstat(hotPath)
+      if (st.isSymbolicLink()) {
+        await rm(hotPath, { force: true })
+      }
+    } catch (error) {
+      if (!(isErrnoException(error) && error.code === "ENOENT")) throw error
+    }
+  }
+}
+
+function armIdleTimer(
+  zoektRepoId: number,
+  repoName: string,
+  idleTtlMs: number,
+  coldDir: string,
+  hotDir: string,
+): void {
+  const existing = pins.get(zoektRepoId)
+  if (existing) clearTimeout(existing.timer)
+
+  const timer = setTimeout(() => {
+    const current = pins.get(zoektRepoId)
+    if (!current || current.timer !== timer) return
+    pins.delete(zoektRepoId)
+    void removeHotSymlinks(repoName, coldDir, hotDir)
+  }, idleTtlMs)
+
+  pins.set(zoektRepoId, { repoName, timer })
+}
+
+/**
+ * Ensure hot-dir symlinks exist for the repo's cold shards and reset the idle TTL.
+ * Missing cold shards is a no-op for files (TTL still arms for the id).
+ */
+export async function pinRepos(
+  repos: ReadonlyArray<{ zoektRepoId: number; repoName: string }>,
+  options?: {
+    coldDir?: string
+    hotDir?: string
+    idleTtlMs?: number
+  },
+): Promise<void> {
+  const coldDir = options?.coldDir ?? ZOEKT_INDEX_DIR
+  const hotDir = options?.hotDir ?? ZOEKT_HOT_DIR
+  const idleTtlMs = options?.idleTtlMs ?? PIN_IDLE_TTL_MS
+
+  await mkdir(hotDir, { recursive: true })
+  await mkdir(coldDir, { recursive: true })
+
+  for (const repo of repos) {
+    const basenames = await listColdBasenames(repo.repoName, coldDir)
+    for (const basename of basenames) {
+      await ensureSymlink(join(hotDir, basename), join(coldDir, basename))
+    }
+    armIdleTimer(repo.zoektRepoId, repo.repoName, idleTtlMs, coldDir, hotDir)
+  }
+}
+
+/**
+ * Re-link hot symlinks for a repo that is currently pinned (e.g. after reindex).
+ * No-op if the repo is not pinned.
+ */
+export async function refreshPinnedRepo(
+  repo: { zoektRepoId: number; repoName: string },
+  options?: { coldDir?: string; hotDir?: string; idleTtlMs?: number },
+): Promise<void> {
+  if (!pins.has(repo.zoektRepoId)) return
+  await pinRepos([repo], options)
+}
+
+/** Drop pin state and hot symlinks for a repo immediately (purge). */
+export async function unpinRepo(
+  repo: { zoektRepoId: number; repoName: string },
+  options?: { coldDir?: string; hotDir?: string },
+): Promise<void> {
+  const coldDir = options?.coldDir ?? ZOEKT_INDEX_DIR
+  const hotDir = options?.hotDir ?? ZOEKT_HOT_DIR
+  const existing = pins.get(repo.zoektRepoId)
+  if (existing) {
+    clearTimeout(existing.timer)
+    pins.delete(repo.zoektRepoId)
+  }
+  await removeHotSymlinks(repo.repoName, coldDir, hotDir)
+}
+
+export function isRepoPinned(zoektRepoId: number): boolean {
+  return pins.has(zoektRepoId)
+}
+
+/** Test helper: clear timers and pin map without touching the filesystem. */
+export function resetPinManagerForTests(): void {
+  for (const entry of pins.values()) clearTimeout(entry.timer)
+  pins.clear()
+}

--- a/apps/codesearch/src/domain/zoekt/shardPrefix.test.ts
+++ b/apps/codesearch/src/domain/zoekt/shardPrefix.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import {
+  isZoektShardBasenameForRepo,
+  zoektShardFilePrefix,
+} from "./shardPrefix.js"
+
+describe("zoektShardFilePrefix", () => {
+  it("matches zoekt url.QueryEscape style for owner/repo names", () => {
+    expect(zoektShardFilePrefix("kubernetes/kubernetes")).toBe(
+      "kubernetes%2Fkubernetes_",
+    )
+    expect(zoektShardFilePrefix("SOURCEDIGITAL/docker-swarm")).toBe(
+      "SOURCEDIGITAL%2Fdocker-swarm_",
+    )
+  })
+
+  it("does not use the old slash-to-underscore convention", () => {
+    expect(zoektShardFilePrefix("owner/repo")).not.toBe("owner_repo_")
+  })
+})
+
+describe("isZoektShardBasenameForRepo", () => {
+  it("matches multi-shard and .meta sidecars", () => {
+    const repo = "kubernetes/kubernetes"
+    expect(
+      isZoektShardBasenameForRepo(
+        "kubernetes%2Fkubernetes_v16.00000.zoekt",
+        repo,
+      ),
+    ).toBe(true)
+    expect(
+      isZoektShardBasenameForRepo(
+        "kubernetes%2Fkubernetes_v16.00002.zoekt",
+        repo,
+      ),
+    ).toBe(true)
+    expect(
+      isZoektShardBasenameForRepo(
+        "kubernetes%2Fkubernetes_v16.00000.zoekt.meta",
+        repo,
+      ),
+    ).toBe(true)
+  })
+
+  it("rejects other repos and non-shard files", () => {
+    const repo = "owner/repo"
+    expect(
+      isZoektShardBasenameForRepo("other%2Frepo_v16.00000.zoekt", repo),
+    ).toBe(false)
+    expect(isZoektShardBasenameForRepo("owner%2Frepo_v16.00000.txt", repo)).toBe(
+      false,
+    )
+  })
+})

--- a/apps/codesearch/src/domain/zoekt/shardPrefix.ts
+++ b/apps/codesearch/src/domain/zoekt/shardPrefix.ts
@@ -1,0 +1,21 @@
+/**
+ * Filename prefix that `zoekt-index` embeds for a repository Name.
+ * Upstream uses `url.QueryEscape` on the name before `_{v}{n}.zoekt`
+ * (see sourcegraph/zoekt index/shard_builder.go shardName).
+ *
+ * `encodeURIComponent` matches QueryEscape for typical `owner/repo` names
+ * (`/` → `%2F`). Example: `kubernetes/kubernetes` → `kubernetes%2Fkubernetes_`.
+ */
+export function zoektShardFilePrefix(repoName: string): string {
+  return `${encodeURIComponent(repoName)}_`
+}
+
+/** True if basename is a cold shard (or .meta sidecar) for repoName. */
+export function isZoektShardBasenameForRepo(
+  basename: string,
+  repoName: string,
+): boolean {
+  const prefix = zoektShardFilePrefix(repoName)
+  if (!basename.startsWith(prefix)) return false
+  return basename.endsWith(".zoekt") || basename.endsWith(".zoekt.meta")
+}

--- a/apps/codesearch/src/domain/zoekt/warmup.integration.test.ts
+++ b/apps/codesearch/src/domain/zoekt/warmup.integration.test.ts
@@ -1,0 +1,158 @@
+import { spawn, type ChildProcess } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { pinRepos, resetPinManagerForTests } from "./pinManager.js"
+import {
+  listLoadedZoektRepoIds,
+  waitUntilZoektReposLoaded,
+  ZoektWarmupTimeoutError,
+} from "./warmup.js"
+
+const hasZoekt = (() => {
+  const dirs = (process.env.PATH ?? "").split(":")
+  const find = (bin: string) => dirs.some((dir) => existsSync(join(dir, bin)))
+  return find("zoekt-index") && find("zoekt-webserver")
+})()
+
+describe.skipIf(!hasZoekt)(
+  "zoekt hot/cold warmup (real zoekt-webserver)",
+  () => {
+    let tmpDir: string
+    let coldDir: string
+    let hotDir: string
+    let srcDir: string
+    let webserver: ChildProcess | null = null
+    let baseUrl: string
+    const zoektRepoId = 42
+    const repoName = "owner/repo"
+
+    function run(cmd: string[], cwd?: string): Promise<void> {
+      return new Promise((resolve, reject) => {
+        const child = spawn(cmd[0]!, cmd.slice(1), {
+          cwd,
+          stdio: ["ignore", "pipe", "pipe"],
+        })
+        let stderr = ""
+        child.stderr?.on("data", (chunk: Buffer) => {
+          stderr += chunk.toString()
+        })
+        child.on("error", reject)
+        child.on("close", (code) => {
+          if (code === 0) resolve()
+          else reject(new Error(`${cmd.join(" ")} failed (${code}): ${stderr}`))
+        })
+      })
+    }
+
+    beforeAll(async () => {
+      tmpDir = await mkdtemp(join(tmpdir(), "zoekt-warmup-"))
+      coldDir = join(tmpDir, "zoekt-index")
+      hotDir = join(tmpDir, "zoekt-hot")
+      srcDir = join(tmpDir, "src")
+      await mkdir(coldDir, { recursive: true })
+      await mkdir(hotDir, { recursive: true })
+      await mkdir(srcDir, { recursive: true })
+      await writeFile(join(srcDir, "a.txt"), "hello needle world\n")
+
+      const metaPath = join(tmpDir, "meta.json")
+      await writeFile(
+        metaPath,
+        JSON.stringify({
+          ID: zoektRepoId,
+          Name: repoName,
+          URL: "https://example.com/owner/repo",
+          Source: srcDir,
+        }),
+      )
+
+      await run(["zoekt-index", "-index", coldDir, "-meta", metaPath, srcDir])
+
+      const port = 19000 + Math.floor(Math.random() * 1000)
+      baseUrl = `http://127.0.0.1:${port}`
+      webserver = spawn(
+        "zoekt-webserver",
+        ["-index", hotDir, "-rpc", "-listen", `:${port}`],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      )
+
+      const deadline = Date.now() + 10_000
+      while (Date.now() < deadline) {
+        try {
+          const loaded = await listLoadedZoektRepoIds(baseUrl)
+          expect(loaded.size).toBe(0)
+          return
+        } catch {
+          await new Promise((r) => setTimeout(r, 50))
+        }
+      }
+      throw new Error("zoekt-webserver did not become ready")
+    }, 60_000)
+
+    afterAll(async () => {
+      resetPinManagerForTests()
+      if (webserver) {
+        webserver.kill("SIGTERM")
+        await new Promise<void>((resolve) => {
+          webserver?.once("exit", () => resolve())
+          setTimeout(resolve, 2000)
+        })
+      }
+      if (tmpDir) await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    it("search stays empty until pin; warmup wait succeeds after pin", async () => {
+      resetPinManagerForTests()
+
+      const before = await fetch(`${baseUrl}/api/search`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ Q: "needle", RepoIDs: [zoektRepoId] }),
+      })
+      expect(before.ok).toBe(true)
+      const beforeBody = (await before.json()) as {
+        Result?: { ShardsScanned?: number; MatchCount?: number }
+      }
+      expect(beforeBody.Result?.ShardsScanned ?? 0).toBe(0)
+      expect(beforeBody.Result?.MatchCount ?? 0).toBe(0)
+
+      // Cold miss is not an HTTP error — list stays empty until pin.
+      await expect(
+        waitUntilZoektReposLoaded({
+          repoIds: [zoektRepoId],
+          baseUrl,
+          timeoutMs: 400,
+          pollIntervalMs: 50,
+        }),
+      ).rejects.toBeInstanceOf(ZoektWarmupTimeoutError)
+
+      const pinResults = await pinRepos([{ zoektRepoId, repoName }], {
+        coldDir,
+        hotDir,
+        idleTtlMs: 60_000,
+      })
+      expect(pinResults[0]?.shardCount).toBeGreaterThan(0)
+
+      await waitUntilZoektReposLoaded({
+        repoIds: [zoektRepoId],
+        baseUrl,
+        timeoutMs: 10_000,
+        pollIntervalMs: 50,
+      })
+
+      const after = await fetch(`${baseUrl}/api/search`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ Q: "needle", RepoIDs: [zoektRepoId] }),
+      })
+      expect(after.ok).toBe(true)
+      const afterBody = (await after.json()) as {
+        Result?: { ShardsScanned?: number; MatchCount?: number }
+      }
+      expect(afterBody.Result?.ShardsScanned ?? 0).toBeGreaterThan(0)
+      expect(afterBody.Result?.MatchCount ?? 0).toBeGreaterThan(0)
+    }, 30_000)
+  },
+)

--- a/apps/codesearch/src/domain/zoekt/warmup.test.ts
+++ b/apps/codesearch/src/domain/zoekt/warmup.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  waitUntilZoektReposLoaded,
+  ZoektWarmupTimeoutError,
+} from "./warmup.js"
+
+describe("waitUntilZoektReposLoaded", () => {
+  it("resolves once /api/list includes every expected repo id", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ List: { Repos: [] } }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            List: { Repos: [{ Repository: { ID: 1 } }] },
+          }),
+          { status: 200 },
+        ),
+      )
+    const sleepFn = vi.fn(async () => {})
+
+    await waitUntilZoektReposLoaded({
+      repoIds: [1],
+      baseUrl: "http://zoekt.test",
+      fetchFn,
+      sleepFn,
+      timeoutMs: 5_000,
+      pollIntervalMs: 1,
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(sleepFn).toHaveBeenCalled()
+  })
+
+  it("retries while Zoekt is unavailable then succeeds", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("connection refused"))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            List: { Repos: [{ Repository: { ID: 7 } }] },
+          }),
+          { status: 200 },
+        ),
+      )
+
+    await waitUntilZoektReposLoaded({
+      repoIds: [7],
+      baseUrl: "http://zoekt.test",
+      fetchFn,
+      sleepFn: async () => {},
+      timeoutMs: 5_000,
+      pollIntervalMs: 1,
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it("times out when repos never appear", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ List: { Repos: [] } }), { status: 200 }),
+    )
+
+    await expect(
+      waitUntilZoektReposLoaded({
+        repoIds: [1, 2],
+        baseUrl: "http://zoekt.test",
+        fetchFn,
+        sleepFn: async () => {},
+        timeoutMs: 5,
+        pollIntervalMs: 1,
+      }),
+    ).rejects.toBeInstanceOf(ZoektWarmupTimeoutError)
+  })
+
+  it("no-ops when there are no repo ids to wait for", async () => {
+    const fetchFn = vi.fn()
+    await waitUntilZoektReposLoaded({
+      repoIds: [],
+      fetchFn,
+    })
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/codesearch/src/domain/zoekt/warmup.ts
+++ b/apps/codesearch/src/domain/zoekt/warmup.ts
@@ -7,6 +7,17 @@ export class ZoektWarmupTimeoutError extends Error {
   }
 }
 
+/** Narrow fetch surface so tests can inject `vi.fn()` without `typeof fetch` friction. */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string
+    headers?: Record<string, string>
+    body?: string
+    signal?: AbortSignal
+  },
+) => Promise<Response>
+
 type ZoektListResponse = {
   List?: {
     Repos?: Array<{
@@ -15,14 +26,19 @@ type ZoektListResponse = {
   }
 }
 
+/** Default under the backend codesearch tool's 10s AbortSignal.timeout. */
+export const ZOEKT_WARMUP_TIMEOUT_MS = 8_000
+const LIST_FETCH_TIMEOUT_MS = 2_000
+
 export async function listLoadedZoektRepoIds(
   baseUrl: string = ZOEKT_WEBSERVER_URL,
-  fetchFn: typeof fetch = fetch,
+  fetchFn: FetchLike = fetch,
 ): Promise<Set<number>> {
   const res = await fetchFn(`${baseUrl}/api/list`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({}),
+    signal: AbortSignal.timeout(LIST_FETCH_TIMEOUT_MS),
   })
   if (!res.ok) {
     throw new Error(`Zoekt list returned status ${res.status}`)
@@ -46,14 +62,14 @@ export async function waitUntilZoektReposLoaded(params: {
   baseUrl?: string
   timeoutMs?: number
   pollIntervalMs?: number
-  fetchFn?: typeof fetch
+  fetchFn?: FetchLike
   sleepFn?: (ms: number) => Promise<void>
 }): Promise<void> {
   const expected = [...new Set(params.repoIds)].filter((id) => id > 0)
   if (expected.length === 0) return
 
   const baseUrl = params.baseUrl ?? ZOEKT_WEBSERVER_URL
-  const timeoutMs = params.timeoutMs ?? 30_000
+  const timeoutMs = params.timeoutMs ?? ZOEKT_WARMUP_TIMEOUT_MS
   const pollIntervalMs = params.pollIntervalMs ?? 100
   const fetchFn = params.fetchFn ?? fetch
   const sleepFn =
@@ -69,7 +85,9 @@ export async function waitUntilZoektReposLoaded(params: {
     } catch (error) {
       lastError = error
     }
-    await sleepFn(pollIntervalMs)
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) break
+    await sleepFn(Math.min(pollIntervalMs, remaining))
   }
 
   const detail =

--- a/apps/codesearch/src/domain/zoekt/warmup.ts
+++ b/apps/codesearch/src/domain/zoekt/warmup.ts
@@ -1,0 +1,80 @@
+import { ZOEKT_WEBSERVER_URL } from "../../config/paths.js"
+
+export class ZoektWarmupTimeoutError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "ZoektWarmupTimeoutError"
+  }
+}
+
+type ZoektListResponse = {
+  List?: {
+    Repos?: Array<{
+      Repository?: { ID?: number }
+    }>
+  }
+}
+
+export async function listLoadedZoektRepoIds(
+  baseUrl: string = ZOEKT_WEBSERVER_URL,
+  fetchFn: typeof fetch = fetch,
+): Promise<Set<number>> {
+  const res = await fetchFn(`${baseUrl}/api/list`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  })
+  if (!res.ok) {
+    throw new Error(`Zoekt list returned status ${res.status}`)
+  }
+  const data = (await res.json()) as ZoektListResponse
+  const ids = new Set<number>()
+  for (const entry of data.List?.Repos ?? []) {
+    const id = entry.Repository?.ID
+    if (typeof id === "number") ids.add(id)
+  }
+  return ids
+}
+
+/**
+ * Poll Zoekt `/api/list` until every expected repo id is loaded, or timeout.
+ * Call after pinning hot symlinks — Zoekt does not error on cold misses; it
+ * returns empty search results with ShardsScanned=0.
+ */
+export async function waitUntilZoektReposLoaded(params: {
+  repoIds: ReadonlyArray<number>
+  baseUrl?: string
+  timeoutMs?: number
+  pollIntervalMs?: number
+  fetchFn?: typeof fetch
+  sleepFn?: (ms: number) => Promise<void>
+}): Promise<void> {
+  const expected = [...new Set(params.repoIds)].filter((id) => id > 0)
+  if (expected.length === 0) return
+
+  const baseUrl = params.baseUrl ?? ZOEKT_WEBSERVER_URL
+  const timeoutMs = params.timeoutMs ?? 30_000
+  const pollIntervalMs = params.pollIntervalMs ?? 100
+  const fetchFn = params.fetchFn ?? fetch
+  const sleepFn =
+    params.sleepFn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const loaded = await listLoadedZoektRepoIds(baseUrl, fetchFn)
+      if (expected.every((id) => loaded.has(id))) return
+      lastError = undefined
+    } catch (error) {
+      lastError = error
+    }
+    await sleepFn(pollIntervalMs)
+  }
+
+  const detail =
+    lastError instanceof Error ? ` last error: ${lastError.message}` : ""
+  throw new ZoektWarmupTimeoutError(
+    `Zoekt did not load repo ids [${expected.join(", ")}] within ${timeoutMs}ms.${detail}`,
+  )
+}

--- a/apps/codesearch/src/domain/zoekt/warmup.ts
+++ b/apps/codesearch/src/domain/zoekt/warmup.ts
@@ -33,12 +33,13 @@ const LIST_FETCH_TIMEOUT_MS = 2_000
 export async function listLoadedZoektRepoIds(
   baseUrl: string = ZOEKT_WEBSERVER_URL,
   fetchFn: FetchLike = fetch,
+  fetchTimeoutMs: number = LIST_FETCH_TIMEOUT_MS,
 ): Promise<Set<number>> {
   const res = await fetchFn(`${baseUrl}/api/list`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({}),
-    signal: AbortSignal.timeout(LIST_FETCH_TIMEOUT_MS),
+    signal: AbortSignal.timeout(Math.max(1, fetchTimeoutMs)),
   })
   if (!res.ok) {
     throw new Error(`Zoekt list returned status ${res.status}`)
@@ -78,16 +79,22 @@ export async function waitUntilZoektReposLoaded(params: {
   const deadline = Date.now() + timeoutMs
   let lastError: unknown
   while (Date.now() < deadline) {
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) break
     try {
-      const loaded = await listLoadedZoektRepoIds(baseUrl, fetchFn)
+      const loaded = await listLoadedZoektRepoIds(
+        baseUrl,
+        fetchFn,
+        Math.min(LIST_FETCH_TIMEOUT_MS, remaining),
+      )
       if (expected.every((id) => loaded.has(id))) return
       lastError = undefined
     } catch (error) {
       lastError = error
     }
-    const remaining = deadline - Date.now()
-    if (remaining <= 0) break
-    await sleepFn(Math.min(pollIntervalMs, remaining))
+    const remainingAfter = deadline - Date.now()
+    if (remainingAfter <= 0) break
+    await sleepFn(Math.min(pollIntervalMs, remainingAfter))
   }
 
   const detail =

--- a/apps/codesearch/src/routes/search.test.ts
+++ b/apps/codesearch/src/routes/search.test.ts
@@ -1,0 +1,141 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { AppEnv } from "../app/env.js"
+
+const { pinReposMock, waitUntilMock } = vi.hoisted(() => ({
+  pinReposMock: vi.fn(),
+  waitUntilMock: vi.fn(),
+}))
+
+vi.mock("../domain/zoekt/pinManager.js", () => ({
+  pinRepos: pinReposMock,
+}))
+
+vi.mock("../domain/zoekt/warmup.js", async () => {
+  const actual = await vi.importActual<typeof import("../domain/zoekt/warmup.js")>(
+    "../domain/zoekt/warmup.js",
+  )
+  return {
+    ...actual,
+    waitUntilZoektReposLoaded: waitUntilMock,
+  }
+})
+
+vi.mock("../config/paths.js", () => ({
+  ZOEKT_WEBSERVER_URL: "http://zoekt.test",
+  ZOEKT_INDEX_DIR: "/cold",
+  ZOEKT_HOT_DIR: "/hot",
+  REPO_CACHE_DIR: "/cache",
+}))
+
+import { ZoektWarmupTimeoutError } from "../domain/zoekt/warmup.js"
+import { registerSearchRoutes } from "./search.js"
+
+function createTestApp(db: {
+  select: ReturnType<typeof vi.fn>
+}) {
+  const app = new OpenAPIHono<AppEnv>()
+  app.use("*", async (c, next) => {
+    c.set("db", db as unknown as AppEnv["Variables"]["db"])
+    c.set("env", { NODE_ENV: "test", PORT: 3001 } as AppEnv["Variables"]["env"])
+    c.set(
+      "auth",
+      {
+        sub: "user_test",
+        orgId: "org_mock123",
+        principal: "user",
+      } as AppEnv["Variables"]["auth"],
+    )
+    await next()
+  })
+  registerSearchRoutes(app)
+  return app
+}
+
+function mockDb(rows: Array<{ zoektRepoId: number; repoName: string }>) {
+  const where = vi.fn().mockResolvedValue(rows)
+  const innerJoin = vi.fn().mockReturnValue({ where })
+  const from = vi.fn().mockReturnValue({ innerJoin })
+  const select = vi.fn().mockReturnValue({ from })
+  return { select, where }
+}
+
+describe("POST /search", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pinReposMock.mockResolvedValue([
+      { zoektRepoId: 1, repoName: "owner/repo", shardCount: 1 },
+    ])
+    waitUntilMock.mockResolvedValue(undefined)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            Result: { Files: [], MatchCount: 0, ShardsScanned: 1 },
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+  })
+
+  it("pins repos and waits for Zoekt warmup before searching", async () => {
+    const db = mockDb([{ zoektRepoId: 1, repoName: "owner/repo" }])
+    const app = createTestApp(db)
+
+    const res = await app.request("/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ Q: "needle", RepoIDs: [1] }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(pinReposMock).toHaveBeenCalledWith([
+      { zoektRepoId: 1, repoName: "owner/repo" },
+    ])
+    expect(waitUntilMock).toHaveBeenCalledWith(
+      expect.objectContaining({ repoIds: [1] }),
+    )
+    expect(fetch).toHaveBeenCalledWith(
+      "http://zoekt.test/api/search",
+      expect.objectContaining({ method: "POST" }),
+    )
+  })
+
+  it("skips warmup wait when no cold shards were pinned", async () => {
+    pinReposMock.mockResolvedValue([
+      { zoektRepoId: 1, repoName: "owner/repo", shardCount: 0 },
+    ])
+    const db = mockDb([{ zoektRepoId: 1, repoName: "owner/repo" }])
+    const app = createTestApp(db)
+
+    const res = await app.request("/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ Q: "needle", RepoIDs: [1] }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(waitUntilMock).not.toHaveBeenCalled()
+  })
+
+  it("returns 503 when warmup times out", async () => {
+    waitUntilMock.mockRejectedValue(
+      new ZoektWarmupTimeoutError("Zoekt did not load repo ids [1]"),
+    )
+    const db = mockDb([{ zoektRepoId: 1, repoName: "owner/repo" }])
+    const app = createTestApp(db)
+
+    const res = await app.request("/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ Q: "needle", RepoIDs: [1] }),
+    })
+
+    expect(res.status).toBe(503)
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringContaining("did not load"),
+    })
+  })
+})

--- a/apps/codesearch/src/routes/search.ts
+++ b/apps/codesearch/src/routes/search.ts
@@ -5,6 +5,11 @@ import type { AppEnv } from "../app/env.js"
 import { ZOEKT_WEBSERVER_URL } from "../config/paths.js"
 import { DEFAULT_CHECKOUT_KEY } from "../domain/repositories/paths.js"
 import { repositories, repositoryCheckouts } from "../db/schema.js"
+import { pinRepos } from "../domain/zoekt/pinManager.js"
+import {
+  waitUntilZoektReposLoaded,
+  ZoektWarmupTimeoutError,
+} from "../domain/zoekt/warmup.js"
 
 const SearchRequestSchema = z
   .object({
@@ -58,7 +63,10 @@ export function registerSearchRoutes(app: OpenAPIHono<AppEnv>) {
     if (!auth) throw new Error("Missing auth context")
     const body = c.req.valid("json")
     const rows = await db
-      .select({ zoektRepoId: repositoryCheckouts.zoektRepoId })
+      .select({
+        zoektRepoId: repositoryCheckouts.zoektRepoId,
+        repoName: repositories.name,
+      })
       .from(repositories)
       .innerJoin(
         repositoryCheckouts,
@@ -74,7 +82,34 @@ export function registerSearchRoutes(app: OpenAPIHono<AppEnv>) {
         ? body.RepoIDs
         : orgRepoIds.length > 0
           ? orgRepoIds
-          : body.RepoIDs ?? []
+          : (body.RepoIDs ?? [])
+
+    const nameById = new Map(rows.map((r) => [r.zoektRepoId, r.repoName]))
+    const toPin = repoIds
+      .map((zoektRepoId) => {
+        const repoName = nameById.get(zoektRepoId)
+        return repoName ? { zoektRepoId, repoName } : null
+      })
+      .filter((r): r is { zoektRepoId: number; repoName: string } => r !== null)
+
+    try {
+      const pinResults = await pinRepos(toPin)
+      const waitForIds = pinResults
+        .filter((r) => r.shardCount > 0)
+        .map((r) => r.zoektRepoId)
+      if (waitForIds.length > 0) {
+        await waitUntilZoektReposLoaded({
+          repoIds: waitForIds,
+          baseUrl: ZOEKT_WEBSERVER_URL,
+        })
+      }
+    } catch (error) {
+      if (error instanceof ZoektWarmupTimeoutError) {
+        return c.json({ error: error.message }, 503)
+      }
+      return c.json({ error: "Zoekt webserver is unavailable" }, 503)
+    }
+
     const payload = {
       Q: body.Q,
       RepoIDs: repoIds,

--- a/apps/codesearch/src/routes/search.ts
+++ b/apps/codesearch/src/routes/search.ts
@@ -76,21 +76,18 @@ export function registerSearchRoutes(app: OpenAPIHono<AppEnv>) {
         ),
       )
       .where(eq(repositories.orgId, auth.orgId))
+    const nameById = new Map(rows.map((r) => [r.zoektRepoId, r.repoName]))
     const orgRepoIds = rows.map((r) => r.zoektRepoId)
-    const repoIds =
+    const requestedIds =
       body.RepoIDs?.length && body.RepoIDs.length > 0
         ? body.RepoIDs
-        : orgRepoIds.length > 0
-          ? orgRepoIds
-          : (body.RepoIDs ?? [])
-
-    const nameById = new Map(rows.map((r) => [r.zoektRepoId, r.repoName]))
-    const toPin = repoIds
-      .map((zoektRepoId) => {
-        const repoName = nameById.get(zoektRepoId)
-        return repoName ? { zoektRepoId, repoName } : null
-      })
-      .filter((r): r is { zoektRepoId: number; repoName: string } => r !== null)
+        : orgRepoIds
+    // Never forward another org's zoekt ids — intersect with org-owned rows.
+    const repoIds = requestedIds.filter((id) => nameById.has(id))
+    const toPin = repoIds.map((zoektRepoId) => ({
+      zoektRepoId,
+      repoName: nameById.get(zoektRepoId)!,
+    }))
 
     try {
       const pinResults = await pinRepos(toPin)

--- a/apps/codesearch/start.sh
+++ b/apps/codesearch/start.sh
@@ -1,10 +1,19 @@
 #!/bin/sh
 set -e
 
+# Cold durable shards (zoekt-index writes here). Hot is a sibling directory of
+# symlinks only — same derivation as apps/codesearch/src/config/paths.ts
+# (no separate env var for hot).
 ZOEKT_INDEX="${ZOEKT_INDEX_DIR:-/data/zoekt-index}"
+ZOEKT_HOT="$(dirname "$ZOEKT_INDEX")/zoekt-hot"
 
-echo "Starting zoekt-webserver on :6070 (index: $ZOEKT_INDEX)"
-zoekt-webserver -index "$ZOEKT_INDEX" -rpc -listen :6070 &
+mkdir -p "$ZOEKT_INDEX"
+# Restart with zero loaded shards so zoekt-webserver does not inherit stale pins.
+rm -rf "$ZOEKT_HOT"
+mkdir -p "$ZOEKT_HOT"
+
+echo "Starting zoekt-webserver on :6070 (hot index: $ZOEKT_HOT, cold: $ZOEKT_INDEX)"
+zoekt-webserver -index "$ZOEKT_HOT" -rpc -listen :6070 &
 ZOEKT_PID=$!
 
 # Forward SIGTERM/INT to both processes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Zoekt-webserver was loading every shard in `ZOEKT_INDEX_DIR`, so Railway PR memory climbed to ~12–20 GB with ~40 repos before kubernetes SCIP finished the kill. This PR adds **hot/cold Zoekt orchestration inside codesearch** (symlink pin on `/search`, 5 min idle unload) and keeps indexer peak mitigations (sequential Zoekt→SCIP, `GOMAXPROCS=2` / `GOGC=50`).

Stacked on `cursor/cgc-k8s-oom-plan-5b38` (SCIP cutover).

## Commits (C1–C6)

| | Scope |
|---|--------|
| C1 | `zoekt-hot` sibling path; `start.sh` serves/clears hot |
| C2 | QueryEscape shard prefix, pin/unpin, 5m TTL, concurrency safety |
| C3 | `/search` pin + `/api/list` warmup retry; real zoekt integration test |
| C4 | Atomic purge hot+cold; force-refresh pins after reindex |
| C5 | Sequential Zoekt→SCIP; indexer GOMAXPROCS/GOGC |
| C6 | Memory gate asserts empty hot + cold-only writes; provisional `MEMORY_MAX` |

## Behavior

- Cold: durable `.zoekt` under `ZOEKT_INDEX_DIR`
- Hot: `dirname(ZOEKT_INDEX_DIR)/zoekt-hot` (no new env) — symlinks only
- `/search`: org-scoped `RepoIDs` → pin → wait until Zoekt lists them → search
- Idle unload ~5 minutes after last pin (timer reset on each search)

## Verification

- `pnpm test:vitest` in `apps/codesearch`: **136 passed** (includes real `zoekt-webserver` warmup integration test when binaries on PATH)
- Manual kubernetes memory gate: script updated for hot/cold; **Docker unavailable in this agent VM**, so `MEMORY_MAX=5670m` kept as **provisional** — run `pnpm --filter @ctxpipe/codesearch test:manual:kubernetes-memory` where Docker works and update the ceiling from the printed peak.

## Follow-ups

- Re-calibrate `MEMORY_MAX` with Docker
- Pre-existing: backend may delete the repo row before codesearch purge runs (404)
- Live Railway re-validation after deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7960dcb9-f2e5-4b0b-b1de-263c87c5d69c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7960dcb9-f2e5-4b0b-b1de-263c87c5d69c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

