### PR TITLE
Add aws-cdk-self-host teardown for full sandbox cleanup

### DIFF
--- a/examples/aws-cdk-self-host/README.md
+++ b/examples/aws-cdk-self-host/README.md
@@ -68,11 +68,32 @@ pnpm --filter @ctxpipe/aws-cdk-self-host e2e:keep \
   -c orgSlug=... -c size=small -c domainName=... -c hostedZoneId=...
 ```
 
-Tear down later:
+Tear down later (stack only):
 
 ```bash
 pnpm --filter @ctxpipe/aws-cdk-self-host destroy
 ```
+
+Full teardown (recommended): delete the CloudFormation stack **and** purge retained leftovers (EFS, DB snapshots, Secrets recovery, stack log groups). Uses `DeleteStack` directly so it still works if `cdk destroy` cannot synth (for example after model-id validation drift).
+
+```bash
+# Preview first
+pnpm --filter @ctxpipe/aws-cdk-self-host teardown -- --dry-run
+
+# Apply
+pnpm --filter @ctxpipe/aws-cdk-self-host teardown
+```
+
+Useful flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `--dry-run` | Print actions only |
+| `--skip-destroy` | Only purge orphans (stack already deleted / deleting) |
+| `--purge-ses` | Also delete the SES email identity for the configured domain |
+| `-c stackName=…` | Override stack name (default `CtxpipeSelfHostE2E`) |
+
+`teardown` keeps the CDK bootstrap stack (`CDKToolkit`), the imported Route53 hosted zone, and SES identity (unless `--purge-ses`).
 
 If you override the stack name (`-c stackName=MyStack`), set the same name for smoke:
 
@@ -84,7 +105,7 @@ CDK_STACK_NAME=MyStack pnpm --filter @ctxpipe/aws-cdk-self-host smoke
 
 - `cdk deploy`: roughly 25–30 minutes on first run (Aurora, Neptune, SES custom resource).
 - `smoke`: polls every 15s for up to ~20 minutes (ECS and migrations).
-- `cdk destroy`: roughly 10–15 minutes.
+- `cdk destroy` / `teardown`: roughly 10–15 minutes for the stack delete, plus a short orphan-purge pass.
 
 ### When smoke fails
 
@@ -94,8 +115,8 @@ CDK_STACK_NAME=MyStack pnpm --filter @ctxpipe/aws-cdk-self-host smoke
 
 ## Cost note
 
-While the stack runs: NAT gateway, Aurora, Neptune, ALB, and Fargate are billed continuously—often on the order of a few dollars per hour in `us-east-1`. Destroy when finished.
+While the stack runs: NAT gateway, Aurora, Neptune, ALB, and Fargate are billed continuously—often on the order of a few dollars per hour in `us-east-1`. Destroy when finished. Prefer `pnpm teardown` so retained EFS and final DB snapshots do not keep accruing storage cost after destroy.
 
 ## Cleanup caveats
 
-The construct uses conservative removal policies: Aurora and Neptune may retain snapshots; EFS may be retained; SES identity may remain; Secrets Manager entries may sit in recovery. Clean those up in the console if you need a fully empty account.
+The construct uses conservative removal policies: Aurora and Neptune take final snapshots (`RemovalPolicy.SNAPSHOT`); codesearch EFS is retained (`RemovalPolicy.RETAIN`); Secrets Manager may sit in a recovery window; SES identity may remain. Use `pnpm teardown` instead of the console for those leftovers.

--- a/examples/aws-cdk-self-host/package.json
+++ b/examples/aws-cdk-self-host/package.json
@@ -9,6 +9,7 @@
     "synth": "pnpm cdk synth",
     "deploy": "pnpm cdk deploy --require-approval never",
     "destroy": "pnpm cdk destroy --force",
+    "teardown": "tsx scripts/teardown.ts",
     "smoke": "tsx scripts/smoke.ts",
     "e2e": "pnpm run deploy && pnpm run smoke && pnpm run destroy",
     "e2e:keep": "pnpm run deploy && pnpm run smoke",
@@ -16,6 +17,15 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.700.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.700.0",
+    "@aws-sdk/client-ec2": "^3.700.0",
+    "@aws-sdk/client-ecs": "^3.700.0",
+    "@aws-sdk/client-efs": "^3.700.0",
+    "@aws-sdk/client-elastic-load-balancing-v2": "^3.700.0",
+    "@aws-sdk/client-neptune": "^3.700.0",
+    "@aws-sdk/client-rds": "^3.700.0",
+    "@aws-sdk/client-secrets-manager": "^3.700.0",
+    "@aws-sdk/client-sesv2": "^3.700.0",
     "@ctxpipe/aws-cdk": "workspace:*",
     "aws-cdk-lib": "^2.260.0",
     "constructs": "^10.6.0"

--- a/examples/aws-cdk-self-host/scripts/teardown.ts
+++ b/examples/aws-cdk-self-host/scripts/teardown.ts
@@ -1,0 +1,741 @@
+#!/usr/bin/env npx tsx
+/**
+ * Destroy the aws-cdk-self-host CloudFormation stack and purge known leftovers
+ * that CDK RemovalPolicy leaves behind (EFS RETAIN, Aurora/Neptune SNAPSHOT,
+ * Secrets Manager recovery, orphan log groups).
+ *
+ * Usage:
+ *   pnpm --filter @ctxpipe/aws-cdk-self-host teardown
+ *   pnpm --filter @ctxpipe/aws-cdk-self-host teardown -- --dry-run
+ *   pnpm --filter @ctxpipe/aws-cdk-self-host teardown -- --purge-ses
+ *   pnpm --filter @ctxpipe/aws-cdk-self-host teardown -- -c stackName=MyStack
+ */
+import {
+  CloudFormationClient,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+  ListStackResourcesCommand,
+  type StackResourceSummary,
+} from "@aws-sdk/client-cloudformation";
+import {
+  CloudWatchLogsClient,
+  DeleteLogGroupCommand,
+  DescribeLogGroupsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  DescribeNatGatewaysCommand,
+  EC2Client,
+} from "@aws-sdk/client-ec2";
+import {
+  DescribeServicesCommand,
+  ECSClient,
+  ListClustersCommand,
+  ListServicesCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  DeleteFileSystemCommand,
+  DeleteMountTargetCommand,
+  DescribeFileSystemsCommand,
+  DescribeMountTargetsCommand,
+  EFSClient,
+} from "@aws-sdk/client-efs";
+import {
+  DescribeLoadBalancersCommand,
+  ElasticLoadBalancingV2Client,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  DeleteDBClusterSnapshotCommand,
+  DescribeDBClusterSnapshotsCommand,
+  DescribeDBClustersCommand,
+  RDSClient,
+} from "@aws-sdk/client-rds";
+import {
+  DeleteDBClusterSnapshotCommand as DeleteNeptuneSnapshotCommand,
+  DescribeDBClusterSnapshotsCommand as DescribeNeptuneSnapshotsCommand,
+  DescribeDBClustersCommand as DescribeNeptuneClustersCommand,
+  NeptuneClient,
+} from "@aws-sdk/client-neptune";
+import {
+  DeleteSecretCommand,
+  DescribeSecretCommand,
+  ListSecretsCommand,
+  SecretsManagerClient,
+} from "@aws-sdk/client-secrets-manager";
+import {
+  DeleteEmailIdentityCommand,
+  SESv2Client,
+} from "@aws-sdk/client-sesv2";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type StackInventory = {
+  efsIds: string[];
+  rdsClusterIds: string[];
+  neptuneClusterIds: string[];
+  secretArns: string[];
+  logGroupNames: string[];
+  lambdaNames: string[];
+  vpcId: string | undefined;
+};
+
+type CliOptions = {
+  dryRun: boolean;
+  purgeSes: boolean;
+  skipDestroy: boolean;
+  stackName: string;
+  domainName: string | undefined;
+};
+
+const packageRoot = join(__dirname, "..");
+
+function parseArgs(argv: string[]): CliOptions {
+  const dryRun = argv.includes("--dry-run");
+  const purgeSes = argv.includes("--purge-ses");
+  const skipDestroy = argv.includes("--skip-destroy");
+
+  let stackName =
+    process.env.CDK_STACK_NAME?.trim() ||
+    process.env.STACK_NAME?.trim() ||
+    "";
+  let domainName = process.env.DOMAIN_NAME?.trim() || "";
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "-c" || arg === "--context") {
+      const value = argv[i + 1];
+      if (!value) continue;
+      i++;
+      const eq = value.indexOf("=");
+      if (eq <= 0) continue;
+      const key = value.slice(0, eq);
+      const val = value.slice(eq + 1);
+      if (key === "stackName" && val) stackName = val;
+      if (key === "domainName" && val) domainName = val;
+      continue;
+    }
+    if (arg.startsWith("-c") && arg.includes("=")) {
+      const value = arg.slice(2);
+      const eq = value.indexOf("=");
+      if (eq <= 0) continue;
+      const key = value.slice(0, eq);
+      const val = value.slice(eq + 1);
+      if (key === "stackName" && val) stackName = val;
+      if (key === "domainName" && val) domainName = val;
+    }
+  }
+
+  if (!stackName || !domainName) {
+    try {
+      const cdkJson = JSON.parse(
+        readFileSync(join(packageRoot, "cdk.json"), "utf8"),
+      ) as { context?: Record<string, unknown> };
+      if (!stackName && typeof cdkJson.context?.stackName === "string") {
+        stackName = cdkJson.context.stackName;
+      }
+      if (!domainName && typeof cdkJson.context?.domainName === "string") {
+        domainName = cdkJson.context.domainName;
+      }
+    } catch {
+      // ignore missing cdk.json
+    }
+  }
+
+  return {
+    dryRun,
+    purgeSes,
+    skipDestroy,
+    stackName: stackName || "CtxpipeSelfHostE2E",
+    domainName: domainName || undefined,
+  };
+}
+
+function log(message: string): void {
+  console.log(message);
+}
+
+function region(): string {
+  return (
+    process.env.AWS_REGION?.trim() ||
+    process.env.AWS_DEFAULT_REGION?.trim() ||
+    process.env.CDK_DEFAULT_REGION?.trim() ||
+    "us-east-1"
+  );
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function stackExists(
+  cfn: CloudFormationClient,
+  stackName: string,
+): Promise<boolean> {
+  try {
+    const out = await cfn.send(new DescribeStacksCommand({ StackName: stackName }));
+    const status = out.Stacks?.[0]?.StackStatus;
+    if (!status) return false;
+    return !status.startsWith("DELETE_COMPLETE");
+  } catch (error) {
+    const name = (error as { name?: string }).name;
+    if (name === "ValidationError") return false;
+    throw error;
+  }
+}
+
+async function waitForStackDeleted(
+  cfn: CloudFormationClient,
+  stackName: string,
+): Promise<void> {
+  for (;;) {
+    const exists = await stackExists(cfn, stackName);
+    if (!exists) {
+      log(`Stack ${stackName} is gone.`);
+      return;
+    }
+    const out = await cfn.send(new DescribeStacksCommand({ StackName: stackName }));
+    const status = out.Stacks?.[0]?.StackStatus ?? "UNKNOWN";
+    log(`Waiting for stack delete… ${status}`);
+    if (status === "DELETE_FAILED") {
+      throw new Error(
+        `Stack ${stackName} entered DELETE_FAILED. Fix blockers in the console and re-run teardown.`,
+      );
+    }
+    await sleep(15_000);
+  }
+}
+
+async function listAllStackResources(
+  cfn: CloudFormationClient,
+  stackName: string,
+): Promise<StackResourceSummary[]> {
+  const resources: StackResourceSummary[] = [];
+  let nextToken: string | undefined;
+  do {
+    const page = await cfn.send(
+      new ListStackResourcesCommand({
+        StackName: stackName,
+        NextToken: nextToken,
+      }),
+    );
+    resources.push(...(page.StackResourceSummaries ?? []));
+    nextToken = page.NextToken;
+  } while (nextToken);
+  return resources;
+}
+
+function inventoryFromResources(resources: StackResourceSummary[]): StackInventory {
+  const efsIds: string[] = [];
+  const rdsClusterIds: string[] = [];
+  const neptuneClusterIds: string[] = [];
+  const secretArns: string[] = [];
+  const logGroupNames: string[] = [];
+  const lambdaNames: string[] = [];
+  let vpcId: string | undefined;
+
+  for (const resource of resources) {
+    const type = resource.ResourceType;
+    const id = resource.PhysicalResourceId;
+    if (!type || !id) continue;
+
+    switch (type) {
+      case "AWS::EFS::FileSystem":
+        efsIds.push(id);
+        break;
+      case "AWS::RDS::DBCluster":
+        rdsClusterIds.push(id);
+        break;
+      case "AWS::Neptune::DBCluster":
+        neptuneClusterIds.push(id);
+        break;
+      case "AWS::SecretsManager::Secret":
+        secretArns.push(id);
+        break;
+      case "AWS::Logs::LogGroup":
+        logGroupNames.push(id);
+        break;
+      case "AWS::Lambda::Function":
+        lambdaNames.push(id);
+        logGroupNames.push(`/aws/lambda/${id}`);
+        break;
+      case "AWS::EC2::VPC":
+        vpcId = id;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {
+    efsIds: [...new Set(efsIds)],
+    rdsClusterIds: [...new Set(rdsClusterIds)],
+    neptuneClusterIds: [...new Set(neptuneClusterIds)],
+    secretArns: [...new Set(secretArns)],
+    logGroupNames: [...new Set(logGroupNames)],
+    lambdaNames: [...new Set(lambdaNames)],
+    vpcId,
+  };
+}
+
+async function discoverRetainedEfs(
+  efs: EFSClient,
+  stackName: string,
+  knownIds: string[],
+): Promise<string[]> {
+  const ids = new Set(knownIds);
+  let marker: string | undefined;
+  do {
+    const page = await efs.send(new DescribeFileSystemsCommand({ Marker: marker }));
+    for (const fs of page.FileSystems ?? []) {
+      const name = fs.Name ?? "";
+      const id = fs.FileSystemId;
+      if (!id) continue;
+      // CDK Name tag for nested constructs: Stack/CtxPipe/DataPlane/CodesearchEfs
+      if (name.startsWith(`${stackName}/`) || name.includes(`/${stackName}/`)) {
+        ids.add(id);
+      }
+    }
+    marker = page.NextMarker;
+  } while (marker);
+  return [...ids];
+}
+
+async function discoverSecretsForStack(
+  secrets: SecretsManagerClient,
+  stackName: string,
+  knownArns: string[],
+): Promise<string[]> {
+  const arns = new Set(knownArns);
+  let nextToken: string | undefined;
+  do {
+    const page = await secrets.send(
+      new ListSecretsCommand({
+        IncludePlannedDeletion: true,
+        NextToken: nextToken,
+      }),
+    );
+    for (const secret of page.SecretList ?? []) {
+      const name = secret.Name ?? "";
+      const arn = secret.ARN;
+      if (!arn) continue;
+      const owningStack = secret.Tags?.find(
+        (tag) => tag.Key === "aws:cloudformation:stack-name",
+      )?.Value;
+      if (
+        owningStack === stackName ||
+        name.includes(stackName) ||
+        name.startsWith("CtxPipe")
+      ) {
+        arns.add(arn);
+      }
+    }
+    nextToken = page.NextToken;
+  } while (nextToken);
+  return [...arns];
+}
+
+/**
+ * Prefer CloudFormation DeleteStack over `cdk destroy` so teardown still works
+ * when the current app synth fails validation (e.g. model id drift) but the
+ * stack already exists in the account.
+ */
+async function deleteCloudFormationStack(
+  cfn: CloudFormationClient,
+  stackName: string,
+  dryRun: boolean,
+): Promise<void> {
+  if (dryRun) {
+    log(`[dry-run] would DeleteStack ${stackName}`);
+    return;
+  }
+  log(`Deleting CloudFormation stack ${stackName}…`);
+  await cfn.send(new DeleteStackCommand({ StackName: stackName }));
+}
+
+async function deleteEfsFilesystem(
+  efs: EFSClient,
+  fileSystemId: string,
+  dryRun: boolean,
+): Promise<void> {
+  if (dryRun) {
+    log(`[dry-run] would delete EFS ${fileSystemId}`);
+    return;
+  }
+  log(`Deleting EFS ${fileSystemId}…`);
+  const mounts = await efs.send(
+    new DescribeMountTargetsCommand({ FileSystemId: fileSystemId }),
+  );
+  for (const mt of mounts.MountTargets ?? []) {
+    if (!mt.MountTargetId) continue;
+    log(`  deleting mount target ${mt.MountTargetId}`);
+    await efs.send(new DeleteMountTargetCommand({ MountTargetId: mt.MountTargetId }));
+  }
+
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const remaining = await efs.send(
+      new DescribeMountTargetsCommand({ FileSystemId: fileSystemId }),
+    );
+    if ((remaining.MountTargets ?? []).length === 0) break;
+    await sleep(5_000);
+  }
+
+  await efs.send(new DeleteFileSystemCommand({ FileSystemId: fileSystemId }));
+  log(`  deleted EFS ${fileSystemId}`);
+}
+
+async function deleteRdsSnapshotsForClusters(
+  rds: RDSClient,
+  clusterIds: string[],
+  dryRun: boolean,
+): Promise<void> {
+  if (clusterIds.length === 0) return;
+  const snaps = await rds.send(new DescribeDBClusterSnapshotsCommand({}));
+  for (const snap of snaps.DBClusterSnapshots ?? []) {
+    const id = snap.DBClusterSnapshotIdentifier;
+    const source = snap.DBClusterIdentifier;
+    if (!id || !source || !clusterIds.includes(source)) continue;
+    if (dryRun) {
+      log(`[dry-run] would delete RDS cluster snapshot ${id}`);
+      continue;
+    }
+    log(`Deleting RDS cluster snapshot ${id}…`);
+    await rds.send(
+      new DeleteDBClusterSnapshotCommand({ DBClusterSnapshotIdentifier: id }),
+    );
+  }
+}
+
+async function deleteNeptuneSnapshotsForClusters(
+  neptune: NeptuneClient,
+  clusterIds: string[],
+  dryRun: boolean,
+): Promise<void> {
+  if (clusterIds.length === 0) return;
+  const snaps = await neptune.send(new DescribeNeptuneSnapshotsCommand({}));
+  for (const snap of snaps.DBClusterSnapshots ?? []) {
+    const id = snap.DBClusterSnapshotIdentifier;
+    const source = snap.DBClusterIdentifier;
+    if (!id || !source || !clusterIds.includes(source)) continue;
+    if (dryRun) {
+      log(`[dry-run] would delete Neptune cluster snapshot ${id}`);
+      continue;
+    }
+    log(`Deleting Neptune cluster snapshot ${id}…`);
+    await neptune.send(
+      new DeleteNeptuneSnapshotCommand({ DBClusterSnapshotIdentifier: id }),
+    );
+  }
+}
+
+async function forceDeleteSecret(
+  secrets: SecretsManagerClient,
+  secretArn: string,
+  dryRun: boolean,
+): Promise<void> {
+  if (dryRun) {
+    log(`[dry-run] would force-delete secret ${secretArn}`);
+    return;
+  }
+  try {
+    const described = await secrets.send(
+      new DescribeSecretCommand({ SecretId: secretArn }),
+    );
+    log(`Force-deleting secret ${described.Name ?? secretArn}…`);
+    await secrets.send(
+      new DeleteSecretCommand({
+        SecretId: secretArn,
+        ForceDeleteWithoutRecovery: true,
+      }),
+    );
+  } catch (error) {
+    const name = (error as { name?: string }).name;
+    if (name === "ResourceNotFoundException") {
+      log(`  secret already gone: ${secretArn}`);
+      return;
+    }
+    throw error;
+  }
+}
+
+async function deleteLogGroup(
+  logs: CloudWatchLogsClient,
+  logGroupName: string,
+  dryRun: boolean,
+): Promise<void> {
+  if (dryRun) {
+    log(`[dry-run] would delete log group ${logGroupName}`);
+    return;
+  }
+  try {
+    await logs.send(new DeleteLogGroupCommand({ logGroupName }));
+    log(`Deleted log group ${logGroupName}`);
+  } catch (error) {
+    const name = (error as { name?: string }).name;
+    if (name === "ResourceNotFoundException") return;
+    throw error;
+  }
+}
+
+async function discoverOrphanLogGroups(
+  logs: CloudWatchLogsClient,
+  stackName: string,
+  known: string[],
+): Promise<string[]> {
+  const names = new Set(known);
+  let nextToken: string | undefined;
+  do {
+    const page = await logs.send(
+      new DescribeLogGroupsCommand({
+        logGroupNamePrefix: stackName,
+        nextToken,
+      }),
+    );
+    for (const group of page.logGroups ?? []) {
+      if (group.logGroupName) names.add(group.logGroupName);
+    }
+    nextToken = page.nextToken;
+  } while (nextToken);
+  return [...names];
+}
+
+async function purgeSesIdentity(
+  ses: SESv2Client,
+  domainName: string | undefined,
+  dryRun: boolean,
+): Promise<void> {
+  if (!domainName) {
+    log("Skipping SES purge: no domainName configured.");
+    return;
+  }
+  // SES identity is typically the parent zone (e.g. aws.ctxpipe.ai for app.aws.ctxpipe.ai)
+  const parts = domainName.split(".");
+  const identity =
+    parts.length > 2 ? parts.slice(1).join(".") : domainName;
+  if (dryRun) {
+    log(`[dry-run] would delete SES email identity ${identity}`);
+    return;
+  }
+  log(`Deleting SES email identity ${identity}…`);
+  try {
+    await ses.send(new DeleteEmailIdentityCommand({ EmailIdentity: identity }));
+  } catch (error) {
+    const name = (error as { name?: string }).name;
+    if (name === "NotFoundException") {
+      log(`  SES identity already gone: ${identity}`);
+      return;
+    }
+    throw error;
+  }
+}
+
+async function verifyCostSensitiveGone(opts: {
+  stackName: string;
+  vpcId: string | undefined;
+  rdsClusterIds: string[];
+  neptuneClusterIds: string[];
+}): Promise<string[]> {
+  const problems: string[] = [];
+  const ec2 = new EC2Client({ region: region() });
+  const rds = new RDSClient({ region: region() });
+  const neptune = new NeptuneClient({ region: region() });
+  const elbv2 = new ElasticLoadBalancingV2Client({ region: region() });
+  const ecs = new ECSClient({ region: region() });
+
+  const nats = await ec2.send(
+    new DescribeNatGatewaysCommand({
+      Filter: [{ Name: "state", Values: ["available", "pending", "deleting"] }],
+    }),
+  );
+  for (const nat of nats.NatGateways ?? []) {
+    if (opts.vpcId && nat.VpcId === opts.vpcId) {
+      problems.push(`NAT gateway still present: ${nat.NatGatewayId} (${nat.State})`);
+    }
+  }
+
+  const rdsClusters = await rds.send(new DescribeDBClustersCommand({}));
+  for (const cluster of rdsClusters.DBClusters ?? []) {
+    const id = cluster.DBClusterIdentifier;
+    if (!id) continue;
+    if (
+      opts.rdsClusterIds.includes(id) ||
+      id.toLowerCase().includes(opts.stackName.toLowerCase())
+    ) {
+      problems.push(`RDS/Aurora cluster still present: ${id} (${cluster.Status})`);
+    }
+  }
+
+  const neptuneClusters = await neptune.send(new DescribeNeptuneClustersCommand({}));
+  for (const cluster of neptuneClusters.DBClusters ?? []) {
+    const id = cluster.DBClusterIdentifier;
+    if (!id) continue;
+    if (opts.neptuneClusterIds.includes(id)) {
+      problems.push(`Neptune cluster still present: ${id} (${cluster.Status})`);
+    }
+  }
+
+  const lbs = await elbv2.send(new DescribeLoadBalancersCommand({}));
+  for (const lb of lbs.LoadBalancers ?? []) {
+    if (opts.vpcId && lb.VpcId === opts.vpcId) {
+      problems.push(`ALB still present: ${lb.LoadBalancerName}`);
+    }
+  }
+
+  const clusters = await ecs.send(new ListClustersCommand({}));
+  for (const clusterArn of clusters.clusterArns ?? []) {
+    if (!clusterArn.includes(opts.stackName)) continue;
+    const services = await ecs.send(
+      new ListServicesCommand({ cluster: clusterArn }),
+    );
+    if ((services.serviceArns ?? []).length === 0) continue;
+    const described = await ecs.send(
+      new DescribeServicesCommand({
+        cluster: clusterArn,
+        services: services.serviceArns,
+      }),
+    );
+    for (const service of described.services ?? []) {
+      if ((service.desiredCount ?? 0) > 0 || (service.runningCount ?? 0) > 0) {
+        problems.push(
+          `ECS service still active: ${service.serviceName} (desired=${service.desiredCount}, running=${service.runningCount})`,
+        );
+      }
+    }
+  }
+
+  return problems;
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const awsRegion = region();
+  log(`Teardown target stack=${opts.stackName} region=${awsRegion} dryRun=${opts.dryRun}`);
+
+  const cfn = new CloudFormationClient({ region: awsRegion });
+  const efs = new EFSClient({ region: awsRegion });
+  const rds = new RDSClient({ region: awsRegion });
+  const neptune = new NeptuneClient({ region: awsRegion });
+  const secrets = new SecretsManagerClient({ region: awsRegion });
+  const logs = new CloudWatchLogsClient({ region: awsRegion });
+  const ses = new SESv2Client({ region: awsRegion });
+
+  let inventory: StackInventory = {
+    efsIds: [],
+    rdsClusterIds: [],
+    neptuneClusterIds: [],
+    secretArns: [],
+    logGroupNames: [],
+    lambdaNames: [],
+    vpcId: undefined,
+  };
+
+  const exists = await stackExists(cfn, opts.stackName);
+  if (exists) {
+    log(`Capturing resources from live stack ${opts.stackName}…`);
+    inventory = inventoryFromResources(
+      await listAllStackResources(cfn, opts.stackName),
+    );
+  } else {
+    log(`Stack ${opts.stackName} is not present; will purge orphans by name.`);
+  }
+
+  inventory.efsIds = await discoverRetainedEfs(efs, opts.stackName, inventory.efsIds);
+  inventory.secretArns = await discoverSecretsForStack(
+    secrets,
+    opts.stackName,
+    inventory.secretArns,
+  );
+  inventory.logGroupNames = await discoverOrphanLogGroups(
+    logs,
+    opts.stackName,
+    inventory.logGroupNames,
+  );
+
+  log("Inventory:");
+  log(`  EFS: ${inventory.efsIds.join(", ") || "(none)"}`);
+  log(`  Aurora clusters: ${inventory.rdsClusterIds.join(", ") || "(none)"}`);
+  log(`  Neptune clusters: ${inventory.neptuneClusterIds.join(", ") || "(none)"}`);
+  log(`  Secrets: ${inventory.secretArns.length}`);
+  log(`  Log groups: ${inventory.logGroupNames.length}`);
+  log(`  VPC: ${inventory.vpcId ?? "(unknown)"}`);
+
+  if (exists && !opts.skipDestroy) {
+    await deleteCloudFormationStack(cfn, opts.stackName, opts.dryRun);
+    if (!opts.dryRun) {
+      await waitForStackDeleted(cfn, opts.stackName);
+    }
+  } else if (exists && opts.skipDestroy) {
+    log("Skipping stack delete (--skip-destroy).");
+  }
+
+  for (const efsId of inventory.efsIds) {
+    await deleteEfsFilesystem(efs, efsId, opts.dryRun);
+  }
+
+  await deleteRdsSnapshotsForClusters(rds, inventory.rdsClusterIds, opts.dryRun);
+  await deleteNeptuneSnapshotsForClusters(
+    neptune,
+    inventory.neptuneClusterIds,
+    opts.dryRun,
+  );
+
+  // Also delete any final snapshots whose identifier embeds the stack name
+  // (covers destroys that already completed before this script captured IDs).
+  if (inventory.rdsClusterIds.length === 0) {
+    const snaps = await rds.send(new DescribeDBClusterSnapshotsCommand({}));
+    for (const snap of snaps.DBClusterSnapshots ?? []) {
+      const id = snap.DBClusterSnapshotIdentifier ?? "";
+      const source = snap.DBClusterIdentifier ?? "";
+      if (
+        !id.toLowerCase().includes(opts.stackName.toLowerCase()) &&
+        !source.toLowerCase().includes(opts.stackName.toLowerCase())
+      ) {
+        continue;
+      }
+      if (opts.dryRun) {
+        log(`[dry-run] would delete RDS cluster snapshot ${id}`);
+        continue;
+      }
+      log(`Deleting RDS cluster snapshot ${id}…`);
+      await rds.send(
+        new DeleteDBClusterSnapshotCommand({ DBClusterSnapshotIdentifier: id }),
+      );
+    }
+  }
+
+  for (const secretArn of inventory.secretArns) {
+    await forceDeleteSecret(secrets, secretArn, opts.dryRun);
+  }
+
+  for (const logGroupName of inventory.logGroupNames) {
+    await deleteLogGroup(logs, logGroupName, opts.dryRun);
+  }
+
+  if (opts.purgeSes) {
+    await purgeSesIdentity(ses, opts.domainName, opts.dryRun);
+  } else {
+    log("Keeping SES identity (pass --purge-ses to remove).");
+  }
+
+  if (opts.dryRun) {
+    log("Dry-run complete. Re-run without --dry-run to apply.");
+    return;
+  }
+
+  const problems = await verifyCostSensitiveGone({
+    stackName: opts.stackName,
+    vpcId: inventory.vpcId,
+    rdsClusterIds: inventory.rdsClusterIds,
+    neptuneClusterIds: inventory.neptuneClusterIds,
+  });
+  if (problems.length > 0) {
+    for (const problem of problems) log(`VERIFY FAIL: ${problem}`);
+    process.exitCode = 1;
+    return;
+  }
+  log("Teardown complete. Cost-sensitive resources look clear.");
+  log("Kept: CDKToolkit bootstrap stack, Route53 hosted zone, SES identity (unless --purge-ses).");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/examples/aws-cdk-self-host/scripts/teardown.ts
+++ b/examples/aws-cdk-self-host/scripts/teardown.ts
@@ -89,9 +89,11 @@ type CliOptions = {
 const packageRoot = join(__dirname, "..");
 
 function parseArgs(argv: string[]): CliOptions {
-  const dryRun = argv.includes("--dry-run");
-  const purgeSes = argv.includes("--purge-ses");
-  const skipDestroy = argv.includes("--skip-destroy");
+  // pnpm may forward a literal `--` before script flags.
+  const args = argv.filter((arg) => arg !== "--");
+  const dryRun = args.includes("--dry-run");
+  const purgeSes = args.includes("--purge-ses");
+  const skipDestroy = args.includes("--skip-destroy");
 
   let stackName =
     process.env.CDK_STACK_NAME?.trim() ||
@@ -99,10 +101,10 @@ function parseArgs(argv: string[]): CliOptions {
     "";
   let domainName = process.env.DOMAIN_NAME?.trim() || "";
 
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
     if (arg === "-c" || arg === "--context") {
-      const value = argv[i + 1];
+      const value = args[i + 1];
       if (!value) continue;
       i++;
       const eq = value.indexOf("=");
@@ -382,6 +384,17 @@ async function deleteEfsFilesystem(
   log(`  deleted EFS ${fileSystemId}`);
 }
 
+function isDeletableClusterSnapshot(snap: {
+  DBClusterSnapshotIdentifier?: string;
+  SnapshotType?: string;
+}): boolean {
+  const id = snap.DBClusterSnapshotIdentifier ?? "";
+  // Automated system snapshots (`rds:…`) cannot be deleted via DeleteDBClusterSnapshot.
+  if (id.startsWith("rds:")) return false;
+  if (snap.SnapshotType && snap.SnapshotType !== "manual") return false;
+  return true;
+}
+
 async function deleteRdsSnapshotsForClusters(
   rds: RDSClient,
   clusterIds: string[],
@@ -393,6 +406,10 @@ async function deleteRdsSnapshotsForClusters(
     const id = snap.DBClusterSnapshotIdentifier;
     const source = snap.DBClusterIdentifier;
     if (!id || !source || !clusterIds.includes(source)) continue;
+    if (!isDeletableClusterSnapshot(snap)) {
+      log(`Skipping non-manual RDS snapshot ${id}`);
+      continue;
+    }
     if (dryRun) {
       log(`[dry-run] would delete RDS cluster snapshot ${id}`);
       continue;
@@ -415,6 +432,10 @@ async function deleteNeptuneSnapshotsForClusters(
     const id = snap.DBClusterSnapshotIdentifier;
     const source = snap.DBClusterIdentifier;
     if (!id || !source || !clusterIds.includes(source)) continue;
+    if (!isDeletableClusterSnapshot(snap)) {
+      log(`Skipping non-manual Neptune snapshot ${id}`);
+      continue;
+    }
     if (dryRun) {
       log(`[dry-run] would delete Neptune cluster snapshot ${id}`);
       continue;
@@ -481,19 +502,21 @@ async function discoverOrphanLogGroups(
   known: string[],
 ): Promise<string[]> {
   const names = new Set(known);
-  let nextToken: string | undefined;
-  do {
-    const page = await logs.send(
-      new DescribeLogGroupsCommand({
-        logGroupNamePrefix: stackName,
-        nextToken,
-      }),
-    );
-    for (const group of page.logGroups ?? []) {
-      if (group.logGroupName) names.add(group.logGroupName);
-    }
-    nextToken = page.nextToken;
-  } while (nextToken);
+  for (const prefix of [stackName, `/aws/lambda/${stackName}`]) {
+    let nextToken: string | undefined;
+    do {
+      const page = await logs.send(
+        new DescribeLogGroupsCommand({
+          logGroupNamePrefix: prefix,
+          nextToken,
+        }),
+      );
+      for (const group of page.logGroups ?? []) {
+        if (group.logGroupName) names.add(group.logGroupName);
+      }
+      nextToken = page.nextToken;
+    } while (nextToken);
+  }
   return [...names];
 }
 
@@ -677,17 +700,22 @@ async function main(): Promise<void> {
     opts.dryRun,
   );
 
-  // Also delete any final snapshots whose identifier embeds the stack name
-  // (covers destroys that already completed before this script captured IDs).
-  if (inventory.rdsClusterIds.length === 0) {
-    const snaps = await rds.send(new DescribeDBClusterSnapshotsCommand({}));
-    for (const snap of snaps.DBClusterSnapshots ?? []) {
+  // Name-based snapshot sweep for orphans after the stack is already gone.
+  {
+    const stackNeedle = opts.stackName.toLowerCase();
+    const rdsSnaps = await rds.send(new DescribeDBClusterSnapshotsCommand({}));
+    for (const snap of rdsSnaps.DBClusterSnapshots ?? []) {
       const id = snap.DBClusterSnapshotIdentifier ?? "";
       const source = snap.DBClusterIdentifier ?? "";
       if (
-        !id.toLowerCase().includes(opts.stackName.toLowerCase()) &&
-        !source.toLowerCase().includes(opts.stackName.toLowerCase())
+        !id.toLowerCase().includes(stackNeedle) &&
+        !source.toLowerCase().includes(stackNeedle)
       ) {
+        continue;
+      }
+      if (inventory.rdsClusterIds.includes(source)) continue;
+      if (!isDeletableClusterSnapshot(snap)) {
+        log(`Skipping non-manual RDS snapshot ${id}`);
         continue;
       }
       if (opts.dryRun) {
@@ -697,6 +725,35 @@ async function main(): Promise<void> {
       log(`Deleting RDS cluster snapshot ${id}…`);
       await rds.send(
         new DeleteDBClusterSnapshotCommand({ DBClusterSnapshotIdentifier: id }),
+      );
+    }
+
+    // CtxPipe Neptune clusters get CDK-generated ids like `neptunedbcluster-…`
+    // with final snapshots `neptunedbcluster-snapshot-…` that do not embed the
+    // stack name. This example teardown treats those as orphans of prior e2e runs.
+    const neptuneSnaps = await neptune.send(new DescribeNeptuneSnapshotsCommand({}));
+    for (const snap of neptuneSnaps.DBClusterSnapshots ?? []) {
+      const id = snap.DBClusterSnapshotIdentifier ?? "";
+      const source = snap.DBClusterIdentifier ?? "";
+      const matchesStack =
+        id.toLowerCase().includes(stackNeedle) ||
+        source.toLowerCase().includes(stackNeedle);
+      const matchesCtxPipeNeptune =
+        id.startsWith("neptunedbcluster-snapshot-") ||
+        source.startsWith("neptunedbcluster-");
+      if (!matchesStack && !matchesCtxPipeNeptune) continue;
+      if (inventory.neptuneClusterIds.includes(source)) continue;
+      if (!isDeletableClusterSnapshot(snap)) {
+        log(`Skipping non-manual Neptune snapshot ${id}`);
+        continue;
+      }
+      if (opts.dryRun) {
+        log(`[dry-run] would delete Neptune cluster snapshot ${id}`);
+        continue;
+      }
+      log(`Deleting Neptune cluster snapshot ${id}…`);
+      await neptune.send(
+        new DeleteNeptuneSnapshotCommand({ DBClusterSnapshotIdentifier: id }),
       );
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
     dependencies:
       '@ai-sdk/langchain':
         specifier: ^3.0.11
-        version: 3.0.11(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@langchain/langgraph@1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(zod@4.3.6)
+        version: 3.0.11(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@langchain/langgraph@1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(zod@4.3.6)
       '@amplitude/analytics-node':
         specifier: ^1.5.52
         version: 1.5.52
@@ -79,25 +79,25 @@ importers:
         version: 1.2.2(patch_hash=e9d1cc8a2cdc198215919e404891152978de735b3505fe90947a13311aac6b73)(hono@4.12.27)(zod@4.3.6)
       '@langchain/aws':
         specifier: ^1.4.2
-        version: 1.4.2(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+        version: 1.4.2(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       '@langchain/core':
         specifier: ^1.2.1
-        version: 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+        version: 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@langchain/langgraph':
         specifier: ^1.4.7
-        version: 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       '@langchain/langgraph-api':
         specifier: ^1.4.1
-        version: 1.4.1(patch_hash=b01298a0428014f8292406d29dc7efdb706c0de947e5b597f38f1c48f0537eb2)(e729015f082e9d8225eb61b6d3f2f1a6)
+        version: 1.4.1(patch_hash=b01298a0428014f8292406d29dc7efdb706c0de947e5b597f38f1c48f0537eb2)(e82b844a2442a19a55f7921c4c11abc0)
       '@langchain/langgraph-checkpoint-postgres':
         specifier: ^1.0.4
-        version: 1.0.4(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@langchain/langgraph-checkpoint@1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)))
+        version: 1.0.4(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@langchain/langgraph-checkpoint@1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)))
       '@langchain/openai':
         specifier: ^1.5.3
-        version: 1.5.3(@aws-sdk/credential-provider-node@3.972.60)(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@smithy/signature-v4@5.6.1)(ws@8.20.0)
+        version: 1.5.3(@aws-sdk/credential-provider-node@3.972.76)(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@smithy/signature-v4@5.6.12)(ws@8.20.0)
       '@langfuse/langchain':
         specifier: ^5.9.1
-        version: 5.9.1(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)
+        version: 5.9.1(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -172,7 +172,7 @@ importers:
         version: 6.2.2
       langchain:
         specifier: ^1.5.2
-        version: 1.5.2(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)
+        version: 1.5.2(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)
       neo4j-driver:
         specifier: ^6.0.1
         version: 6.0.1
@@ -212,7 +212,7 @@ importers:
         version: 12.17.0(@types/express@4.17.25)(@types/node@25.3.0)(typescript@5.9.3)(webpack@5.105.4)
       '@langchain/langgraph-checkpoint':
         specifier: ^1.1.3
-        version: 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+        version: 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       '@modelcontextprotocol/conformance':
         specifier: ^0.1.15
         version: 0.1.15(@cfworker/json-schema@4.1.1)
@@ -548,6 +548,33 @@ importers:
       '@aws-sdk/client-cloudformation':
         specifier: ^3.700.0
         version: 3.1044.0
+      '@aws-sdk/client-cloudwatch-logs':
+        specifier: ^3.700.0
+        version: 3.1101.0
+      '@aws-sdk/client-ec2':
+        specifier: ^3.700.0
+        version: 3.1101.0
+      '@aws-sdk/client-ecs':
+        specifier: ^3.700.0
+        version: 3.1101.0
+      '@aws-sdk/client-efs':
+        specifier: ^3.700.0
+        version: 3.1101.0
+      '@aws-sdk/client-elastic-load-balancing-v2':
+        specifier: ^3.700.0
+        version: 3.1101.0
+      '@aws-sdk/client-neptune':
+        specifier: ^3.700.0
+        version: 3.1101.0
+      '@aws-sdk/client-rds':
+        specifier: ^3.700.0
+        version: 3.1101.0
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.700.0
+        version: 3.1101.0
+      '@aws-sdk/client-sesv2':
+        specifier: ^3.700.0
+        version: 3.1101.0
       '@ctxpipe/aws-cdk':
         specifier: workspace:*
         version: link:../../packages/aws-cdk
@@ -767,44 +794,116 @@ packages:
     resolution: {integrity: sha512-2EFBp9dmQchKzfMozPYj6EO4iaauoWtYwmsK6k7Yv4jXumBRJKS7KWPbZ2pkpklFAG+OLMHPTEbIRL7ZDKPJWg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-cloudwatch-logs@3.1101.0':
+    resolution: {integrity: sha512-J5h456uYrOdJXjNc6N+3D6cAF90RdhV8wwyPsnBmg0/ZvNq1FaFEsGS27R3hr3uAO3nDleZj2E9Tr6esgXfuVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-ec2@3.1101.0':
+    resolution: {integrity: sha512-SyOtkj7nvvrL1Kum456bNW2JoGldaLzvW3H4XWqD9aqnrOMpqBL1gfKEqo2bTGG9vXKiJKVVVKkwd+X1OUyuVg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-ecs@3.1101.0':
+    resolution: {integrity: sha512-1FVgz9G3HiomwvB3gaobiWF5wdQ98V2wXvHoIwbx1J6lR0+k3c2lI9WAVHEDiw3IIy25KWAby1KfGLovPqlDWg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-efs@3.1101.0':
+    resolution: {integrity: sha512-V18gm4R6yxOUu3KxI/8YJmfzai+C3Ty4grFcoDPKQTa7MRlnCGPHUTD5HE6/VFKKMlPj+5Qs0gHNuvH96fq+nA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-elastic-load-balancing-v2@3.1101.0':
+    resolution: {integrity: sha512-SHAEfZX2EZbtf0pEFcgicY/ngfbBWhyoDJvmet1ex9Www8tAAiV0N1HETCd2sngSVnyE5anZ15rM0xR8W6Ny0A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-kendra@3.1077.0':
     resolution: {integrity: sha512-xFFQTXemqzpHBmuIN2iG4b6WYOaPDP4LM1KcxTQEw7u0/WvumZq0HE6JKOt1R+I9Qyl+Fkl+pWdcPknikNEUtg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-neptune@3.1101.0':
+    resolution: {integrity: sha512-z9iZdbZGNViS0uu+7iYEvoAPYwYeBiFjNv5RV5VlnU1XGVi559tFeW5ApawzNoqv8SZoIVRn0N9qMY/rHduV7g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-rds@3.1101.0':
+    resolution: {integrity: sha512-O/cj/nHK6/WhemFWqM8xsWRzOY8bxcTzryz27llP86WbvAPaCOLtWAiNkYIlg8IQI9n5Dgi3hNED5phJI+eYtg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-secrets-manager@3.1101.0':
+    resolution: {integrity: sha512-+FZgLzBuzbGOJN3Hoo0QadoFs8U9MK7PwqHscRCNdMaU33yqqBTjCtHsiZCXyCJeuW7gar8+fojLGQQEmEiOAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sesv2@3.1101.0':
+    resolution: {integrity: sha512-5n4COAW5u6T1gOz4t6RueAncImDjK0wdoQEXu1ABnRfLAoNa2dlouubKq3lHLliQdhhEo4so7Cn88ylprab0Ng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.25':
     resolution: {integrity: sha512-fJFkx6u6wCqGMV/v6EAxiwa2UzEukbvr1hNPv4MrD3yj4IFz011jZg42/eSTOP/u5kJ0tlILqEjCWtT8GiKZvA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.4':
+    resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.51':
     resolution: {integrity: sha512-Xo+/zf5k5pZdo53X8aVXN4MJGfU/M1P7yMM/GbNY/x9fyRZGEzjhKqW38GA0FSQQ9TYKs+bfPyz5ja4bi6pjTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    resolution: {integrity: sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.53':
     resolution: {integrity: sha512-7E9oFUcf9YWe+ttGiWhe/cCSI+pswwelzgQMoKXgPJi1AIfS27TK6et5ZULqEqHu30zbN+jh1RqlwcXqY/aXyg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.67':
+    resolution: {integrity: sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.58':
     resolution: {integrity: sha512-MPr0hD8pyDGfF3dWXvFOILhcKTB9ptqJOJK9JEuDQzpc2HgKisY16eR7IrKUXxSbz8LZj+LHz/CS8Y5G1ai7yw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    resolution: {integrity: sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.57':
     resolution: {integrity: sha512-kPWc/SCrl9agKeywxKwPEoQHanWag0LcNQrcZpEQpjNifkxq6tQENhgrrS9al317CF6yytyihlX+FhPHlk0QjA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.72':
+    resolution: {integrity: sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.60':
     resolution: {integrity: sha512-hE2hIBJQjCDRx8TbSqpVQ+/o2mIrJZQZbQ3LlwE2bJf7z47x5GmhcvGwZPqJH7Oq//SzTXEBGSZ4qSpK3yPbhw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    resolution: {integrity: sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.51':
     resolution: {integrity: sha512-081dD2RlnmY+G05v6E73KfACvDjPjnttrLjGHE2SSglbID25UcuijbWpL4g+XR5T2Kl4oIJoVBXi64s+2f009Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.65':
+    resolution: {integrity: sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.57':
     resolution: {integrity: sha512-dC7ZyX3EHKHLOeVUEDzzGvk0L1s6N06YDrau7P0rGXL/j1cO+DzN2w1x9vcEh7zljVCR3019f5mi1Th+GGTURw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    resolution: {integrity: sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.57':
     resolution: {integrity: sha512-HtWM3FV2o7NJFJSUqFLBlxmV9RxQRHpzCvQaP1n1Qo4CxQSvwpJ8ERWHiLqXMFDgDXyELt+EZNFcpG6XQRcJbQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    resolution: {integrity: sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/eventstream-handler-node@3.972.24':
@@ -827,6 +926,14 @@ packages:
     resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-ec2@3.972.53':
+    resolution: {integrity: sha512-WEIycst5f9Tj2Sqj2lfpypshh8N78keVFEkentp02nzi4ROsgElvT/sXZbjUlJ1HFQV9WPER1k6aZoCfqNqsuA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-rds@3.972.53':
+    resolution: {integrity: sha512-rRG7dO/vAZz5w/vSPJiOjxDeM1fdQ5rmU6JsQqzLa+NeW1h8uUlL3PkHiEnRGRqJkKJr6OsAoJaWrWlFH1dusQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-user-agent@3.972.38':
     resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
@@ -839,6 +946,10 @@ packages:
     resolution: {integrity: sha512-VpRQ3wR6l+fwRHV5veJL2ehtyQFrGyH/2CJG9DVtb8H3xyqqnZWSTSrq/CJJ7DvDlDgrPRiW2SkYA8pN6VWCFQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.39':
+    resolution: {integrity: sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.13':
     resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
     engines: {node: '>=20.0.0'}
@@ -847,12 +958,24 @@ packages:
     resolution: {integrity: sha512-u8qd064XsHzM0Mk+yH4IPKn/ZC9rdniEKs+neBHNlsPZirw3rcLvmrH4ImoKC4yF7A0I/MbcC3dseARnJLiAhg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1077.0':
     resolution: {integrity: sha512-sRUkfZ3fpOco95jZHsQUQiXvuIVLvCmWVclFg6dRFDyfsYs6Pdr/NuZ2+yJxeHN+6WAfDh2aZ8nlZntnvuhZUQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1100.0':
+    resolution: {integrity: sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.14':
     resolution: {integrity: sha512-vH4pEu9YBEwr67yT+GVcmKX0GzfIrIYUn+MF5vXg9OspouVnAekuyVyawFvZHEK7WlcwVDwNrqI3ZBDUAiyu9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.8':
@@ -879,8 +1002,16 @@ packages:
     resolution: {integrity: sha512-2loKuOMRFDg1nwdni5AtJ9S5juVbRNPNsPC7tWTfkHyycPwACMhxepspUHi8GhvfNlL2cQo3sPMod1uib+KZ0w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@azure-rest/core-client@2.6.0':
@@ -5518,12 +5649,24 @@ packages:
     resolution: {integrity: sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.4':
     resolution: {integrity: sha512-jT0WrDaM88L5na9FX1xRNywCS3B1n75wPY5Ksasjo0PHUtuI7d8FclksN1BbOSYTiaiKxUDqU23nUymH/V+AaQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.1':
     resolution: {integrity: sha512-fW6l9rWoyk1iyzfuZaERnZLNjB6WIojgGm6Bo9Hpfpy3RUpltjLikNlxTsS/YtxVobcfbCGBuAncREYqT4hvqQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-node@4.2.14':
@@ -5570,6 +5713,10 @@ packages:
     resolution: {integrity: sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.14':
     resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
@@ -5594,12 +5741,20 @@ packages:
     resolution: {integrity: sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.13':
     resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.15.1':
     resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.14':
@@ -8151,10 +8306,12 @@ packages:
 
   drizzle-kit@1.0.0-beta.22:
     resolution: {integrity: sha512-9HTZuQRljQKTgCx4UhiGn8KYYfHGk4+B/bRR1714W67kz0qgJvdrG527i8rQD8uUyET9UTGR1u8syySJD4znGw==}
+    deprecated: The 1.0.0-beta line is superseded by the 1.0 release candidate. Install drizzle-kit@rc instead.
     hasBin: true
 
   drizzle-orm@1.0.0-beta.22:
     resolution: {integrity: sha512-F+DZyVIvH0oVKa/w08Cle1xfoH+pc+htIXHG/frnMLG72aby9NYYr9oc+9XvghnoO4umxFItduz0OMmQJMnenw==}
+    deprecated: The 1.0.0-beta line is superseded by the 1.0 release candidate. Install drizzle-orm@rc instead.
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -13321,12 +13478,12 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
-  '@ai-sdk/langchain@3.0.11(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@langchain/langgraph@1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(zod@4.3.6)':
+  '@ai-sdk/langchain@3.0.11(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@langchain/langgraph@1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       ai: 7.0.11(zod@4.3.6)
     optionalDependencies:
-      '@langchain/langgraph': 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      '@langchain/langgraph': 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
     transitivePeerDependencies:
       - zod
 
@@ -13577,6 +13734,62 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-cloudwatch-logs@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-ec2@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/middleware-sdk-ec2': 3.972.53
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-ecs@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-efs@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-elastic-load-balancing-v2@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-kendra@3.1077.0':
     dependencies:
       '@aws-sdk/core': 3.974.25
@@ -13586,6 +13799,53 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.1
       '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-neptune@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/middleware-sdk-rds': 3.972.53
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-rds@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/middleware-sdk-rds': 3.972.53
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-secrets-manager@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-sesv2@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/core@3.974.25':
@@ -13599,12 +13859,31 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.4':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.51':
     dependencies:
       '@aws-sdk/core': 3.974.25
       '@aws-sdk/types': 3.973.14
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.53':
@@ -13615,6 +13894,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.1
       '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.58':
@@ -13633,6 +13922,22 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-login': 3.972.72
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.57':
     dependencies:
       '@aws-sdk/core': 3.974.25
@@ -13640,6 +13945,15 @@ snapshots:
       '@aws-sdk/types': 3.973.14
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.60':
@@ -13656,12 +13970,34 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.76':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-ini': 3.973.10
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.51':
     dependencies:
       '@aws-sdk/core': 3.974.25
       '@aws-sdk/types': 3.973.14
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.57':
@@ -13674,6 +14010,16 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/token-providers': 3.1100.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.57':
     dependencies:
       '@aws-sdk/core': 3.974.25
@@ -13681,6 +14027,15 @@ snapshots:
       '@aws-sdk/types': 3.973.14
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/eventstream-handler-node@3.972.24':
@@ -13718,6 +14073,24 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-ec2@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-rds@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-user-agent@3.972.38':
     dependencies:
       '@aws-sdk/core': 3.974.25
@@ -13750,6 +14123,17 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.39':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
       '@aws-sdk/types': 3.973.14
@@ -13765,6 +14149,13 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1077.0':
     dependencies:
       '@aws-sdk/core': 3.974.25
@@ -13774,9 +14165,23 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1100.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.14':
     dependencies:
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.8':
@@ -13812,7 +14217,14 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@azure-rest/core-client@2.6.0':
     dependencies:
@@ -16017,20 +16429,20 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@langchain/aws@1.4.2(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/aws@1.4.2(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
       '@aws-sdk/client-bedrock-agent-runtime': 3.1077.0
       '@aws-sdk/client-bedrock-runtime': 3.1077.0
       '@aws-sdk/client-kendra': 3.1077.0
       '@aws-sdk/credential-provider-node': 3.972.60
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
 
-  '@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.14(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.7.14(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.3.6
@@ -16041,15 +16453,15 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-api@1.4.1(patch_hash=b01298a0428014f8292406d29dc7efdb706c0de947e5b597f38f1c48f0537eb2)(e729015f082e9d8225eb61b6d3f2f1a6)':
+  '@langchain/langgraph-api@1.4.1(patch_hash=b01298a0428014f8292406d29dc7efdb706c0de947e5b597f38f1c48f0537eb2)(e82b844a2442a19a55f7921c4c11abc0)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@hono/node-server': 1.19.14(hono@4.12.27)
       '@hono/node-ws': 1.3.1(@hono/node-server@1.19.14(hono@4.12.27))(hono@4.12.27)
       '@hono/zod-validator': 0.7.6(hono@4.12.27)(zod@4.3.6)
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph': 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
-      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/langgraph': 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       '@langchain/langgraph-ui': 1.4.1
       '@langchain/protocol': 0.0.18
       '@types/json-schema': 7.0.15
@@ -16058,7 +16470,7 @@ snapshots:
       dotenv: 16.6.1
       exit-hook: 4.0.0
       hono: 4.12.27
-      langsmith: 0.7.14(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.7.14(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       open: 10.2.0
       semver: 7.7.4
       stacktrace-parser: 0.1.11
@@ -16069,7 +16481,7 @@ snapshots:
       winston-console-format: 1.0.8
       zod: 4.3.6
     optionalDependencies:
-      '@langchain/langgraph-sdk': 1.9.25(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/langgraph-sdk': 1.9.25(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -16081,21 +16493,21 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@langchain/langgraph-checkpoint-postgres@1.0.4(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@langchain/langgraph-checkpoint@1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)))':
+  '@langchain/langgraph-checkpoint-postgres@1.0.4(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@langchain/langgraph-checkpoint@1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)))':
     dependencies:
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       pg: 8.18.0
     transitivePeerDependencies:
       - pg-native
 
-  '@langchain/langgraph-checkpoint@1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
 
-  '@langchain/langgraph-sdk@1.9.25(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.9.25(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@langchain/protocol': 0.0.18
       '@types/json-schema': 7.0.15
       p-queue: 9.1.2
@@ -16112,11 +16524,11 @@ snapshots:
       esbuild-plugin-tailwindcss: 2.1.0
       zod: 4.3.6
 
-  '@langchain/langgraph@1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+  '@langchain/langgraph@1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
-      '@langchain/langgraph-sdk': 1.9.25(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@langchain/langgraph-sdk': 1.9.25(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@langchain/protocol': 0.0.18
       '@standard-schema/spec': 1.1.0
       zod: 4.3.6
@@ -16126,11 +16538,11 @@ snapshots:
       - svelte
       - vue
 
-  '@langchain/openai@1.5.3(@aws-sdk/credential-provider-node@3.972.60)(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@smithy/signature-v4@5.6.1)(ws@8.20.0)':
+  '@langchain/openai@1.5.3(@aws-sdk/credential-provider-node@3.972.76)(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@smithy/signature-v4@5.6.12)(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       js-tiktoken: 1.0.21
-      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6)
+      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
@@ -16144,9 +16556,9 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@langfuse/langchain@5.9.1(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)':
+  '@langfuse/langchain@5.9.1(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.0)
       '@langfuse/tracing': 5.9.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
@@ -19723,6 +20135,17 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.4':
     dependencies:
       '@smithy/core': 3.29.0
@@ -19733,6 +20156,12 @@ snapshots:
     dependencies:
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/hash-node@4.2.14':
@@ -19810,6 +20239,12 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.14':
     dependencies:
       '@smithy/types': 4.15.1
@@ -19840,6 +20275,12 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.13':
     dependencies:
       '@smithy/core': 3.29.0
@@ -19851,6 +20292,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 
@@ -24834,12 +25279,12 @@ snapshots:
 
   kysely@0.29.3: {}
 
-  langchain@1.5.2(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0):
+  langchain@1.5.2(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0):
     dependencies:
-      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph': 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
-      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
-      langsmith: 0.7.14(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/langgraph': 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      langsmith: 0.7.14(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -24860,14 +25305,14 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  langsmith@0.7.14(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
+  langsmith@0.7.14(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-proto': 0.213.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
-      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6)
+      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6)
       ws: 8.20.0
 
   latest-version@7.0.0:
@@ -26170,10 +26615,10 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.1)(ws@8.20.0)(zod@4.3.6):
+  openai@6.45.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
-      '@aws-sdk/credential-provider-node': 3.972.60
-      '@smithy/signature-v4': 5.6.1
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@smithy/signature-v4': 5.6.12
       ws: 8.20.0
       zod: 4.3.6
 


### PR DESCRIPTION
## Summary
- Adds `pnpm teardown` for `@ctxpipe/aws-cdk-self-host` that deletes the CloudFormation stack and purges retained leftovers (EFS, Aurora/Neptune final snapshots, Secrets Manager recovery, stack log groups).
- Uses `DeleteStack` directly so teardown still works when `cdk destroy` cannot synth (e.g. model-id validation drift).
- Documents dry-run / skip-destroy / purge-ses flags; keeps CDKToolkit, imported Route53 zone, and SES by default.

## Test plan
- [x] `pnpm --filter @ctxpipe/aws-cdk-self-host typecheck`
- [x] Run `pnpm --filter @ctxpipe/aws-cdk-self-host teardown` against sandbox (`CtxpipeSelfHostE2E`) with `AWS_PROFILE=ctxpipe-sandbox`
- [x] Confirm NAT / Aurora / Neptune / ALB / ECS are gone after teardown completes
- [x] Confirm retained EFS filesystems named under `CtxpipeSelfHostE2E/` are deleted
- [x] Confirm `CDKToolkit` bootstrap stack remains