### PR TITLE
Select TypeScript SCIP only from root tsconfig/jsconfig

### DIFF
--- a/.changeset/root-only-ts-scip.md
+++ b/.changeset/root-only-ts-scip.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Select TypeScript SCIP only when a root `tsconfig.json` / `jsconfig.json` exists, so nested-only configs no longer schedule `scip-typescript` (and fail ingest) when the indexer always runs with cwd at checkout root.

--- a/apps/codesearch/src/domain/indexing/detectLanguages.test.ts
+++ b/apps/codesearch/src/domain/indexing/detectLanguages.test.ts
@@ -59,6 +59,26 @@ describe("detectLanguages", () => {
     expect(detectLanguages(checkoutPath)).toEqual([])
   })
 
+  it.each(["tsconfig.json", "jsconfig.json"] as const)(
+    "does not select typescript from nested-only %s (indexer cwd is checkout root)",
+    (marker) => {
+      const checkoutPath = createCheckout()
+      touch(checkoutPath, join("packages", "x", marker))
+      touch(checkoutPath, join("apps", "foo", "package.json"))
+
+      expect(detectLanguages(checkoutPath)).toEqual([])
+    },
+  )
+
+  it("still selects typescript when root tsconfig.json exists alongside nested configs", () => {
+    const checkoutPath = createCheckout()
+    touch(checkoutPath, "tsconfig.json")
+    touch(checkoutPath, join("packages", "x", "tsconfig.json"))
+    touch(checkoutPath, join("apps", "foo", "jsconfig.json"))
+
+    expect(detectLanguages(checkoutPath)).toEqual(["typescript"])
+  })
+
   it.each<[ScipIndexerId, string]>([
     ["ruby", "project.gemspec"],
     ["dotnet", "project.csproj"],

--- a/apps/codesearch/src/domain/indexing/detectLanguages.ts
+++ b/apps/codesearch/src/domain/indexing/detectLanguages.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync, type Dirent } from "node:fs"
+import { existsSync, readdirSync, statSync, type Dirent } from "node:fs"
 import { join } from "node:path"
 
 export type ScipIndexerId =
@@ -46,13 +46,14 @@ const SKIP_DIRS = new Set([
 const MAX_ENTRIES = 20_000
 const MAX_DEPTH = 8
 
+/** TypeScript SCIP runs with cwd = checkout root; only root configs are valid. */
+const ROOT_TYPESCRIPT_MARKERS = ["tsconfig.json", "jsconfig.json"] as const
+
 const EXACT_FILE_MARKERS: ReadonlyArray<{
   name: string
   indexer: ScipIndexerId
 }> = [
   { name: "go.mod", indexer: "go" },
-  { name: "tsconfig.json", indexer: "typescript" },
-  { name: "jsconfig.json", indexer: "typescript" },
   { name: "pyproject.toml", indexer: "python" },
   { name: "setup.py", indexer: "python" },
   { name: "requirements.txt", indexer: "python" },
@@ -106,6 +107,8 @@ function noteFile(found: Set<ScipIndexerId>, name: string): void {
 /**
  * Detect SCIP indexer families present under a checkout.
  * Breadth-first walk with bounded depth/entry caps; skips common junk dirs.
+ * TypeScript is root-only (`tsconfig.json` / `jsconfig.json` at checkout root)
+ * because `scip-typescript` always runs with cwd = checkout root.
  * Unexpected I/O errors propagate; missing checkout returns [].
  */
 export function detectLanguages(checkoutPath: string): ScipIndexerId[] {
@@ -119,6 +122,13 @@ export function detectLanguages(checkoutPath: string): ScipIndexerId[] {
   if (!rootStat.isDirectory()) return []
 
   const found = new Set<ScipIndexerId>()
+  for (const marker of ROOT_TYPESCRIPT_MARKERS) {
+    if (existsSync(join(checkoutPath, marker))) {
+      found.add("typescript")
+      break
+    }
+  }
+
   let entriesScanned = 0
   const queue: Array<{ dir: string; depth: number }> = [
     { dir: checkoutPath, depth: 0 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #268, repos with only nested `tsconfig.json` / `jsconfig.json` (no root config) still selected `typescript` via BFS detection. `scip-typescript` always runs with `cwd = checkout root`, so those ingest jobs failed with the same missing-tsconfig stderr / `scip:typescript` 500s.

## Fix

- Select `typescript` only when `checkout/tsconfig.json` or `checkout/jsconfig.json` exists
- Nested-only configs no longer schedule TypeScript SCIP (Zoekt still succeeds; ingest completes)
- Root configs continue to select TypeScript as before

Trade-off: monorepos with only package-level tsconfigs lose TypeScript SCIP until multi-root indexing exists. Zoekt-only success is strictly better than failing the whole ingest.

## TDD

1. Added failing tests for nested-only `tsconfig.json` / `jsconfig.json` (plus root+nested still selects)
2. Confirmed 2 failures reproducing the contract mismatch
3. Applied root-only selection and re-ran: **37/37** `detectLanguages` tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://ctxpipe.slack.com/archives/C0AMVSR0EBW/p1785932638399439?thread_ts=1785932638.399439&cid=C0AMVSR0EBW)

<div><a href="https://cursor.com/agents/bc-8db5ebf7-89bd-5a34-8894-aede9012c46c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8db5ebf7-89bd-5a34-8894-aede9012c46c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

