### PR TITLE
Fix SCIP TypeScript detection for package.json-only repos

### DIFF
--- a/apps/codesearch/src/domain/indexing/detectLanguages.test.ts
+++ b/apps/codesearch/src/domain/indexing/detectLanguages.test.ts
@@ -27,7 +27,8 @@ afterEach(() => {
 describe("detectLanguages", () => {
   it.each<[ScipIndexerId, string]>([
     ["go", "go.mod"],
-    ["typescript", "package.json"],
+    ["typescript", "tsconfig.json"],
+    ["typescript", "jsconfig.json"],
     ["python", "pyproject.toml"],
     ["python", "setup.py"],
     ["python", "requirements.txt"],
@@ -50,15 +51,12 @@ describe("detectLanguages", () => {
     expect(detectLanguages(checkoutPath)).toEqual([indexer])
   })
 
-  it.each([
-    "tsconfig.json",
-    "jsconfig.json",
-  ])("detects TypeScript projects with package.json and %s", (configMarker) => {
+  it("does not select typescript from bare package.json without tsconfig/jsconfig", () => {
     const checkoutPath = createCheckout()
     touch(checkoutPath, "package.json")
-    touch(checkoutPath, configMarker)
+    touch(checkoutPath, join("src", "index.js"))
 
-    expect(detectLanguages(checkoutPath)).toEqual(["typescript"])
+    expect(detectLanguages(checkoutPath)).toEqual([])
   })
 
   it.each<[ScipIndexerId, string]>([
@@ -114,7 +112,7 @@ describe("detectLanguages", () => {
     for (const marker of [
       "composer.json",
       "Cargo.toml",
-      "package.json",
+      "tsconfig.json",
       "go.mod",
       "pom.xml",
       "pyproject.toml",

--- a/apps/codesearch/src/domain/indexing/detectLanguages.ts
+++ b/apps/codesearch/src/domain/indexing/detectLanguages.ts
@@ -51,7 +51,8 @@ const EXACT_FILE_MARKERS: ReadonlyArray<{
   indexer: ScipIndexerId
 }> = [
   { name: "go.mod", indexer: "go" },
-  { name: "package.json", indexer: "typescript" },
+  { name: "tsconfig.json", indexer: "typescript" },
+  { name: "jsconfig.json", indexer: "typescript" },
   { name: "pyproject.toml", indexer: "python" },
   { name: "setup.py", indexer: "python" },
   { name: "requirements.txt", indexer: "python" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

SCIP TypeScript indexing failed closed on Node repos without a root `tsconfig.json`. Language detection treated any `package.json` as “run TypeScript SCIP”, then `scip-typescript` exited 1 with `missing tsconfig.json / no files got indexed`. That 500 failed the `scip:typescript` OpenWorkflow step and marked the whole ingest failed (even when Zoekt succeeded). Same pattern hit multiple Tru repos in prod.

## Fix

- Detect typescript from `tsconfig.json` / `jsconfig.json` instead of `package.json` (same idea as clang + `compile_commands.json`).
- Keep `package.json` only as a touched-path hint in `scipTouchedLanguages` once typescript is already detected.

## TDD

1. Updated `detectLanguages` tests first (including a regression case for bare `package.json` + `.js`).
2. Confirmed 4 failures on current detection.
3. Applied the marker change and re-ran: **34/34** `detectLanguages` tests pass; related SCIP selection tests also pass (57 total).

## Note

Nested-only `tsconfig` under a root-only `scip-typescript` runner remains a separate limitation (already broken before this change).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://ctxpipe.slack.com/archives/C0AMVSR0EBW/p1785932638399439?thread_ts=1785932638.399439&cid=C0AMVSR0EBW)

<div><a href="https://cursor.com/agents/bc-93b23cd1-e195-5283-8640-25b02f11fbd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93b23cd1-e195-5283-8640-25b02f11fbd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

