### PR TITLE
Instruct Cursor Task sub-agents to use Grok and Sol

### DIFF
--- a/.ai/memory/lessons-learned.md
+++ b/.ai/memory/lessons-learned.md
@@ -533,7 +533,7 @@ Highest-priority confirmed rules for agents. Migrated from former `patterns.md` 
 - **Source:** ui-design-skills research / product-ui skill
 
 ### Cursor Task models
-- **Rule:** always pass an explicit Task `model` (see root [AGENTS.md](../../AGENTS.md) **Cursor Task models**). Implementation and explore: `cursor-grok-4.6-high-fast`. Review and grilling: `gpt-5.6-sol-xhigh`. Map leftover Claude names: Sonnet/Fable/Haiku → Grok; Opus (including xhigh/fast) → Sol (`gpt-5.6-sol-xhigh` / `gpt-5.6-sol-high` / `gpt-5.6-sol-high-fast`). This is a parent-agent nudge; disabling Claude in Cursor Settings → Models is the hard block.
+- **Rule:** always pass an explicit Task `model` (see root [AGENTS.md](../../AGENTS.md) **Cursor Task models**). Implementation and explore: `cursor-grok-4.6-high-fast`. Review and grilling: `gpt-5.6-sol-high`. Map leftover Claude names: Sonnet/Fable/Haiku → Grok; Opus (including xhigh/fast) → `gpt-5.6-sol-high`. This is a parent-agent nudge; disabling Claude in Cursor Settings → Models is the hard block.
 - **Category:** convention
 - **Date:** 2026-08-17
 - **Source:** user preference (Grok for implementations, Sol for reviews)

--- a/.ai/memory/lessons-learned.md
+++ b/.ai/memory/lessons-learned.md
@@ -532,3 +532,9 @@ Highest-priority confirmed rules for agents. Migrated from former `patterns.md` 
 - **Date:** 2026-08-15
 - **Source:** ui-design-skills research / product-ui skill
 
+### Cursor Task models
+- **Rule:** always pass an explicit Task `model` (see root [AGENTS.md](../../AGENTS.md) **Cursor Task models**). Implementation and explore: `cursor-grok-4.6-high-fast`. Review and grilling: `gpt-5.6-sol-xhigh`. Map leftover Claude names: Sonnet/Fable/Haiku → Grok; Opus (including xhigh/fast) → Sol (`gpt-5.6-sol-xhigh` / `gpt-5.6-sol-high` / `gpt-5.6-sol-high-fast`). This is a parent-agent nudge; disabling Claude in Cursor Settings → Models is the hard block.
+- **Category:** convention
+- **Date:** 2026-08-17
+- **Source:** user preference (Grok for implementations, Sol for reviews)
+

--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -57,6 +57,8 @@ Each smell reads *what it is* → *how to fix*; match it against the diff:
 
 ### 4. Spawn both sub-agents in parallel
 
+Spawn both with `model: gpt-5.6-sol-xhigh`.
+
 **Standards sub-agent prompt** — include:
 
 - The full diff command and commit list.

--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -57,7 +57,7 @@ Each smell reads *what it is* → *how to fix*; match it against the diff:
 
 ### 4. Spawn both sub-agents in parallel
 
-Spawn both with `model: gpt-5.6-sol-xhigh`.
+Spawn both with `model: gpt-5.6-sol-high`.
 
 **Standards sub-agent prompt** — include:
 

--- a/.cursor/skills/implement/SKILL.md
+++ b/.cursor/skills/implement/SKILL.md
@@ -12,6 +12,6 @@ Use /tdd where possible, at pre-agreed seams.
 
 Run typechecking regularly, single test files regularly, and the full test suite once at the end.
 
-Once done, use /code-review (`gpt-5.6-sol-xhigh`) to review the work.
+Once done, use /code-review (`gpt-5.6-sol-high`) to review the work.
 
 Commit your work to the current branch.

--- a/.cursor/skills/implement/SKILL.md
+++ b/.cursor/skills/implement/SKILL.md
@@ -6,10 +6,12 @@ disable-model-invocation: true
 
 Implement the work described by the user in the spec or tickets.
 
+Use `cursor-grok-4.6-high-fast` for implementation Task sub-agents.
+
 Use /tdd where possible, at pre-agreed seams.
 
 Run typechecking regularly, single test files regularly, and the full test suite once at the end.
 
-Once done, use /code-review to review the work.
+Once done, use /code-review (`gpt-5.6-sol-xhigh`) to review the work.
 
 Commit your work to the current branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ For Storybook conventions and tools, read [.agents/skills/storybook/SKILL.md](.a
 
 Skills that say "commit your work" (or similar) are overridden: create a git commit only when the user explicitly asks to commit in the conversation.
 
+### Cursor Task models
+
+On Task, always set `model`: `cursor-grok-4.6-high-fast` for implementation and explore; `gpt-5.6-sol-xhigh` for review and grilling. Treat Claude/Sonnet/Opus/Fable/Haiku names as those two slugs.
+
 ### Issue tracker
 
 Local markdown under `.ai/scratchpad/<feature>/`. See [`.ai/agents/issue-tracker.md`](.ai/agents/issue-tracker.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Skills that say "commit your work" (or similar) are overridden: create a git com
 
 ### Cursor Task models
 
-On Task, always set `model`: `cursor-grok-4.6-high-fast` for implementation and explore; `gpt-5.6-sol-xhigh` for review and grilling. Treat Claude/Sonnet/Opus/Fable/Haiku names as those two slugs.
+On Task, always set `model`: `cursor-grok-4.6-high-fast` for implementation and explore; `gpt-5.6-sol-high` for review and grilling. Treat Claude/Sonnet/Opus/Fable/Haiku names as those two slugs.
 
 ### Issue tracker
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Soft routing for Cursor Task sub-agents so the parent stops defaulting isolated work to Claude/Sonnet.

**Always pass `model` on Task** (do not inherit):

- Implementation and explore: `cursor-grok-4.6-high-fast`
- Review and grilling: `gpt-5.6-sol-high`
- Claude/Sonnet/Opus/Fable/Haiku names map to those two slugs

This is a parent-agent nudge. Disabling Claude in Cursor Settings → Models remains the hard block.

Changes:

- Short **Cursor Task models** section in `AGENTS.md`
- Confirmed lesson with the remap table in `.ai/memory/lessons-learned.md`
- `/implement` and `/code-review` pass the matching slugs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4df83ac1-3493-4d91-a462-155a15cb7306?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4df83ac1-3493-4d91-a462-155a15cb7306&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

