### PR TITLE
fix(cloud-agent): install unzip so Bun can be installed

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     git \
     sudo \
+    unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ########################################################


### PR DESCRIPTION
## Summary
- Cursor Cloud agent image builds fail at the Bun install step with `error: unzip is required to install bun`.
- Add `unzip` to the Ubuntu 24.04 base packages in `.cursor/Dockerfile` so `bun.sh/install` can run.

## Test plan
- [ ] Rebuild the Cloud Agent image so the updated Dockerfile is used
- [ ] Confirm the image build gets past `curl -fsSL https://bun.sh/install | bash`
- [ ] Confirm a new Cursor Cloud agent starts successfully


Made with [Cursor](https://cursor.com)