### PR TITLE
Avoid root package shadowing the ctxpipe CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ctxpipe",
+  "name": "@ctxpipe-dev/root",
   "version": "0.1.0",
   "private": true,
   "license": "Elastic-2.0",


### PR DESCRIPTION
## Summary
- rename the private monorepo root package to `@ctxpipe-dev/root`
- allow unqualified `npx ctxpipe` to resolve the published CLI package and its executable

## Test plan
- [x] Run `pnpm install`
- [x] Run `npx ctxpipe --version` and confirm it returns `0.2.0`