### PR TITLE
Finish Linear simplification (lifecycle + binding API)

### DIFF
--- a/apps/backend/src/models/linear-connector.test.ts
+++ b/apps/backend/src/models/linear-connector.test.ts
@@ -11,10 +11,10 @@ import {
   claimLinearConfigPrCreation,
   LinearConfigPrCreationInProgressError,
   LinearSyncBindingBusyError,
-  markLinearSyncTargetInitialSync,
+  claimLinearBindingInitialSync,
   planLinearSyncBindingUpdate,
-  type LinearSyncTarget,
-  withLinearSyncTargetSnapshot,
+  type LinearBinding,
+  withLinearBindingSnapshot,
 } from "./linear-connector.js"
 
 const dbMocks = vi.hoisted(() => ({
@@ -26,7 +26,7 @@ vi.mock("../db/client.js", async (importOriginal) => {
   return { ...actual, getSystemDb: dbMocks.getSystemDb }
 })
 
-function binding(overrides: Partial<LinearSyncTarget> = {}): LinearSyncTarget {
+function binding(overrides: Partial<LinearBinding> = {}): LinearBinding {
   return {
     id: "con_linear",
     orgId: "org_1",
@@ -80,7 +80,7 @@ function claimDb(claimedIds: string[]): Db {
   } as unknown as Db
 }
 
-function linearConnectionRow(setupPhase: LinearSyncTarget["setupPhase"]) {
+function linearConnectionRow(setupPhase: LinearBinding["setupPhase"]) {
   return {
     id: "con_linear",
     orgId: "org_1",
@@ -103,7 +103,7 @@ function linearConnectionRow(setupPhase: LinearSyncTarget["setupPhase"]) {
 }
 
 function systemDb(
-  setupPhase: LinearSyncTarget["setupPhase"],
+  setupPhase: LinearBinding["setupPhase"],
   setTransactionActive?: (active: boolean) => void,
 ): Db {
   const row = linearConnectionRow(setupPhase)
@@ -244,7 +244,7 @@ describe("Linear connector model", () => {
     dbMocks.getSystemDb.mockReturnValue(systemDb(setupPhase))
 
     await expect(
-      markLinearSyncTargetInitialSync({
+      claimLinearBindingInitialSync({
         connectionId: "con_linear",
         repositoryId: "repo_1",
         branch: "main",
@@ -261,7 +261,7 @@ describe("Linear connector model", () => {
     dbMocks.getSystemDb.mockReturnValue(db)
 
     await expect(
-      markLinearSyncTargetInitialSync({
+      claimLinearBindingInitialSync({
         connectionId: "con_linear",
         repositoryId: "repo_1",
         branch: "main",
@@ -289,7 +289,7 @@ describe("Linear connector model", () => {
     } as unknown as Db)
 
     await expect(
-      markLinearSyncTargetInitialSync({
+      claimLinearBindingInitialSync({
         connectionId: "con_linear",
         repositoryId: "repo_1",
         branch: "main",
@@ -298,7 +298,7 @@ describe("Linear connector model", () => {
 
     dbMocks.getSystemDb.mockReturnValue(systemDb("awaiting_merge"))
     await expect(
-      markLinearSyncTargetInitialSync({
+      claimLinearBindingInitialSync({
         connectionId: "con_linear",
         repositoryId: "repo_other",
         branch: "main",
@@ -318,7 +318,7 @@ describe("Linear connector model", () => {
     })
 
     await expect(
-      withLinearSyncTargetSnapshot(
+      withLinearBindingSnapshot(
         {
           connectionId: "con_linear",
           repositoryId: "repo_1",

--- a/apps/backend/src/models/linear-connector.test.ts
+++ b/apps/backend/src/models/linear-connector.test.ts
@@ -263,11 +263,10 @@ describe("Linear connector model", () => {
 
   it("releases the verification transaction before running sync I/O", async () => {
     let transactionActive = false
-    dbMocks.getSystemDb.mockReturnValue(
-      systemDb("live", (active) => {
-        transactionActive = active
-      }),
-    )
+    const db = systemDb("live", (active) => {
+      transactionActive = active
+    })
+    dbMocks.getSystemDb.mockReturnValue(db)
     const operation = vi.fn(async () => {
       expect(transactionActive).toBe(false)
       return "committed"
@@ -285,5 +284,7 @@ describe("Linear connector model", () => {
       ),
     ).resolves.toBe("committed")
     expect(operation).toHaveBeenCalledOnce()
+    // Pre- and post-verify each open a short advisory-lock transaction.
+    expect(db.transaction).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/backend/src/models/linear-connector.test.ts
+++ b/apps/backend/src/models/linear-connector.test.ts
@@ -243,9 +243,13 @@ describe("Linear connector model", () => {
   ] as const)("claims initial sync from %s", async (setupPhase) => {
     dbMocks.getSystemDb.mockReturnValue(systemDb(setupPhase))
 
-    await expect(markLinearSyncTargetInitialSync("con_linear")).resolves.toBe(
-      true,
-    )
+    await expect(
+      markLinearSyncTargetInitialSync({
+        connectionId: "con_linear",
+        repositoryId: "repo_1",
+        branch: "main",
+      }),
+    ).resolves.toBe(true)
   })
 
   it.each([
@@ -256,9 +260,50 @@ describe("Linear connector model", () => {
     const db = systemDb(setupPhase)
     dbMocks.getSystemDb.mockReturnValue(db)
 
-    await expect(markLinearSyncTargetInitialSync("con_linear")).resolves.toBe(
-      false,
-    )
+    await expect(
+      markLinearSyncTargetInitialSync({
+        connectionId: "con_linear",
+        repositoryId: "repo_1",
+        branch: "main",
+      }),
+    ).resolves.toBe(false)
+  })
+
+  it("does not claim initial sync when binding is disabled or rebound", async () => {
+    const disabled = linearConnectionRow("awaiting_merge")
+    disabled.config.enabled = false
+    dbMocks.getSystemDb.mockReturnValue({
+      transaction: vi.fn(async (operation: (tx: Db) => Promise<unknown>) =>
+        operation({
+          execute: vi.fn(),
+          select: vi.fn(() => ({
+            from: vi.fn(() => ({
+              where: vi.fn(() => ({
+                limit: vi.fn().mockResolvedValue([disabled]),
+              })),
+            })),
+          })),
+          update: vi.fn(),
+        } as unknown as Db),
+      ),
+    } as unknown as Db)
+
+    await expect(
+      markLinearSyncTargetInitialSync({
+        connectionId: "con_linear",
+        repositoryId: "repo_1",
+        branch: "main",
+      }),
+    ).resolves.toBe(false)
+
+    dbMocks.getSystemDb.mockReturnValue(systemDb("awaiting_merge"))
+    await expect(
+      markLinearSyncTargetInitialSync({
+        connectionId: "con_linear",
+        repositoryId: "repo_other",
+        branch: "main",
+      }),
+    ).resolves.toBe(false)
   })
 
   it("releases the verification transaction before running sync I/O", async () => {

--- a/apps/backend/src/models/linear-connector.ts
+++ b/apps/backend/src/models/linear-connector.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, sql } from "drizzle-orm"
 import type { Env } from "../config/env.js"
 import type { Db } from "../db/client.js"
-import { getOrgDb, getSystemDb, withOrgDbContext } from "../db/client.js"
+import { getOrgDb, getSystemDb } from "../db/client.js"
 import {
   CONNECTION_TYPE_LINEAR,
   connections,
@@ -36,7 +36,7 @@ export interface LinearScope {
   teamKey: string | null
 }
 /** Sync binding projected from `connections.config` (+ timestamps from the connection row). */
-export type LinearSyncTarget = {
+export type LinearBinding = {
   id: string
   orgId: string
   connectionId: string
@@ -50,14 +50,14 @@ export type LinearSyncTarget = {
   updatedAt: Date
 }
 
-export type LinearSyncTargetWithRepo = LinearSyncTarget & {
+export type LinearBindingWithRepo = LinearBinding & {
   repositoryName: string
   githubConnectionId: string | null
 }
 
-function syncTargetFromConnectionRow(
+function bindingFromConnectionRow(
   row: ConnectionRow,
-): LinearSyncTarget | undefined {
+): LinearBinding | undefined {
   const config = parseLinearConnectionStored(
     row.config as Record<string, unknown>,
   )
@@ -113,7 +113,7 @@ export class LinearSyncBindingBusyError extends Error {
 
 /** Pure rebind rules for sync binding on `connections.config`. */
 export function planLinearSyncBindingUpdate(input: {
-  existing: LinearSyncTarget | undefined
+  existing: LinearBinding | undefined
   repositoryId: string
   branch: string
   enabled: boolean
@@ -396,24 +396,6 @@ export async function refreshLinearConnectionTokensWithLock(input: {
   })
 }
 
-export async function getLinearConnectionForWebhook(
-  connectionId: string,
-  env: Env,
-): Promise<LinearConnection | undefined> {
-  const db = getSystemDb()
-  const [row] = await db
-    .select()
-    .from(connections)
-    .where(
-      and(
-        eq(connections.id, connectionId),
-        eq(connections.type, CONNECTION_TYPE_LINEAR),
-      ),
-    )
-    .limit(1)
-  return row ? linearConnectionToShape(row, env) : undefined
-}
-
 export async function listLinearConnectionsByWorkspaceId(
   workspaceId: string,
   env: Env,
@@ -493,10 +475,10 @@ export async function deleteLinearConnectionById(
   })
 }
 
-export async function getLinearSyncTargetWithRepoByConnectionId(
+export async function getLinearBindingWithRepoByConnectionId(
   orgId: string,
   connectionId: string,
-): Promise<LinearSyncTargetWithRepo | undefined> {
+): Promise<LinearBindingWithRepo | undefined> {
   const db = getSystemDb()
   const [row] = await db
     .select({
@@ -522,7 +504,7 @@ export async function getLinearSyncTargetWithRepoByConnectionId(
     )
     .limit(1)
   if (!row) return undefined
-  const target = syncTargetFromConnectionRow(row.connection)
+  const target = bindingFromConnectionRow(row.connection)
   if (!target) return undefined
   return {
     ...target,
@@ -531,7 +513,7 @@ export async function getLinearSyncTargetWithRepoByConnectionId(
   }
 }
 
-async function assertLinearSyncTargetSnapshot(input: {
+async function assertLinearBindingSnapshot(input: {
   connectionId: string
   repositoryId: string
   branch: string
@@ -552,7 +534,7 @@ async function assertLinearSyncTargetSnapshot(input: {
         ),
       )
       .limit(1)
-    const target = row ? syncTargetFromConnectionRow(row) : undefined
+    const target = row ? bindingFromConnectionRow(row) : undefined
     if (
       !target ||
       target.repositoryId !== input.repositoryId ||
@@ -568,7 +550,7 @@ async function assertLinearSyncTargetSnapshot(input: {
 }
 
 /** Verify binding, run GitHub I/O outside the lock, re-verify afterward. */
-export async function withLinearSyncTargetSnapshot<T>(
+export async function withLinearBindingSnapshot<T>(
   input: {
     connectionId: string
     repositoryId: string
@@ -577,15 +559,15 @@ export async function withLinearSyncTargetSnapshot<T>(
   },
   operation: () => Promise<T>,
 ): Promise<T> {
-  await assertLinearSyncTargetSnapshot(input)
+  await assertLinearBindingSnapshot(input)
   const result = await operation()
-  await assertLinearSyncTargetSnapshot(input)
+  await assertLinearBindingSnapshot(input)
   return result
 }
 
-export async function getLinearSyncTargetByConnectionId(
+export async function getLinearBindingByConnectionId(
   connectionId: string,
-): Promise<LinearSyncTarget | undefined> {
+): Promise<LinearBinding | undefined> {
   const db = getSystemDb()
   const [row] = await db
     .select()
@@ -597,12 +579,12 @@ export async function getLinearSyncTargetByConnectionId(
       ),
     )
     .limit(1)
-  return row ? syncTargetFromConnectionRow(row) : undefined
+  return row ? bindingFromConnectionRow(row) : undefined
 }
 
-export async function listLinearSyncTargetsWithRepoByRepositoryId(
+export async function listLinearBindingsWithRepoByRepositoryId(
   repositoryId: string,
-): Promise<LinearSyncTargetWithRepo[]> {
+): Promise<LinearBindingWithRepo[]> {
   const db = getSystemDb()
   const rows = await db
     .select({
@@ -625,7 +607,7 @@ export async function listLinearSyncTargetsWithRepoByRepositoryId(
       ),
     )
   return rows.flatMap((row) => {
-    const target = syncTargetFromConnectionRow(row.connection)
+    const target = bindingFromConnectionRow(row.connection)
     if (!target) return []
     return [
       {
@@ -673,7 +655,7 @@ export async function resetLinearConnectorAfterMissingConfig(input: {
   })
 }
 
-type LinearSyncTargetPatchInput = {
+type LinearBindingPatchInput = {
   repositoryId?: string
   repositoryName?: string
   gitUrl?: string
@@ -685,7 +667,7 @@ type LinearSyncTargetPatchInput = {
 async function resolveRepositoryIdForLinearSync(
   tx: Db,
   orgId: string,
-  sync: LinearSyncTargetPatchInput,
+  sync: LinearBindingPatchInput,
   defaultGithubConnectionId: string | undefined,
 ): Promise<{ repositoryId: string; didCreate: boolean }> {
   if (sync.repositoryId) {
@@ -761,7 +743,7 @@ export async function claimLinearConfigPrCreation(
       ),
     )
     .limit(1)
-  const target = row ? syncTargetFromConnectionRow(row) : undefined
+  const target = row ? bindingFromConnectionRow(row) : undefined
   if (!target) throw new Error("Linear sync target not found")
 
   const claimed = await tx
@@ -794,11 +776,11 @@ export async function patchLinearConnectorConfig(input: {
   orgId: string
   connectionId: string
   scopes?: LinearScope[]
-  syncTarget?: LinearSyncTargetPatchInput
+  syncTarget?: LinearBindingPatchInput
   claimConfigPrCreation?: boolean
 }): Promise<{
+  /** Scopes submitted for workflow enqueue only (not persisted as draft). */
   scopes: LinearScope[]
-  scopesChanged: boolean
   syncTargetChanged: boolean
   configPrClaimed: boolean
   previousConfigPrState?: {
@@ -857,7 +839,7 @@ export async function patchLinearConnectorConfig(input: {
       if (!connectionRow) {
         throw new Error("Linear connection does not belong to organization")
       }
-      const existingTarget = syncTargetFromConnectionRow(connectionRow)
+      const existingTarget = bindingFromConnectionRow(connectionRow)
       const plan = planLinearSyncBindingUpdate({
         existing: existingTarget,
         repositoryId,
@@ -903,7 +885,6 @@ export async function patchLinearConnectorConfig(input: {
 
     return {
       scopes: input.scopes ?? [],
-      scopesChanged: input.scopes !== undefined,
       syncTargetChanged,
       configPrClaimed: Boolean(previousConfigPrState),
       previousConfigPrState,
@@ -914,7 +895,7 @@ export async function patchLinearConnectorConfig(input: {
   })
 }
 
-export async function updateLinearSyncTargetPrState(input: {
+export async function updateLinearBindingPrState(input: {
   connectionId: string
   pendingConfigPullUrl: string | null
   pendingConfigPrCreating: boolean
@@ -950,7 +931,7 @@ export async function updateLinearSyncTargetPrState(input: {
   })
 }
 
-export async function transitionLinearSyncTargetState(input: {
+export async function transitionLinearBindingState(input: {
   connectionId: string
   expectedSetupPhase: LinearSetupPhase
   expectedPendingConfigPrCreating: boolean
@@ -975,7 +956,7 @@ export async function transitionLinearSyncTargetState(input: {
         ),
       )
       .limit(1)
-    const target = row ? syncTargetFromConnectionRow(row) : undefined
+    const target = row ? bindingFromConnectionRow(row) : undefined
     if (
       !target ||
       target.repositoryId !== input.repositoryId ||
@@ -1024,7 +1005,7 @@ export async function releaseLinearConfigPrCreationClaim(input: {
         ),
       )
       .limit(1)
-    const target = row ? syncTargetFromConnectionRow(row) : undefined
+    const target = row ? bindingFromConnectionRow(row) : undefined
     // Only restore if we still own the in-progress claim; skip if rebound.
     if (
       !target ||
@@ -1048,7 +1029,7 @@ export async function releaseLinearConfigPrCreationClaim(input: {
 }
 
 /** CAS into initial_sync only when binding still matches the activating push. */
-export async function markLinearSyncTargetInitialSync(input: {
+export async function claimLinearBindingInitialSync(input: {
   connectionId: string
   repositoryId: string
   branch: string
@@ -1068,7 +1049,7 @@ export async function markLinearSyncTargetInitialSync(input: {
         ),
       )
       .limit(1)
-    const target = row ? syncTargetFromConnectionRow(row) : undefined
+    const target = row ? bindingFromConnectionRow(row) : undefined
     if (
       !target ||
       !target.enabled ||
@@ -1116,7 +1097,7 @@ export async function claimLinearContentSyncRetry(
         ),
       )
       .limit(1)
-    const target = row ? syncTargetFromConnectionRow(row) : undefined
+    const target = row ? bindingFromConnectionRow(row) : undefined
     if (!target || target.setupPhase !== "sync_failed") return false
     const [claimed] = await tx
       .update(connections)
@@ -1134,29 +1115,7 @@ export async function claimLinearContentSyncRetry(
   })
 }
 
-export async function markLinearSyncTargetFailed(
-  connectionId: string,
-): Promise<void> {
-  await updateLinearSyncTargetPrState({
-    connectionId,
-    pendingConfigPullUrl: null,
-    pendingConfigPrCreating: false,
-    setupPhase: "sync_failed",
-  })
-}
-
-export async function markLinearSyncTargetLive(
-  connectionId: string,
-): Promise<void> {
-  await updateLinearSyncTargetPrState({
-    connectionId,
-    pendingConfigPullUrl: null,
-    pendingConfigPrCreating: false,
-    setupPhase: "live",
-  })
-}
-
-export async function finalizeLinearSyncTargetAfterContentWorkflow(input: {
+export async function finalizeLinearBindingAfterContentWorkflow(input: {
   connectionId: string
   workflowStatus: "completed" | "partial_failed" | "failed"
 }): Promise<boolean> {
@@ -1175,7 +1134,7 @@ export async function finalizeLinearSyncTargetAfterContentWorkflow(input: {
         ),
       )
       .limit(1)
-    const target = row ? syncTargetFromConnectionRow(row) : undefined
+    const target = row ? bindingFromConnectionRow(row) : undefined
     if (!target || target.setupPhase !== "initial_sync") return false
     const [updated] = await tx
       .update(connections)
@@ -1248,11 +1207,4 @@ export async function clearLinearSyncBindingsForRepository(input: {
     if (updated) cleared += 1
   }
   return cleared
-}
-
-export function withLinearOrgContext<T>(
-  orgId: string,
-  fn: () => Promise<T>,
-): Promise<T> {
-  return withOrgDbContext(orgId, fn)
 }

--- a/apps/backend/src/models/linear-connector.ts
+++ b/apps/backend/src/models/linear-connector.ts
@@ -1047,20 +1047,23 @@ export async function releaseLinearConfigPrCreationClaim(input: {
   })
 }
 
-export async function markLinearSyncTargetInitialSync(
-  connectionId: string,
-): Promise<boolean> {
+/** CAS into initial_sync only when binding still matches the activating push. */
+export async function markLinearSyncTargetInitialSync(input: {
+  connectionId: string
+  repositoryId: string
+  branch: string
+}): Promise<boolean> {
   const db = getSystemDb()
   return db.transaction(async (tx) => {
     await tx.execute(
-      sql`select pg_advisory_xact_lock(hashtextextended(${connectionId}, 0))`,
+      sql`select pg_advisory_xact_lock(hashtextextended(${input.connectionId}, 0))`,
     )
     const [row] = await tx
       .select()
       .from(connections)
       .where(
         and(
-          eq(connections.id, connectionId),
+          eq(connections.id, input.connectionId),
           eq(connections.type, CONNECTION_TYPE_LINEAR),
         ),
       )
@@ -1068,6 +1071,9 @@ export async function markLinearSyncTargetInitialSync(
     const target = row ? syncTargetFromConnectionRow(row) : undefined
     if (
       !target ||
+      !target.enabled ||
+      target.repositoryId !== input.repositoryId ||
+      target.branch !== input.branch ||
       !(
         target.setupPhase === "awaiting_merge" ||
         target.setupPhase === "sync_failed" ||
@@ -1086,7 +1092,7 @@ export async function markLinearSyncTargetInitialSync(
         }),
         updatedAt: new Date(),
       })
-      .where(eq(connections.id, connectionId))
+      .where(eq(connections.id, input.connectionId))
       .returning({ id: connections.id })
     return Boolean(updated)
   })

--- a/apps/backend/src/models/linear-connector.ts
+++ b/apps/backend/src/models/linear-connector.ts
@@ -531,15 +531,12 @@ export async function getLinearSyncTargetWithRepoByConnectionId(
   }
 }
 
-export async function withLinearSyncTargetSnapshot<T>(
-  input: {
-    connectionId: string
-    repositoryId: string
-    branch: string
-    setupPhase: "initial_sync" | "live"
-  },
-  operation: () => Promise<T>,
-): Promise<T> {
+async function assertLinearSyncTargetSnapshot(input: {
+  connectionId: string
+  repositoryId: string
+  branch: string
+  setupPhase: "initial_sync" | "live"
+}): Promise<void> {
   const db = getSystemDb()
   await db.transaction(async (tx) => {
     await tx.execute(
@@ -568,7 +565,22 @@ export async function withLinearSyncTargetSnapshot<T>(
       )
     }
   })
-  return operation()
+}
+
+/** Verify binding, run GitHub I/O outside the lock, re-verify afterward. */
+export async function withLinearSyncTargetSnapshot<T>(
+  input: {
+    connectionId: string
+    repositoryId: string
+    branch: string
+    setupPhase: "initial_sync" | "live"
+  },
+  operation: () => Promise<T>,
+): Promise<T> {
+  await assertLinearSyncTargetSnapshot(input)
+  const result = await operation()
+  await assertLinearSyncTargetSnapshot(input)
+  return result
 }
 
 export async function getLinearSyncTargetByConnectionId(
@@ -997,11 +1009,41 @@ export async function releaseLinearConfigPrCreationClaim(input: {
     setupPhase: LinearSetupPhase
   }
 }): Promise<void> {
-  await updateLinearSyncTargetPrState({
-    connectionId: input.connectionId,
-    pendingConfigPullUrl: input.previousState.pendingConfigPullUrl,
-    pendingConfigPrCreating: false,
-    setupPhase: input.previousState.setupPhase,
+  const db = getSystemDb()
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${input.connectionId}, 0))`,
+    )
+    const [row] = await tx
+      .select()
+      .from(connections)
+      .where(
+        and(
+          eq(connections.id, input.connectionId),
+          eq(connections.type, CONNECTION_TYPE_LINEAR),
+        ),
+      )
+      .limit(1)
+    const target = row ? syncTargetFromConnectionRow(row) : undefined
+    // Only restore if we still own the in-progress claim; skip if rebound.
+    if (
+      !target ||
+      target.setupPhase !== "awaiting_merge" ||
+      !target.pendingConfigPrCreating
+    ) {
+      return
+    }
+    await tx
+      .update(connections)
+      .set({
+        config: mergeLinearStoredConfig(row!, {
+          pendingConfigPullUrl: input.previousState.pendingConfigPullUrl,
+          pendingConfigPrCreating: false,
+          setupPhase: input.previousState.setupPhase,
+        }),
+        updatedAt: new Date(),
+      })
+      .where(eq(connections.id, input.connectionId))
   })
 }
 

--- a/apps/backend/src/models/linear-connector.ts
+++ b/apps/backend/src/models/linear-connector.ts
@@ -775,13 +775,13 @@ export async function claimLinearConfigPrCreation(
 export async function patchLinearConnectorConfig(input: {
   orgId: string
   connectionId: string
+  /** Scopes for config-PR workflow input only — not stored in Postgres. */
   scopes?: LinearScope[]
-  syncTarget?: LinearBindingPatchInput
+  binding?: LinearBindingPatchInput
   claimConfigPrCreation?: boolean
 }): Promise<{
   /** Scopes submitted for workflow enqueue only (not persisted as draft). */
   scopes: LinearScope[]
-  syncTargetChanged: boolean
   configPrClaimed: boolean
   previousConfigPrState?: {
     pendingConfigPullUrl: string | null
@@ -815,17 +815,16 @@ export async function patchLinearConnectorConfig(input: {
       sql`select pg_advisory_xact_lock(hashtextextended(${input.connectionId}, 0))`,
     )
 
-    let syncTargetChanged = false
     let supersededConfigPullUrl: string | null | undefined
     let supersededConfigRepositoryId: string | null | undefined
     let repositoryIngestion: { orgId: string; repositoryId: string } | undefined
 
-    if (input.syncTarget !== undefined) {
+    if (input.binding !== undefined) {
       const { repositoryId, didCreate } =
         await resolveRepositoryIdForLinearSync(
           tx,
           input.orgId,
-          input.syncTarget,
+          input.binding,
           defaultGithubConnectionId,
         )
       if (didCreate) {
@@ -843,10 +842,9 @@ export async function patchLinearConnectorConfig(input: {
       const plan = planLinearSyncBindingUpdate({
         existing: existingTarget,
         repositoryId,
-        branch: input.syncTarget.branch,
-        enabled: input.syncTarget.enabled,
+        branch: input.binding.branch,
+        enabled: input.binding.enabled,
       })
-      syncTargetChanged = plan.changed
       supersededConfigPullUrl = plan.previousConfigPullUrlToClose
       supersededConfigRepositoryId = plan.previousRepositoryIdToClose
 
@@ -855,8 +853,8 @@ export async function patchLinearConnectorConfig(input: {
         .set({
           config: mergeLinearStoredConfig(connectionRow, {
             repositoryId,
-            branch: input.syncTarget.branch,
-            enabled: input.syncTarget.enabled,
+            branch: input.binding.branch,
+            enabled: input.binding.enabled,
             ...(plan.resetLifecycle
               ? {
                   setupPhase: "draft" as const,
@@ -885,7 +883,6 @@ export async function patchLinearConnectorConfig(input: {
 
     return {
       scopes: input.scopes ?? [],
-      syncTargetChanged,
       configPrClaimed: Boolean(previousConfigPrState),
       previousConfigPrState,
       supersededConfigPullUrl,

--- a/apps/backend/src/openworkflow/workflows/linear-sync-config.test.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-config.test.ts
@@ -19,8 +19,8 @@ vi.mock("../../db/client.js", () => ({
 }))
 vi.mock("../../models/linear-connector.js", () => ({
   getLinearConnectionByConnectionId: mocks.getConnection,
-  getLinearSyncTargetWithRepoByConnectionId: mocks.getTarget,
-  transitionLinearSyncTargetState: mocks.transitionTarget,
+  getLinearBindingWithRepoByConnectionId: mocks.getTarget,
+  transitionLinearBindingState: mocks.transitionTarget,
 }))
 vi.mock("../../services/github/installation-write-client.js", () => ({
   closePullRequest: mocks.closePullRequest,

--- a/apps/backend/src/openworkflow/workflows/linear-sync-config.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-config.ts
@@ -4,8 +4,8 @@ import { parseEnv } from "../../config/env.js"
 import { withOrgDbContext } from "../../db/client.js"
 import {
   getLinearConnectionByConnectionId,
-  getLinearSyncTargetWithRepoByConnectionId,
-  transitionLinearSyncTargetState,
+  getLinearBindingWithRepoByConnectionId,
+  transitionLinearBindingState,
 } from "../../models/linear-connector.js"
 import { closePullRequest } from "../../services/github/installation-write-client.js"
 import { syncLinearConfigYaml } from "../../services/linear/sync.js"
@@ -35,7 +35,7 @@ export const linearSyncConfig = defineWorkflow(
     schema: LinearSyncConfigInputSchema,
   },
   async ({ input }) => {
-    const target = await getLinearSyncTargetWithRepoByConnectionId(
+    const target = await getLinearBindingWithRepoByConnectionId(
       input.orgId,
       input.connectionId,
     )
@@ -70,7 +70,7 @@ export const linearSyncConfig = defineWorkflow(
       })
       if (result.changed) {
         const updated = await withOrgDbContext(input.orgId, () =>
-          transitionLinearSyncTargetState({
+          transitionLinearBindingState({
             connectionId: input.connectionId,
             expectedSetupPhase: "awaiting_merge",
             expectedPendingConfigPrCreating: true,
@@ -100,7 +100,7 @@ export const linearSyncConfig = defineWorkflow(
       } else {
         failurePhase = "sync_failed"
         const updated = await withOrgDbContext(input.orgId, () =>
-          transitionLinearSyncTargetState({
+          transitionLinearBindingState({
             connectionId: input.connectionId,
             expectedSetupPhase: "awaiting_merge",
             expectedPendingConfigPrCreating: true,
@@ -126,7 +126,7 @@ export const linearSyncConfig = defineWorkflow(
       return result
     } catch (error) {
       await withOrgDbContext(input.orgId, () =>
-        transitionLinearSyncTargetState({
+        transitionLinearBindingState({
           connectionId: input.connectionId,
           expectedSetupPhase: expectedPhase,
           expectedPendingConfigPrCreating,

--- a/apps/backend/src/openworkflow/workflows/linear-sync-content.test.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-content.test.ts
@@ -17,9 +17,9 @@ vi.mock("../../db/client.js", () => ({
   ),
 }))
 vi.mock("../../models/linear-connector.js", () => ({
-  finalizeLinearSyncTargetAfterContentWorkflow: mocks.finalizeTarget,
+  finalizeLinearBindingAfterContentWorkflow: mocks.finalizeTarget,
   getLinearConnectionByConnectionId: mocks.getConnection,
-  getLinearSyncTargetWithRepoByConnectionId: mocks.getTarget,
+  getLinearBindingWithRepoByConnectionId: mocks.getTarget,
   refreshLinearConnectionTokensWithLock: vi.fn(),
 }))
 vi.mock("../../observability/logger.js", () => ({

--- a/apps/backend/src/openworkflow/workflows/linear-sync-content.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-content.ts
@@ -3,9 +3,9 @@ import { z } from "zod"
 import { parseEnv } from "../../config/env.js"
 import { withOrgDbContext } from "../../db/client.js"
 import {
-  finalizeLinearSyncTargetAfterContentWorkflow,
+  finalizeLinearBindingAfterContentWorkflow,
   getLinearConnectionByConnectionId,
-  getLinearSyncTargetWithRepoByConnectionId,
+  getLinearBindingWithRepoByConnectionId,
   refreshLinearConnectionTokensWithLock,
 } from "../../models/linear-connector.js"
 import { getLogger } from "../../observability/logger.js"
@@ -31,14 +31,14 @@ export const linearSyncContent = defineWorkflow(
     const env = parseEnv(process.env as Record<string, string | undefined>)
     const markSyncFailed = () =>
       withOrgDbContext(input.orgId, () =>
-        finalizeLinearSyncTargetAfterContentWorkflow({
+        finalizeLinearBindingAfterContentWorkflow({
           connectionId: input.connectionId,
           workflowStatus: "failed",
         }),
       )
     const context = await step
       .run({ name: "load-linear-sync-context" }, async () => {
-        const target = await getLinearSyncTargetWithRepoByConnectionId(
+        const target = await getLinearBindingWithRepoByConnectionId(
           input.orgId,
           input.connectionId,
         )
@@ -131,7 +131,7 @@ export const linearSyncContent = defineWorkflow(
 
       await step.run({ name: "finalize-linear-sync" }, () =>
         withOrgDbContext(input.orgId, () =>
-          finalizeLinearSyncTargetAfterContentWorkflow({
+          finalizeLinearBindingAfterContentWorkflow({
             connectionId: input.connectionId,
             workflowStatus: result.status,
           }),

--- a/apps/backend/src/openworkflow/workflows/linear-sync-entity.test.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-entity.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../db/client.js", () => ({
 }))
 vi.mock("../../models/linear-connector.js", () => ({
   getLinearConnectionByConnectionId: mocks.getConnection,
-  getLinearSyncTargetWithRepoByConnectionId: mocks.getTarget,
+  getLinearBindingWithRepoByConnectionId: mocks.getTarget,
   refreshLinearConnectionTokensWithLock: vi.fn(),
 }))
 vi.mock("../../observability/logger.js", () => ({

--- a/apps/backend/src/openworkflow/workflows/linear-sync-entity.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-entity.ts
@@ -4,7 +4,7 @@ import { parseEnv } from "../../config/env.js"
 import { withOrgDbContext } from "../../db/client.js"
 import {
   getLinearConnectionByConnectionId,
-  getLinearSyncTargetWithRepoByConnectionId,
+  getLinearBindingWithRepoByConnectionId,
   refreshLinearConnectionTokensWithLock,
 } from "../../models/linear-connector.js"
 import { getLogger } from "../../observability/logger.js"
@@ -52,7 +52,7 @@ export const linearSyncEntity = defineWorkflow(
               env,
             ),
           ),
-          getLinearSyncTargetWithRepoByConnectionId(
+          getLinearBindingWithRepoByConnectionId(
             input.orgId,
             input.connectionId,
           ),

--- a/apps/backend/src/routes/v1/connectors-linear.test.ts
+++ b/apps/backend/src/routes/v1/connectors-linear.test.ts
@@ -38,13 +38,13 @@ vi.mock("../../models/github-installation.js", () => ({
 vi.mock("../../models/linear-connector.js", () => ({
   claimLinearContentSyncRetry: mocks.claimContentRetry,
   deleteLinearConnectionById: vi.fn(),
-  getLinearSyncTargetWithRepoByConnectionId: mocks.getTarget,
+  getLinearBindingWithRepoByConnectionId: mocks.getTarget,
   MULTIPLE_LINEAR_CONNECTIONS_MESSAGE: "multiple",
   patchLinearConnectorConfig: mocks.patchConfig,
   refreshLinearConnectionTokensWithLock: vi.fn(),
   releaseLinearConfigPrCreationClaim: mocks.releaseClaim,
   resolveLinearConnectionForOrgDetailed: mocks.resolveConnection,
-  updateLinearSyncTargetPrState: mocks.updatePrState,
+  updateLinearBindingPrState: mocks.updatePrState,
   upsertLinearConnectionFromOAuth: mocks.upsertConnection,
 }))
 vi.mock("../../openworkflow/enqueue-repository-ingestion.js", () => ({
@@ -323,7 +323,6 @@ describe("Linear connector routes", () => {
   it("does not claim a config pull request for a target-only patch", async () => {
     mocks.patchConfig.mockResolvedValueOnce({
       scopes: [],
-      scopesChanged: false,
       syncTargetChanged: true,
       configPrClaimed: false,
     })
@@ -374,7 +373,6 @@ describe("Linear connector routes", () => {
     })
     mocks.patchConfig.mockResolvedValueOnce({
       scopes,
-      scopesChanged: true,
       syncTargetChanged: false,
       configPrClaimed: false,
     })
@@ -416,7 +414,6 @@ describe("Linear connector routes", () => {
     })
     mocks.patchConfig.mockResolvedValueOnce({
       scopes: [{ externalId: "team-1" }],
-      scopesChanged: false,
       syncTargetChanged: false,
       configPrClaimed: true,
       previousConfigPrState: {
@@ -463,7 +460,6 @@ describe("Linear connector routes", () => {
     mocks.loadConfig.mockResolvedValueOnce(null)
     mocks.patchConfig.mockResolvedValueOnce({
       scopes,
-      scopesChanged: false,
       syncTargetChanged: false,
       configPrClaimed: true,
       previousConfigPrState: {
@@ -506,7 +502,6 @@ describe("Linear connector routes", () => {
   it("restores the prior phase when configuration enqueue fails", async () => {
     mocks.patchConfig.mockResolvedValueOnce({
       scopes: [],
-      scopesChanged: true,
       syncTargetChanged: false,
       configPrClaimed: true,
       previousConfigPrState: {

--- a/apps/backend/src/routes/v1/connectors-linear.test.ts
+++ b/apps/backend/src/routes/v1/connectors-linear.test.ts
@@ -323,7 +323,6 @@ describe("Linear connector routes", () => {
   it("does not claim a config pull request for a target-only patch", async () => {
     mocks.patchConfig.mockResolvedValueOnce({
       scopes: [],
-      syncTargetChanged: true,
       configPrClaimed: false,
     })
     const app = appWithVariables().route(
@@ -351,7 +350,7 @@ describe("Linear connector routes", () => {
       orgId: "org_1",
       connectionId: "con_linear",
       claimConfigPrCreation: false,
-      syncTarget: {
+      binding: {
         repositoryId: "repo_1",
         branch: "main",
         enabled: true,
@@ -373,7 +372,6 @@ describe("Linear connector routes", () => {
     })
     mocks.patchConfig.mockResolvedValueOnce({
       scopes,
-      syncTargetChanged: false,
       configPrClaimed: false,
     })
     const app = appWithVariables().route(
@@ -414,7 +412,6 @@ describe("Linear connector routes", () => {
     })
     mocks.patchConfig.mockResolvedValueOnce({
       scopes: [{ externalId: "team-1" }],
-      syncTargetChanged: false,
       configPrClaimed: true,
       previousConfigPrState: {
         pendingConfigPullUrl: null,
@@ -460,7 +457,6 @@ describe("Linear connector routes", () => {
     mocks.loadConfig.mockResolvedValueOnce(null)
     mocks.patchConfig.mockResolvedValueOnce({
       scopes,
-      syncTargetChanged: false,
       configPrClaimed: true,
       previousConfigPrState: {
         pendingConfigPullUrl: null,
@@ -502,7 +498,6 @@ describe("Linear connector routes", () => {
   it("restores the prior phase when configuration enqueue fails", async () => {
     mocks.patchConfig.mockResolvedValueOnce({
       scopes: [],
-      syncTargetChanged: false,
       configPrClaimed: true,
       previousConfigPrState: {
         pendingConfigPullUrl: null,

--- a/apps/backend/src/routes/v1/connectors-linear.ts
+++ b/apps/backend/src/routes/v1/connectors-linear.ts
@@ -7,10 +7,10 @@ import { getRepositoryForOrg } from "../../models/repositories.js"
 import {
   claimLinearContentSyncRetry,
   deleteLinearConnectionById,
-  getLinearSyncTargetWithRepoByConnectionId as getLinearConnectionBindingWithRepoByConnectionId,
+  getLinearBindingWithRepoByConnectionId,
   LinearConfigPrCreationInProgressError,
+  type LinearBindingWithRepo,
   type LinearConnection,
-  type LinearSyncTargetWithRepo as LinearConnectionBindingWithRepo,
   type LinearScope,
   LinearSyncBindingBusyError,
   MULTIPLE_LINEAR_CONNECTIONS_MESSAGE,
@@ -18,7 +18,7 @@ import {
   refreshLinearConnectionTokensWithLock,
   releaseLinearConfigPrCreationClaim,
   resolveLinearConnectionForOrgDetailed,
-  updateLinearSyncTargetPrState as updateLinearConnectionBindingPrState,
+  updateLinearBindingPrState,
   upsertLinearConnectionFromOAuth,
 } from "../../models/linear-connector.js"
 import { getLogger } from "../../observability/logger.js"
@@ -472,7 +472,7 @@ async function resolveInstalledLinear(
 async function loadLinearScopesFromGit(input: {
   orgId: string
   env: AppEnv["Variables"]["env"]
-  binding: LinearConnectionBindingWithRepo | undefined
+  binding: LinearBindingWithRepo | undefined
   fallbackToTargetBranch?: boolean
 }): Promise<LinearScope[]> {
   const { binding } = input
@@ -567,7 +567,7 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
     const [isGithubLinked, binding] = await Promise.all([
       orgHasAnyGithubConnection(orgId),
       connection
-        ? getLinearConnectionBindingWithRepoByConnectionId(orgId, connection.id)
+        ? getLinearBindingWithRepoByConnectionId(orgId, connection.id)
         : Promise.resolve(undefined),
     ])
     const scopes = await loadLinearScopesFromGit({
@@ -658,7 +658,7 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
     if (installed.status === "error") {
       return c.json({ error: installed.error }, installed.httpStatus)
     }
-    const binding = await getLinearConnectionBindingWithRepoByConnectionId(
+    const binding = await getLinearBindingWithRepoByConnectionId(
       orgId,
       installed.connection.id,
     )
@@ -722,7 +722,7 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
             await loadLinearScopesFromGit({
               orgId,
               env: c.var.env,
-              binding: await getLinearConnectionBindingWithRepoByConnectionId(
+              binding: await getLinearBindingWithRepoByConnectionId(
                 orgId,
                 installed.connection.id,
               ),
@@ -848,7 +848,7 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
     if (installed.status === "error") {
       return c.json({ error: installed.error }, installed.httpStatus)
     }
-    const binding = await getLinearConnectionBindingWithRepoByConnectionId(
+    const binding = await getLinearBindingWithRepoByConnectionId(
       orgId,
       installed.connection.id,
     )
@@ -938,7 +938,7 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
     if (installed.status === "error") {
       return c.json({ error: installed.error }, installed.httpStatus)
     }
-    const binding = await getLinearConnectionBindingWithRepoByConnectionId(
+    const binding = await getLinearBindingWithRepoByConnectionId(
       orgId,
       installed.connection.id,
     )
@@ -966,7 +966,7 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
         connectionId: installed.connection.id,
       })
     } catch (error) {
-      await updateLinearConnectionBindingPrState({
+      await updateLinearBindingPrState({
         connectionId: installed.connection.id,
         pendingConfigPullUrl: null,
         pendingConfigPrCreating: false,

--- a/apps/backend/src/routes/v1/connectors-linear.ts
+++ b/apps/backend/src/routes/v1/connectors-linear.ts
@@ -714,7 +714,8 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
       return c.json({ error: installed.error }, installed.httpStatus)
     }
     const body = LinearPatchConfigRequestSchema.parse(await c.req.json())
-    const scopesChanged =
+    // Compare against git scope only to skip noop manage-scope (no DB draft).
+    const shouldEnqueueConfigPr =
       body.scopes === undefined
         ? false
         : !linearScopesEqual(
@@ -734,10 +735,10 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
       saved = await patchLinearConnectorConfig({
         orgId,
         connectionId: installed.connection.id,
-        claimConfigPrCreation: scopesChanged,
+        claimConfigPrCreation: shouldEnqueueConfigPr,
         ...(body.scopes !== undefined ? { scopes: body.scopes } : {}),
         ...(body.syncTarget !== undefined
-          ? { syncTarget: body.syncTarget }
+          ? { binding: body.syncTarget }
           : {}),
       })
     } catch (error) {

--- a/apps/backend/src/routes/webhooks/github/github-linear-push.test.ts
+++ b/apps/backend/src/routes/webhooks/github/github-linear-push.test.ts
@@ -30,10 +30,10 @@ vi.mock("../../../models/repositories.js", () => ({
 }))
 vi.mock("../../../models/linear-connector.js", () => ({
   getLinearConnectionByConnectionId: mocks.getConnection,
-  listLinearSyncTargetsWithRepoByRepositoryId: mocks.listTargets,
-  markLinearSyncTargetInitialSync: mocks.markInitialSync,
+  listLinearBindingsWithRepoByRepositoryId: mocks.listTargets,
+  claimLinearBindingInitialSync: mocks.markInitialSync,
   resetLinearConnectorAfterMissingConfig: mocks.reset,
-  transitionLinearSyncTargetState: mocks.transitionState,
+  transitionLinearBindingState: mocks.transitionState,
 }))
 vi.mock("../../../openworkflow/client.js", () => ({
   runWorkflowWithWorkerWake: mocks.runWorkflow,

--- a/apps/backend/src/routes/webhooks/github/github-linear-push.test.ts
+++ b/apps/backend/src/routes/webhooks/github/github-linear-push.test.ts
@@ -95,7 +95,11 @@ describe("Linear config push activation", () => {
       log: { error: vi.fn() },
     })
 
-    expect(mocks.markInitialSync).toHaveBeenCalledWith("con_linear")
+    expect(mocks.markInitialSync).toHaveBeenCalledWith({
+      connectionId: "con_linear",
+      repositoryId: "repo_1",
+      branch: "main",
+    })
     expect(mocks.runWorkflow).toHaveBeenCalledWith(
       { name: "linear-sync-content" },
       { orgId: "org_1", connectionId: "con_linear" },
@@ -138,7 +142,11 @@ describe("Linear config push activation", () => {
       log: { error: vi.fn() },
     })
 
-    expect(mocks.markInitialSync).toHaveBeenCalledWith("con_linear")
+    expect(mocks.markInitialSync).toHaveBeenCalledWith({
+      connectionId: "con_linear",
+      repositoryId: "repo_1",
+      branch: "main",
+    })
     expect(mocks.runWorkflow).not.toHaveBeenCalled()
   })
 

--- a/apps/backend/src/routes/webhooks/github/github-linear-push.test.ts
+++ b/apps/backend/src/routes/webhooks/github/github-linear-push.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   markInitialSync: vi.fn(),
   reset: vi.fn(),
   runWorkflow: vi.fn(),
+  transitionState: vi.fn(),
 }))
 
 vi.mock("../../../config/env.js", () => ({
@@ -32,6 +33,7 @@ vi.mock("../../../models/linear-connector.js", () => ({
   listLinearSyncTargetsWithRepoByRepositoryId: mocks.listTargets,
   markLinearSyncTargetInitialSync: mocks.markInitialSync,
   resetLinearConnectorAfterMissingConfig: mocks.reset,
+  transitionLinearSyncTargetState: mocks.transitionState,
 }))
 vi.mock("../../../openworkflow/client.js", () => ({
   runWorkflowWithWorkerWake: mocks.runWorkflow,
@@ -61,6 +63,7 @@ beforeEach(() => {
     {
       orgId: "org_1",
       connectionId: "con_linear",
+      repositoryId: "repo_1",
       repositoryName: "acme/context",
       githubConnectionId: "con_github",
       branch: "main",
@@ -78,6 +81,7 @@ beforeEach(() => {
   })
   mocks.compareCommits.mockResolvedValue(false)
   mocks.markInitialSync.mockResolvedValue(true)
+  mocks.transitionState.mockResolvedValue(true)
 })
 
 describe("Linear config push activation", () => {
@@ -153,5 +157,31 @@ describe("Linear config push activation", () => {
         log: { error: vi.fn() },
       }),
     ).rejects.toThrow("GitHub unavailable")
+  })
+
+  it("restores awaiting_merge when initial-sync enqueue fails", async () => {
+    mocks.runWorkflow.mockRejectedValueOnce(new Error("worker unavailable"))
+    const error = vi.fn()
+
+    await maybeActivateLinearSyncOnConfigPush({
+      installationId: 42,
+      githubConnectionId: "con_github",
+      repoFullName: "acme/context",
+      ref: "refs/heads/main",
+      commits: [{ modified: ["linear/config.yaml"] }],
+      log: { error },
+    })
+
+    expect(mocks.transitionState).toHaveBeenCalledWith({
+      connectionId: "con_linear",
+      expectedSetupPhase: "initial_sync",
+      expectedPendingConfigPrCreating: false,
+      repositoryId: "repo_1",
+      branch: "main",
+      pendingConfigPullUrl: null,
+      pendingConfigPrCreating: false,
+      setupPhase: "awaiting_merge",
+    })
+    expect(error).toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/routes/webhooks/github/github-linear-push.ts
+++ b/apps/backend/src/routes/webhooks/github/github-linear-push.ts
@@ -3,10 +3,10 @@ import { withOrgDbContext } from "../../../db/client.js"
 import { listInstallationsByGithubInstallationId } from "../../../models/github-installation.js"
 import {
   getLinearConnectionByConnectionId,
-  listLinearSyncTargetsWithRepoByRepositoryId,
-  markLinearSyncTargetInitialSync,
+  listLinearBindingsWithRepoByRepositoryId,
+  claimLinearBindingInitialSync,
   resetLinearConnectorAfterMissingConfig,
-  transitionLinearSyncTargetState,
+  transitionLinearBindingState,
 } from "../../../models/linear-connector.js"
 import { findRepositoryByGithubInstallation } from "../../../models/repositories.js"
 import { runWorkflowWithWorkerWake } from "../../../openworkflow/client.js"
@@ -97,7 +97,7 @@ export async function maybeActivateLinearSyncOnConfigPush(input: {
     }
     if (!configTouched) continue
 
-    const targets = await listLinearSyncTargetsWithRepoByRepositoryId(
+    const targets = await listLinearBindingsWithRepoByRepositoryId(
       repository.id,
     )
     for (const target of targets) {
@@ -140,7 +140,7 @@ export async function maybeActivateLinearSyncOnConfigPush(input: {
       }
 
       if (
-        !(await markLinearSyncTargetInitialSync({
+        !(await claimLinearBindingInitialSync({
           connectionId: target.connectionId,
           repositoryId: target.repositoryId,
           branch: target.branch,
@@ -155,7 +155,7 @@ export async function maybeActivateLinearSyncOnConfigPush(input: {
         })
       } catch (error) {
         // Avoid leaving a stuck initial_sync that blocks later CAS claims.
-        await transitionLinearSyncTargetState({
+        await transitionLinearBindingState({
           connectionId: target.connectionId,
           expectedSetupPhase: "initial_sync",
           expectedPendingConfigPrCreating: false,

--- a/apps/backend/src/routes/webhooks/github/github-linear-push.ts
+++ b/apps/backend/src/routes/webhooks/github/github-linear-push.ts
@@ -6,6 +6,7 @@ import {
   listLinearSyncTargetsWithRepoByRepositoryId,
   markLinearSyncTargetInitialSync,
   resetLinearConnectorAfterMissingConfig,
+  transitionLinearSyncTargetState,
 } from "../../../models/linear-connector.js"
 import { findRepositoryByGithubInstallation } from "../../../models/repositories.js"
 import { runWorkflowWithWorkerWake } from "../../../openworkflow/client.js"
@@ -140,10 +141,27 @@ export async function maybeActivateLinearSyncOnConfigPush(input: {
 
       if (!(await markLinearSyncTargetInitialSync(target.connectionId)))
         continue
-      await runWorkflowWithWorkerWake(linearSyncContent.spec, {
-        orgId: target.orgId,
-        connectionId: target.connectionId,
-      })
+      try {
+        await runWorkflowWithWorkerWake(linearSyncContent.spec, {
+          orgId: target.orgId,
+          connectionId: target.connectionId,
+        })
+      } catch (error) {
+        // Avoid leaving a stuck initial_sync that blocks later CAS claims.
+        await transitionLinearSyncTargetState({
+          connectionId: target.connectionId,
+          expectedSetupPhase: "initial_sync",
+          expectedPendingConfigPrCreating: false,
+          repositoryId: target.repositoryId,
+          branch: target.branch,
+          pendingConfigPullUrl: null,
+          pendingConfigPrCreating: false,
+          setupPhase: "awaiting_merge",
+        })
+        input.log.error(
+          error instanceof Error ? error : new Error(String(error)),
+        )
+      }
     }
   }
 }

--- a/apps/backend/src/routes/webhooks/github/github-linear-push.ts
+++ b/apps/backend/src/routes/webhooks/github/github-linear-push.ts
@@ -139,8 +139,15 @@ export async function maybeActivateLinearSyncOnConfigPush(input: {
         continue
       }
 
-      if (!(await markLinearSyncTargetInitialSync(target.connectionId)))
+      if (
+        !(await markLinearSyncTargetInitialSync({
+          connectionId: target.connectionId,
+          repositoryId: target.repositoryId,
+          branch: target.branch,
+        }))
+      ) {
         continue
+      }
       try {
         await runWorkflowWithWorkerWake(linearSyncContent.spec, {
           orgId: target.orgId,

--- a/apps/backend/src/routes/webhooks/linear/linear.test.ts
+++ b/apps/backend/src/routes/webhooks/linear/linear.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock("../../../models/linear-connector.js", () => ({
-  getLinearSyncTargetByConnectionId: mocks.getSyncTarget,
+  getLinearBindingByConnectionId: mocks.getSyncTarget,
   listLinearConnectionsByWorkspaceId: mocks.listConnections,
   recordLinearOAuthRevocation: mocks.recordRevocation,
 }))

--- a/apps/backend/src/routes/webhooks/linear/linear.ts
+++ b/apps/backend/src/routes/webhooks/linear/linear.ts
@@ -3,7 +3,7 @@ import type { OpenAPIHono } from "@hono/zod-openapi"
 import { LinearWebhookClient } from "@linear/sdk/webhooks"
 import type { AppEnv } from "../../../app/env.js"
 import {
-  getLinearSyncTargetByConnectionId,
+  getLinearBindingByConnectionId,
   listLinearConnectionsByWorkspaceId,
   recordLinearOAuthRevocation,
 } from "../../../models/linear-connector.js"
@@ -225,7 +225,7 @@ export function registerLinearWebhookRoute(app: OpenAPIHono<AppEnv>) {
     if (!target) return c.body(null, 202)
     for (const connection of connections) {
       if (connection.status !== "installed") continue
-      const syncTarget = await getLinearSyncTargetByConnectionId(connection.id)
+      const syncTarget = await getLinearBindingByConnectionId(connection.id)
       if (!syncTarget?.enabled || syncTarget.setupPhase !== "live") {
         continue
       }

--- a/apps/backend/src/routes/webhooks/linear/linear.ts
+++ b/apps/backend/src/routes/webhooks/linear/linear.ts
@@ -225,8 +225,8 @@ export function registerLinearWebhookRoute(app: OpenAPIHono<AppEnv>) {
     if (!target) return c.body(null, 202)
     for (const connection of connections) {
       if (connection.status !== "installed") continue
-      const syncTarget = await getLinearBindingByConnectionId(connection.id)
-      if (!syncTarget?.enabled || syncTarget.setupPhase !== "live") {
+      const binding = await getLinearBindingByConnectionId(connection.id)
+      if (!binding?.enabled || binding.setupPhase !== "live") {
         continue
       }
       await runWorkflowWithWorkerWake(linearSyncEntity.spec, {

--- a/apps/backend/src/services/linear/sync.test.ts
+++ b/apps/backend/src/services/linear/sync.test.ts
@@ -3,7 +3,7 @@ import type { Env } from "../../config/env.js"
 import type {
   LinearConnection,
   LinearScope,
-  LinearSyncTargetWithRepo,
+  LinearBindingWithRepo,
 } from "../../models/linear-connector.js"
 import { syncLinearConfigYaml, syncLinearContentToGit } from "./sync.js"
 
@@ -19,7 +19,7 @@ const content = vi.hoisted(() => ({
   buildLinearMirror: vi.fn(),
 }))
 const model = vi.hoisted(() => ({
-  withLinearSyncTargetSnapshot: vi.fn(
+  withLinearBindingSnapshot: vi.fn(
     async (_input: unknown, operation: () => Promise<unknown>) => operation(),
   ),
 }))
@@ -71,7 +71,7 @@ const target = {
   pendingConfigPrCreating: true,
   createdAt: new Date(),
   updatedAt: new Date(),
-} satisfies LinearSyncTargetWithRepo
+} satisfies LinearBindingWithRepo
 
 const scopes = [
   {
@@ -96,7 +96,7 @@ beforeEach(() => {
   github.listFilesInTree.mockResolvedValue([])
   github.commitFiles.mockResolvedValue("commit-sha")
   content.buildLinearMirror.mockResolvedValue({ files: [], failures: [] })
-  model.withLinearSyncTargetSnapshot.mockImplementation(
+  model.withLinearBindingSnapshot.mockImplementation(
     async (_input: unknown, operation: () => Promise<unknown>) => operation(),
   )
 })
@@ -183,7 +183,7 @@ describe("syncLinearContentToGit", () => {
       files: [{ path: "linear/issues/eng-1--issue-1.md", content: "stale" }],
       failures: [],
     })
-    model.withLinearSyncTargetSnapshot.mockRejectedValueOnce(
+    model.withLinearBindingSnapshot.mockRejectedValueOnce(
       new Error("Linear sync target changed while content was being built"),
     )
 

--- a/apps/backend/src/services/linear/sync.ts
+++ b/apps/backend/src/services/linear/sync.ts
@@ -2,8 +2,8 @@ import type { Env } from "../../config/env.js"
 import {
   type LinearConnection,
   type LinearScope,
-  type LinearSyncTargetWithRepo,
-  withLinearSyncTargetSnapshot,
+  type LinearBindingWithRepo,
+  withLinearBindingSnapshot,
 } from "../../models/linear-connector.js"
 import {
   closePullRequest,
@@ -34,7 +34,7 @@ export async function syncLinearConfigYaml(input: {
   orgSlug: string
   env: Env
   connection: LinearConnection
-  target: LinearSyncTargetWithRepo
+  target: LinearBindingWithRepo
   scopes: LinearScope[]
 }): Promise<{ changed: boolean; pullUrl?: string; pullNumber?: number }> {
   const githubConnectionId = input.target.githubConnectionId
@@ -116,7 +116,7 @@ export async function syncLinearContentToGit(input: {
   orgId: string
   env: Env
   connection: LinearConnection
-  target: LinearSyncTargetWithRepo
+  target: LinearBindingWithRepo
   config: ParsedLinearRepoConfig
   onTokenRefresh?: LinearTokenRefreshHandler
 }): Promise<{
@@ -169,7 +169,7 @@ export async function syncLinearContentToGit(input: {
           )
       : []
 
-  await withLinearSyncTargetSnapshot(
+  await withLinearBindingSnapshot(
     {
       connectionId: input.connection.id,
       repositoryId: input.target.repositoryId,
@@ -203,7 +203,7 @@ export async function syncLinearIncrementalContent(input: {
   orgId: string
   env: Env
   connection: LinearConnection
-  target: LinearSyncTargetWithRepo
+  target: LinearBindingWithRepo
   config: ParsedLinearRepoConfig
   entity: LinearEntityChange
   onTokenRefresh?: LinearTokenRefreshHandler
@@ -231,7 +231,7 @@ export async function syncLinearIncrementalContent(input: {
     existingPaths: existing.map((file) => file.path),
     onTokenRefresh: input.onTokenRefresh,
   })
-  await withLinearSyncTargetSnapshot(
+  await withLinearBindingSnapshot(
     {
       connectionId: input.connection.id,
       repositoryId: input.target.repositoryId,

--- a/apps/docs/content/docs/(guide)/connections/source-connectors/linear.mdx
+++ b/apps/docs/content/docs/(guide)/connections/source-connectors/linear.mdx
@@ -128,11 +128,14 @@ review the replacement configuration pull request.
 ## Keeping content current
 
 Linear sends signed webhook events to ctx| when supported entities change.
-After validating the event against the live Git scope, ctx| directly enqueues
-an OpenWorkflow entity-sync run, updates the affected files, and starts another
-repository ingestion. There is no Linear-specific dirty-entity table. Missed
-webhook events are not automatically backfilled: repair webhook delivery, then
-update the affected entities in Linear again so fresh events are delivered.
+While the connector is live, ctx| validates the event against the Git scope,
+directly enqueues an OpenWorkflow entity-sync run, updates the affected files,
+and starts another repository ingestion. Events that arrive before the connector
+is live (including during initial sync) are skipped — the same trade-off as
+Confluence — rather than buffered in a Linear-specific dirty-entity table.
+Missed webhook events are not automatically backfilled: repair webhook delivery,
+then update the affected entities in Linear again so fresh events are delivered,
+or use content retry / remirror after a failed initial sync.
 
 ## Verify the complete flow
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the post Round-2 Linear simplification on top of `linear-connector`: lifecycle race fixes and control-plane collapse. **No new queues, tables, or reconcile jobs.**

## Changes

### Should-fix / races
- Re-verify Linear binding after GitHub I/O (advisory lock not held across `commitFiles`)
- Restore `awaiting_merge` when content-sync enqueue fails after CAS into `initial_sync`
- CAS config-PR claim release only while still awaiting merge with the claim flag
- CAS initial sync against current `repositoryId` / `branch` / `enabled`

### Binding API simplify
- Rename SyncTarget helpers → Binding (`LinearBinding`, `claimLinearBindingInitialSync`, etc.)
- Delete dead exports: `getLinearConnectionForWebhook`, `markFailed`/`markLive`, `withLinearOrgContext`
- HTTP wire field `syncTarget` preserved; model patch uses `binding`
- Drop fake `scopesChanged` / unused `syncTargetChanged` returns; scopes are workflow transit (git compare is only the manage-scope noop guard)

### Considers
- Docs: non-live phases including `initial_sync` skip Linear webhooks (ADR-022 already stated this)
- Shared GitHub `manageUrl` / `installationId` filter kept
- Note to refresh parent PR #271 description (comment on this PR; `#271` comment via `gh` not permitted)

## Test plan

- [x] Focused Linear unit tests (connector model, push webhook, routes, sync/incremental, config/content/entity workflows, Linear webhook)
- [x] Sol adversarial passes on critical CAS / enqueue restore; binding rename reviewed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-194f5e2f-623e-4a82-9ee1-8cbf66915cd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-194f5e2f-623e-4a82-9ee1-8cbf66915cd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

