### PR TITLE
Handle codesearch ingest OOM with memory-fit error and complete_with_issues

### DIFF
--- a/.ai/memory/lessons-learned.md
+++ b/.ai/memory/lessons-learned.md
@@ -281,7 +281,7 @@ Highest-priority confirmed rules for agents. Migrated from former `patterns.md` 
 - **Source:** migrated from patterns.md
 
 ### Durable repository indexing
-- **Rule:** durability belongs in OpenWorkflow step boundaries, not DIY codesearch/Postgres phase checkpoints. `repository-ingestion` runs child workflow `repository-index` (clone-checkout → zoekt fail-fast → detect-languages → `Promise.all` `scip:${lang}` → merge-scip). Codesearch exposes phase HTTP APIs with in-process spawn admission and same-repo purge exclusion (no begin/end lease). Step badge writes are monotonic. Extract is OW+ReAct (per-root `extract-kind` then `identify`, then dedup/project/embed) — keep LangGraph for conversation/Studio, not as the ingest durable orchestrator.
+- **Rule:** durability belongs in OpenWorkflow step boundaries, not DIY codesearch/Postgres phase checkpoints. `repository-ingestion` runs child workflow `repository-index` (clone-checkout → zoekt non-fatal → detect-languages → `Promise.all` `scip:${lang}` → merge-scip). Zoekt failure returns `searchIndexOk: false` and the parent marks `complete_with_issues` so extract can still run. Codesearch exposes phase HTTP APIs with in-process spawn admission and same-repo purge exclusion (no begin/end lease). Step badge writes are monotonic. Extract is OW+ReAct (per-root `extract-kind` then `identify`, then dedup/project/embed) — keep LangGraph for conversation/Studio, not as the ingest durable orchestrator.
 - **Category:** convention
 - **Date:** 2026-08-11
 - **Source:** migrated from patterns.md

--- a/.changeset/codesearch-ingest-memory.md
+++ b/.changeset/codesearch-ingest-memory.md
@@ -2,4 +2,4 @@
 "@ctxpipe/aws-cdk": minor
 ---
 
-Raise codesearch Fargate memory to 4/8/12 GiB on small/medium/large so ingest peaks fit, and ship Zoekt-optional complete-with-issues ingest plus a memory-fit error instead of fetch failed.
+Raise codesearch Fargate memory to 4/8/12 GiB on small/medium/large so ingest peaks fit. Upgrading this package and running `cdk deploy` also rolls pinned backend, worker, UI, codesearch, and migrate images: Zoekt-optional `complete_with_issues` ingest, the memory-fit error instead of `fetch failed`, and the Postgres enum migration (run automatically on deploy).

--- a/.changeset/codesearch-ingest-memory.md
+++ b/.changeset/codesearch-ingest-memory.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": minor
+---
+
+Raise codesearch Fargate memory to 4/8/12 GiB on small/medium/large so ingest peaks fit, and ship Zoekt-optional complete-with-issues ingest plus a memory-fit error instead of fetch failed.

--- a/apps/backend/migrations/20260818080007_complete_with_issues/migration.sql
+++ b/apps/backend/migrations/20260818080007_complete_with_issues/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "repository_indexing_status" ADD VALUE 'complete_with_issues';

--- a/apps/backend/migrations/20260818080007_complete_with_issues/snapshot.json
+++ b/apps/backend/migrations/20260818080007_complete_with_issues/snapshot.json
@@ -1,0 +1,5563 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "97c34b7b-3a20-40cf-b296-32ee2aa60972",
+  "prevIds": [
+    "d5a414de-64ef-40f5-a8df-f306e0336bfe"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "queued",
+        "running",
+        "ready",
+        "failed",
+        "unindexing",
+        "complete_with_issues"
+      ],
+      "name": "repository_indexing_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "apikeys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "device_codes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "invitations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "jwkss",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "members",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_access_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_clients",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_consents",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_refresh_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "passkeys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "two_factors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "claim_evidence",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "claims",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "confluence_spaces",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "confluence_sync_targets",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "connections",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "conversations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "objects",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "org_onboarding",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "pending_accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "repositories",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "repository_checkouts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'default'",
+      "generated": null,
+      "identity": null,
+      "name": "config_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "prefix",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refill_interval",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refill_amount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_refill_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "rate_limit_enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "86400000",
+      "generated": null,
+      "identity": null,
+      "name": "rate_limit_time_window",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "10",
+      "generated": null,
+      "identity": null,
+      "name": "rate_limit_max",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "request_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "remaining",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_request",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "permissions",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_polled_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "polling_interval",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "jwkss"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "jwkss"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "private_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "jwkss"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "jwkss"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "jwkss"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_secret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "disabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "skip_consent",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "enable_end_session",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "contacts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tos",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "policy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "software_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "software_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "software_statement",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "redirect_uris",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_logout_redirect_uris",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_endpoint_auth_method",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "grant_types",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "response_types",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "auth_time",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "counter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transports",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "two_factors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "secret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "two_factors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backup_codes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "two_factors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "two_factors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "two_factor_enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "onboarding_completed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "claim_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logical_source_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "extraction_method",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "real",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "confidence",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valid_from",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valid_to",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provenance",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subject_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "predicate",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "object_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valid_from",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valid_to",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_observed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_observed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "real",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aggregated_confidence",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "connection_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "space_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "space_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "selected_page_ids",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_synced_page_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_synced_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "connection_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "branch",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'live'",
+      "generated": null,
+      "identity": null,
+      "name": "setup_phase",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pending_config_pull_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "pending_config_pr_creating",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'New Chat'",
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_message_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deduplication_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "vector(2000)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embedding",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "search_content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_onboarding"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_onboarding"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_by_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_onboarding"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_onboarding"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conflicting_account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "git_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "index_ready",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "repository_indexing_status",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "indexing_status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "indexing_error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "indexing_failed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_ingested_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_ingested_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "indexing_reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "indexing_step",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "indexing_step_total",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "indexing_step_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "github_connection_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'main'",
+      "generated": null,
+      "identity": null,
+      "name": "ref",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "commit_sha",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checkout_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "zoekt_repo_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "config_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "apikeys_configId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "reference_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "apikeys_referenceId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "apikeys_key_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "apikeys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_email_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_slug_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "passkeys_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "passkeys_credentialID_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "secret",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "twoFactors_secret_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "two_factors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "twoFactors_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "two_factors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "claim_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "claim_evidence_claim_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "logical_source_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "claim_evidence_logical_source_key_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "claims_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "subject_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "claims_subject_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "object_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "claims_object_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "claims_status_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "claims"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "connection_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "confluence_spaces_connection_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "connection_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "confluence_sync_targets_connection_id_uq",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "confluence_sync_targets_repository_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "connections_org_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "connections_org_id_type_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "last_message_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversations_org_id_last_message_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversations_org_id_source_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversations_org_id_updated_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "last_message_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversations_org_id_user_id_last_message_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "objects_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "objects_kind_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "objects_org_id_kind_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deduplication_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "objects_org_id_deduplication_key_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "embedding",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": {
+            "name": "vector_cosine_ops",
+            "default": false
+          }
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "hnsw",
+      "concurrently": false,
+      "name": "retrieval_embeddings_embedding_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "to_tsvector('english', \"search_content\")",
+          "isExpression": true,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "retrieval_search_content_fts_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "objects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "pending_accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "repositories_name_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "github_connection_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "repositories_github_connection_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "repository_checkouts_repository_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_inviter_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "oauth_clients",
+      "columnsTo": [
+        "client_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "oauth_access_tokens_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_access_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "refresh_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "oauth_refresh_tokens",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_clients_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_clients"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "oauth_clients",
+      "columnsTo": [
+        "client_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_consents_client_id_oauth_clients_client_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_consents_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "oauth_clients",
+      "columnsTo": [
+        "client_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "oauth_refresh_tokens_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_refresh_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_refresh_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "passkeys_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "two_factors_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "two_factors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "claim_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "claims",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "claim_evidence_claim_id_claims_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "claim_evidence"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "connection_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "connections",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "confluence_spaces_connection_id_connections_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "confluence_sync_targets_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "connection_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "connections",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "confluence_sync_targets_connection_id_connections_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "repository_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "repositories",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "confluence_sync_targets_repository_id_repositories_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "confluence_sync_targets"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "connections_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "connections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_onboarding_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_onboarding"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "completed_by_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "org_onboarding_completed_by_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_onboarding"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "pending_accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "pending_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "github_connection_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "connections",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "repositories_github_connection_id_connections_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "repository_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "repositories",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "repository_checkouts_repository_id_repositories_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "public",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "apikeys_pkey",
+      "schema": "public",
+      "table": "apikeys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "device_codes_pkey",
+      "schema": "public",
+      "table": "device_codes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitations_pkey",
+      "schema": "public",
+      "table": "invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "jwkss_pkey",
+      "schema": "public",
+      "table": "jwkss",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "members_pkey",
+      "schema": "public",
+      "table": "members",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_access_tokens_pkey",
+      "schema": "public",
+      "table": "oauth_access_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_clients_pkey",
+      "schema": "public",
+      "table": "oauth_clients",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_consents_pkey",
+      "schema": "public",
+      "table": "oauth_consents",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_refresh_tokens_pkey",
+      "schema": "public",
+      "table": "oauth_refresh_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "passkeys_pkey",
+      "schema": "public",
+      "table": "passkeys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "two_factors_pkey",
+      "schema": "public",
+      "table": "two_factors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "public",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "claim_evidence_pkey",
+      "schema": "public",
+      "table": "claim_evidence",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "claims_pkey",
+      "schema": "public",
+      "table": "claims",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "confluence_spaces_pkey",
+      "schema": "public",
+      "table": "confluence_spaces",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "confluence_sync_targets_pkey",
+      "schema": "public",
+      "table": "confluence_sync_targets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "connections_pkey",
+      "schema": "public",
+      "table": "connections",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversations_pkey",
+      "schema": "public",
+      "table": "conversations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "objects_pkey",
+      "schema": "public",
+      "table": "objects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "organization_id"
+      ],
+      "nameExplicit": false,
+      "name": "org_onboarding_pkey",
+      "schema": "public",
+      "table": "org_onboarding",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "pending_accounts_pkey",
+      "schema": "public",
+      "table": "pending_accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repositories_pkey",
+      "schema": "public",
+      "table": "repositories",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_checkouts_pkey",
+      "schema": "public",
+      "table": "repository_checkouts",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "connection_id",
+        "space_key"
+      ],
+      "nullsNotDistinct": false,
+      "name": "confluence_spaces_connection_space_key_uq",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "confluence_spaces"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name",
+        "org_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "repositories_name_org_id_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "git_url",
+        "org_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "repositories_git_url_org_id_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "repositories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "repository_id",
+        "checkout_key"
+      ],
+      "nullsNotDistinct": false,
+      "name": "repository_checkouts_repository_id_checkout_key_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "repository_checkouts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_access_tokens_token_key",
+      "schema": "public",
+      "table": "oauth_access_tokens",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_clients_client_id_key",
+      "schema": "public",
+      "table": "oauth_clients",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_key",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "zoekt_repo_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "repository_checkouts_zoekt_repo_id_key",
+      "schema": "public",
+      "table": "repository_checkouts",
+      "entityType": "uniques"
+    }
+  ],
+  "renames": []
+}

--- a/apps/backend/src/db/schema/repositories.ts
+++ b/apps/backend/src/db/schema/repositories.ts
@@ -22,6 +22,7 @@ export const repositoryIndexingStatusValues = [
   "ready",
   "failed",
   "unindexing",
+  "complete_with_issues",
 ] as const
 export const repositoryIndexingStatusEnum = pgEnum(
   "repository_indexing_status",

--- a/apps/backend/src/domain/codeIngestion/codesearchIndexPhases.test.ts
+++ b/apps/backend/src/domain/codeIngestion/codesearchIndexPhases.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const signUpstreamJwtMock = vi.hoisted(() => vi.fn())
+const parseEnvMock = vi.hoisted(() => vi.fn())
+const codesearchBaseUrlMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../auth/upstreamJwt.js", () => ({
+  signUpstreamJwt: signUpstreamJwtMock,
+}))
+vi.mock("../../config/env.js", () => ({
+  parseEnv: parseEnvMock,
+}))
+vi.mock("../../lib/agentToolRuntime.js", () => ({
+  codesearchBaseUrl: codesearchBaseUrlMock,
+}))
+vi.mock("../../lib/withTransientHttpRetry.js", () => ({
+  withTransientHttpRetry: async (run: () => Promise<unknown>) => run(),
+}))
+vi.mock("../../observability/logger.js", () => ({
+  log: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}))
+
+import { CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY } from "../../lib/memoryFitError.js"
+import { codesearchIndexZoekt } from "./codesearchIndexPhases.js"
+
+describe("codesearchIndexZoekt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    signUpstreamJwtMock.mockResolvedValue("token")
+    parseEnvMock.mockReturnValue({})
+    codesearchBaseUrlMock.mockReturnValue("http://codesearch:3001")
+  })
+
+  it("rewrites exhausted fetch failed to the memory-fit message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("fetch failed")),
+    )
+    await expect(
+      codesearchIndexZoekt({ repositoryId: "repo_1", orgId: "org_1" }),
+    ).rejects.toThrow(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY)
+    vi.unstubAllGlobals()
+  })
+
+  it("rewrites HTTP 500 exit 137 bodies to the memory-fit message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: "Command failed with exit code 137\nstderr: Killed",
+          }),
+          { status: 500 },
+        ),
+      ),
+    )
+    await expect(
+      codesearchIndexZoekt({ repositoryId: "repo_1", orgId: "org_1" }),
+    ).rejects.toThrow(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY)
+    vi.unstubAllGlobals()
+  })
+})

--- a/apps/backend/src/domain/codeIngestion/codesearchIndexPhases.test.ts
+++ b/apps/backend/src/domain/codeIngestion/codesearchIndexPhases.test.ts
@@ -42,6 +42,19 @@ describe("codesearchIndexZoekt", () => {
     vi.unstubAllGlobals()
   })
 
+  it("rewrites exhausted ECONNRESET to the memory-fit message", async () => {
+    const cause = new Error("read ECONNRESET") as NodeJS.ErrnoException
+    cause.code = "ECONNRESET"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("fetch failed", { cause })),
+    )
+    await expect(
+      codesearchIndexZoekt({ repositoryId: "repo_1", orgId: "org_1" }),
+    ).rejects.toThrow(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY)
+    vi.unstubAllGlobals()
+  })
+
   it("rewrites HTTP 500 exit 137 bodies to the memory-fit message", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/backend/src/domain/codeIngestion/codesearchIndexPhases.ts
+++ b/apps/backend/src/domain/codeIngestion/codesearchIndexPhases.ts
@@ -4,6 +4,7 @@ import { parseEnv } from "../../config/env.js"
 import { codesearchBaseUrl } from "../../lib/agentToolRuntime.js"
 import {
   CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+  isCodesearchTaskDeath,
   isMemoryFitFailure,
   userFacingIndexingError,
 } from "../../lib/memoryFitError.js"
@@ -67,7 +68,7 @@ async function codesearchPhaseFetch(
       { retries: 10, baseDelayMs: 200, maxDelayMs: 30_000 },
     )
   } catch (error) {
-    if (isMemoryFitFailure(error)) {
+    if (isMemoryFitFailure(error) || isCodesearchTaskDeath(error)) {
       log.info({
         step: "repository-index.memory_exceeded",
         path,

--- a/apps/backend/src/domain/codeIngestion/codesearchIndexPhases.ts
+++ b/apps/backend/src/domain/codeIngestion/codesearchIndexPhases.ts
@@ -2,7 +2,13 @@ import { z } from "zod"
 import { signUpstreamJwt } from "../../auth/upstreamJwt.js"
 import { parseEnv } from "../../config/env.js"
 import { codesearchBaseUrl } from "../../lib/agentToolRuntime.js"
+import {
+  CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+  isMemoryFitFailure,
+  userFacingIndexingError,
+} from "../../lib/memoryFitError.js"
 import { withTransientHttpRetry } from "../../lib/withTransientHttpRetry.js"
+import { log } from "../../observability/logger.js"
 
 const renameSchema = z.object({
   from: z.string(),
@@ -37,28 +43,41 @@ async function codesearchPhaseFetch(
   init: RequestInit,
 ): Promise<Response> {
   const env = parseEnv(process.env as Record<string, string | undefined>)
-  return withTransientHttpRetry(
-    async () => {
-      const token = await signUpstreamJwt({
-        env,
-        audience: env.AUTH_TOKEN_AUDIENCE_CODESEARCH ?? "codesearch",
-        claims: {
-          sub: `repo:${auth.repositoryId}`,
-          orgId: auth.orgId,
-          principal: "service",
-        },
+  try {
+    return await withTransientHttpRetry(
+      async () => {
+        const token = await signUpstreamJwt({
+          env,
+          audience: env.AUTH_TOKEN_AUDIENCE_CODESEARCH ?? "codesearch",
+          claims: {
+            sub: `repo:${auth.repositoryId}`,
+            orgId: auth.orgId,
+            principal: "service",
+          },
+        })
+        return fetch(`${codesearchBaseUrl()}/${auth.repositoryId}${path}`, {
+          ...init,
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            ...(init.headers ?? {}),
+          },
+        })
+      },
+      { retries: 10, baseDelayMs: 200, maxDelayMs: 30_000 },
+    )
+  } catch (error) {
+    if (isMemoryFitFailure(error)) {
+      log.info({
+        step: "repository-index.memory_exceeded",
+        path,
+        repositoryId: auth.repositoryId,
+        error: userFacingIndexingError(error),
       })
-      return fetch(`${codesearchBaseUrl()}/${auth.repositoryId}${path}`, {
-        ...init,
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-          ...(init.headers ?? {}),
-        },
-      })
-    },
-    { retries: 10, baseDelayMs: 200, maxDelayMs: 30_000 },
-  )
+      throw new Error(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY, { cause: error })
+    }
+    throw error
+  }
 }
 
 async function parseOrThrow<T>(
@@ -77,7 +96,12 @@ async function parseOrThrow<T>(
     } catch {
       // non-JSON
     }
-    throw new Error(`${label} failed with status ${res.status}: ${detail}`)
+    const combined = `${label} failed with status ${res.status}: ${detail}`
+    throw new Error(
+      isMemoryFitFailure(combined) || isMemoryFitFailure(detail)
+        ? CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY
+        : combined,
+    )
   }
   let json: unknown
   try {

--- a/apps/backend/src/lib/memoryFitError.test.ts
+++ b/apps/backend/src/lib/memoryFitError.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import {
+  CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+  isMemoryFitFailure,
+  memoryFitLogFields,
+  userFacingIndexingError,
+} from "./memoryFitError.js"
+
+describe("isMemoryFitFailure", () => {
+  it("detects indexer SIGKILL exit 137", () => {
+    expect(
+      isMemoryFitFailure(new Error("Command failed with exit code 137")),
+    ).toBe(true)
+  })
+
+  it("detects undici TypeError fetch failed", () => {
+    expect(isMemoryFitFailure(new TypeError("fetch failed"))).toBe(true)
+  })
+
+  it("detects ECONNRESET on nested cause", () => {
+    const cause = new Error("socket hang up") as NodeJS.ErrnoException
+    cause.code = "ECONNRESET"
+    expect(isMemoryFitFailure(new TypeError("fetch failed", { cause }))).toBe(
+      true,
+    )
+  })
+
+  it("detects EPIPE and ENOMEM errnos", () => {
+    const pipe = new Error("write EPIPE") as NodeJS.ErrnoException
+    pipe.code = "EPIPE"
+    const mem = new Error("Cannot allocate memory") as NodeJS.ErrnoException
+    mem.code = "ENOMEM"
+    expect(isMemoryFitFailure(pipe)).toBe(true)
+    expect(isMemoryFitFailure(mem)).toBe(true)
+  })
+
+  it("does not treat unrelated errors as memory-fit", () => {
+    expect(isMemoryFitFailure(new Error("Repository not found"))).toBe(false)
+    expect(isMemoryFitFailure(new Error("Command failed with exit code 1"))).toBe(
+      false,
+    )
+  })
+})
+
+describe("userFacingIndexingError", () => {
+  it("rewrites fetch failed and exit 137 to the canonical memory message", () => {
+    expect(userFacingIndexingError(new TypeError("fetch failed"))).toBe(
+      CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+    )
+    expect(
+      userFacingIndexingError(
+        new Error("Command failed with exit code 137\nstderr: killed"),
+      ),
+    ).toBe(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY)
+  })
+
+  it("passes through unrelated messages", () => {
+    expect(userFacingIndexingError(new Error("Repository not found"))).toBe(
+      "Repository not found",
+    )
+  })
+})
+
+describe("memoryFitLogFields", () => {
+  it("extracts errno and cause message from a nested fetch failure", () => {
+    const cause = new Error("read ECONNRESET") as NodeJS.ErrnoException
+    cause.code = "ECONNRESET"
+    expect(memoryFitLogFields(new TypeError("fetch failed", { cause }))).toEqual(
+      {
+        errno: "ECONNRESET",
+        cause: "read ECONNRESET",
+      },
+    )
+  })
+})

--- a/apps/backend/src/lib/memoryFitError.test.ts
+++ b/apps/backend/src/lib/memoryFitError.test.ts
@@ -36,9 +36,9 @@ describe("isMemoryFitFailure", () => {
 
   it("does not treat unrelated errors as memory-fit", () => {
     expect(isMemoryFitFailure(new Error("Repository not found"))).toBe(false)
-    expect(isMemoryFitFailure(new Error("Command failed with exit code 1"))).toBe(
-      false,
-    )
+    expect(
+      isMemoryFitFailure(new Error("Command failed with exit code 1")),
+    ).toBe(false)
   })
 })
 
@@ -65,11 +65,11 @@ describe("memoryFitLogFields", () => {
   it("extracts errno and cause message from a nested fetch failure", () => {
     const cause = new Error("read ECONNRESET") as NodeJS.ErrnoException
     cause.code = "ECONNRESET"
-    expect(memoryFitLogFields(new TypeError("fetch failed", { cause }))).toEqual(
-      {
-        errno: "ECONNRESET",
-        cause: "read ECONNRESET",
-      },
-    )
+    expect(
+      memoryFitLogFields(new TypeError("fetch failed", { cause })),
+    ).toEqual({
+      errno: "ECONNRESET",
+      cause: "read ECONNRESET",
+    })
   })
 })

--- a/apps/backend/src/lib/memoryFitError.test.ts
+++ b/apps/backend/src/lib/memoryFitError.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+  isCodesearchTaskDeath,
   isMemoryFitFailure,
   memoryFitLogFields,
   userFacingIndexingError,
@@ -13,24 +14,21 @@ describe("isMemoryFitFailure", () => {
     ).toBe(true)
   })
 
-  it("detects undici TypeError fetch failed", () => {
-    expect(isMemoryFitFailure(new TypeError("fetch failed"))).toBe(true)
+  it("does not treat undici fetch failed as memory-fit outside codesearch phases", () => {
+    expect(isMemoryFitFailure(new TypeError("fetch failed"))).toBe(false)
   })
 
-  it("detects ECONNRESET on nested cause", () => {
+  it("does not treat ECONNRESET as memory-fit outside codesearch phases", () => {
     const cause = new Error("socket hang up") as NodeJS.ErrnoException
     cause.code = "ECONNRESET"
     expect(isMemoryFitFailure(new TypeError("fetch failed", { cause }))).toBe(
-      true,
+      false,
     )
   })
 
-  it("detects EPIPE and ENOMEM errnos", () => {
-    const pipe = new Error("write EPIPE") as NodeJS.ErrnoException
-    pipe.code = "EPIPE"
+  it("detects ENOMEM errno", () => {
     const mem = new Error("Cannot allocate memory") as NodeJS.ErrnoException
     mem.code = "ENOMEM"
-    expect(isMemoryFitFailure(pipe)).toBe(true)
     expect(isMemoryFitFailure(mem)).toBe(true)
   })
 
@@ -42,16 +40,36 @@ describe("isMemoryFitFailure", () => {
   })
 })
 
+describe("isCodesearchTaskDeath", () => {
+  it("detects undici TypeError fetch failed", () => {
+    expect(isCodesearchTaskDeath(new TypeError("fetch failed"))).toBe(true)
+  })
+
+  it("detects ECONNRESET and EPIPE on nested cause", () => {
+    const reset = new Error("socket hang up") as NodeJS.ErrnoException
+    reset.code = "ECONNRESET"
+    const pipe = new Error("write EPIPE") as NodeJS.ErrnoException
+    pipe.code = "EPIPE"
+    expect(
+      isCodesearchTaskDeath(new TypeError("fetch failed", { cause: reset })),
+    ).toBe(true)
+    expect(isCodesearchTaskDeath(pipe)).toBe(true)
+  })
+})
+
 describe("userFacingIndexingError", () => {
-  it("rewrites fetch failed and exit 137 to the canonical memory message", () => {
-    expect(userFacingIndexingError(new TypeError("fetch failed"))).toBe(
-      CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
-    )
+  it("rewrites exit 137 to the canonical memory message", () => {
     expect(
       userFacingIndexingError(
         new Error("Command failed with exit code 137\nstderr: killed"),
       ),
     ).toBe(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY)
+  })
+
+  it("passes through extract fetch failed", () => {
+    expect(userFacingIndexingError(new TypeError("fetch failed"))).toBe(
+      "fetch failed",
+    )
   })
 
   it("passes through unrelated messages", () => {

--- a/apps/backend/src/lib/memoryFitError.ts
+++ b/apps/backend/src/lib/memoryFitError.ts
@@ -1,0 +1,71 @@
+/** User-visible copy when codesearch ingest hits a cgroup/OOM kill. */
+export const CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY =
+  "Codebase didn't fit available memory"
+
+const MEMORY_FIT_MESSAGE_RE =
+  /exit code 137\b|fetch failed|\bENOMEM\b|codebase didn't fit available memory/i
+
+const MEMORY_FIT_ERRNOS = new Set(["ECONNRESET", "EPIPE", "ENOMEM"])
+
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const code = (error as NodeJS.ErrnoException).code
+  return typeof code === "string" ? code : undefined
+}
+
+function collectErrors(error: unknown): unknown[] {
+  const out: unknown[] = []
+  const queue: unknown[] = [error]
+  const seen = new Set<unknown>()
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (current == null || seen.has(current)) continue
+    seen.add(current)
+    out.push(current)
+    if (current && typeof current === "object" && "cause" in current) {
+      queue.push((current as { cause: unknown }).cause)
+    }
+  }
+  return out
+}
+
+export function isMemoryFitFailure(error: unknown): boolean {
+  for (const item of collectErrors(error)) {
+    if (typeof item === "string" && MEMORY_FIT_MESSAGE_RE.test(item)) {
+      return true
+    }
+    if (item instanceof Error && MEMORY_FIT_MESSAGE_RE.test(item.message)) {
+      return true
+    }
+    const code = errorCode(item)
+    if (code && MEMORY_FIT_ERRNOS.has(code)) return true
+  }
+  return false
+}
+
+export function userFacingIndexingError(
+  error: unknown,
+  fallback = "Repository ingestion failed",
+): string {
+  if (isMemoryFitFailure(error)) return CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim()
+  }
+  if (typeof error === "string" && error.trim()) return error.trim()
+  return fallback
+}
+
+export function memoryFitLogFields(error: unknown): {
+  errno?: string
+  cause?: string
+} {
+  const fields: { errno?: string; cause?: string } = {}
+  for (const item of collectErrors(error)) {
+    const code = errorCode(item)
+    if (code && fields.errno == null) fields.errno = code
+    if (item instanceof Error && item !== error && fields.cause == null) {
+      fields.cause = item.message
+    }
+  }
+  return fields
+}

--- a/apps/backend/src/lib/memoryFitError.ts
+++ b/apps/backend/src/lib/memoryFitError.ts
@@ -3,9 +3,7 @@ export const CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY =
   "Codebase didn't fit available memory"
 
 const MEMORY_FIT_MESSAGE_RE =
-  /exit code 137\b|fetch failed|\bENOMEM\b|codebase didn't fit available memory/i
-
-const MEMORY_FIT_ERRNOS = new Set(["ECONNRESET", "EPIPE", "ENOMEM"])
+  /exit code 137\b|\bENOMEM\b|codebase didn't fit available memory/i
 
 function errorCode(error: unknown): string | undefined {
   if (!error || typeof error !== "object") return undefined
@@ -29,16 +27,25 @@ function collectErrors(error: unknown): unknown[] {
   return out
 }
 
+function matchesMessage(item: unknown, pattern: RegExp): boolean {
+  if (typeof item === "string") return pattern.test(item)
+  return item instanceof Error && pattern.test(item.message)
+}
+
 export function isMemoryFitFailure(error: unknown): boolean {
   for (const item of collectErrors(error)) {
-    if (typeof item === "string" && MEMORY_FIT_MESSAGE_RE.test(item)) {
-      return true
-    }
-    if (item instanceof Error && MEMORY_FIT_MESSAGE_RE.test(item.message)) {
-      return true
-    }
+    if (matchesMessage(item, MEMORY_FIT_MESSAGE_RE)) return true
+    if (errorCode(item) === "ENOMEM") return true
+  }
+  return false
+}
+
+/** Undici/socket death of the codesearch task — only remap at codesearch HTTP phases. */
+export function isCodesearchTaskDeath(error: unknown): boolean {
+  for (const item of collectErrors(error)) {
+    if (matchesMessage(item, /fetch failed/i)) return true
     const code = errorCode(item)
-    if (code && MEMORY_FIT_ERRNOS.has(code)) return true
+    if (code === "ECONNRESET" || code === "EPIPE") return true
   }
   return false
 }

--- a/apps/backend/src/lib/withTransientHttpRetry.test.ts
+++ b/apps/backend/src/lib/withTransientHttpRetry.test.ts
@@ -160,8 +160,8 @@ describe("withTransientHttpRetry", () => {
   })
 
   it("does not retry non-gateway Response statuses", async () => {
-    const result = await withTransientHttpRetry(async () =>
-      new Response("nope", { status: 404 }),
+    const result = await withTransientHttpRetry(
+      async () => new Response("nope", { status: 404 }),
     )
     expect(result.status).toBe(404)
     expect(log.info).not.toHaveBeenCalled()

--- a/apps/backend/src/lib/withTransientHttpRetry.test.ts
+++ b/apps/backend/src/lib/withTransientHttpRetry.test.ts
@@ -57,6 +57,28 @@ describe("withTransientHttpRetry", () => {
     expect(log.error).not.toHaveBeenCalled()
   })
 
+  it("logs nested cause and errno on fetch failed retries", async () => {
+    const cause = new Error("read ECONNRESET") as NodeJS.ErrnoException
+    cause.code = "ECONNRESET"
+    let n = 0
+    await withTransientHttpRetry(
+      async () => {
+        n += 1
+        if (n < 2) throw new TypeError("fetch failed", { cause })
+        return "ok"
+      },
+      { retries: 2, baseDelayMs: 1 },
+    )
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        step: "http.transient_retry",
+        message: "fetch failed",
+        errno: "ECONNRESET",
+        cause: "read ECONNRESET",
+      }),
+    )
+  })
+
   it("does not retry on AbortError", async () => {
     const err = new DOMException("aborted", "AbortError")
     await expect(

--- a/apps/backend/src/lib/withTransientHttpRetry.ts
+++ b/apps/backend/src/lib/withTransientHttpRetry.ts
@@ -1,4 +1,5 @@
 import { log } from "../observability/logger.js"
+import { memoryFitLogFields } from "./memoryFitError.js"
 
 /** Thrown to trigger a retry inside {@link withTransientHttpRetry}. */
 export class TransientHttpError extends Error {
@@ -103,6 +104,7 @@ export async function withTransientHttpRetry<T>(
           maxAttempts,
           delayMs,
           message: errorMessage(e),
+          ...memoryFitLogFields(e),
         })
         await new Promise((r) => setTimeout(r, delayMs))
         continue

--- a/apps/backend/src/models/repositories.test.ts
+++ b/apps/backend/src/models/repositories.test.ts
@@ -50,9 +50,9 @@ import {
   INDEXING_RUNNING_STALE_MS,
   listRepositoriesForGithubConnection,
   listRepositoriesForOrg,
-  pruneGithubConnectionRepositoriesNotInGitUrls,
   markRepositoryIndexingFailed,
   markRepositoryIndexingReadyWithIssues,
+  pruneGithubConnectionRepositoriesNotInGitUrls,
   setRepositoryIndexingStep,
   tryClaimRepositoryIndexingEnqueue,
 } from "./repositories.js"
@@ -62,9 +62,7 @@ const githubConnectionId = "con_github"
 const orgSlug = "acme"
 const repositoryId = "repo_AAAAAAAAAAAAAAAAAAAAAAAAAA"
 
-function mockLinkedRepos(
-  rows: Array<{ id: string; gitUrl: string }>,
-) {
+function mockLinkedRepos(rows: Array<{ id: string; gitUrl: string }>) {
   getOrgDbMock.mockReturnValue({
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
@@ -160,9 +158,7 @@ describe("getRepositoryForOrg", () => {
   it("returns null when no row matches (cross-tenant id)", async () => {
     mockRepositoryWithZoekt(null)
 
-    await expect(
-      getRepositoryForOrg(orgId, repositoryId),
-    ).resolves.toBeNull()
+    await expect(getRepositoryForOrg(orgId, repositoryId)).resolves.toBeNull()
     expect(getSystemDbMock).toHaveBeenCalledTimes(1)
   })
 })
@@ -317,7 +313,10 @@ describe("deleteRepository", () => {
   it("runs Postgres purge inside withOrgDbContext and graph/codesearch after", async () => {
     await deleteRepository({ orgId, orgSlug, repositoryId })
 
-    expect(withOrgDbContextMock).toHaveBeenCalledWith(orgId, expect.any(Function))
+    expect(withOrgDbContextMock).toHaveBeenCalledWith(
+      orgId,
+      expect.any(Function),
+    )
     expect(purgeRepositoryPostgresMock).toHaveBeenCalledWith({
       orgId,
       repositoryId,
@@ -409,13 +408,33 @@ describe("markRepositoryIndexingFailed", () => {
 
     await markRepositoryIndexingFailed({
       repositoryId,
-      error: new TypeError("fetch failed"),
+      error: new Error("Codebase didn't fit available memory"),
     })
 
     expect(set).toHaveBeenCalledWith(
       expect.objectContaining({
         indexingStatus: "failed",
         indexingError: "Codebase didn't fit available memory",
+        indexReady: false,
+      }),
+    )
+  })
+
+  it("does not remap unrelated fetch failed from non-codesearch work", async () => {
+    const where = vi.fn().mockResolvedValue(undefined)
+    const set = vi.fn().mockReturnValue({ where })
+    const update = vi.fn().mockReturnValue({ set })
+    getOrgDbMock.mockReturnValue({ update })
+
+    await markRepositoryIndexingFailed({
+      repositoryId,
+      error: new TypeError("fetch failed"),
+    })
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indexingStatus: "failed",
+        indexingError: "fetch failed",
         indexReady: false,
       }),
     )

--- a/apps/backend/src/models/repositories.test.ts
+++ b/apps/backend/src/models/repositories.test.ts
@@ -51,6 +51,8 @@ import {
   listRepositoriesForGithubConnection,
   listRepositoriesForOrg,
   pruneGithubConnectionRepositoriesNotInGitUrls,
+  markRepositoryIndexingFailed,
+  markRepositoryIndexingReadyWithIssues,
   setRepositoryIndexingStep,
   tryClaimRepositoryIndexingEnqueue,
 } from "./repositories.js"
@@ -363,6 +365,60 @@ describe("deleteRepository", () => {
 
     expect(withGraphClientMock).not.toHaveBeenCalled()
     expect(notifyCodesearchRepositoryDeletedMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("markRepositoryIndexingReadyWithIssues", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps indexReady and stores the Zoekt issue", async () => {
+    const where = vi.fn().mockResolvedValue(undefined)
+    const set = vi.fn().mockReturnValue({ where })
+    const update = vi.fn().mockReturnValue({ set })
+    getOrgDbMock.mockReturnValue({ update })
+
+    await markRepositoryIndexingReadyWithIssues({
+      repositoryId,
+      targetHash: "abc123",
+      error: new Error("Command failed with exit code 137"),
+    })
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indexingStatus: "complete_with_issues",
+        indexReady: true,
+        indexingError: "Codebase didn't fit available memory",
+        lastIngestedHash: "abc123",
+      }),
+    )
+  })
+})
+
+describe("markRepositoryIndexingFailed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("stores the memory-fit message instead of fetch failed", async () => {
+    const where = vi.fn().mockResolvedValue(undefined)
+    const set = vi.fn().mockReturnValue({ where })
+    const update = vi.fn().mockReturnValue({ set })
+    getOrgDbMock.mockReturnValue({ update })
+
+    await markRepositoryIndexingFailed({
+      repositoryId,
+      error: new TypeError("fetch failed"),
+    })
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indexingStatus: "failed",
+        indexingError: "Codebase didn't fit available memory",
+        indexReady: false,
+      }),
+    )
   })
 })
 

--- a/apps/backend/src/models/repositories.ts
+++ b/apps/backend/src/models/repositories.ts
@@ -12,6 +12,7 @@ import {
   purgeRepositoryPostgres,
 } from "../domain/repositoryDeletion.js"
 import { generateObjectId } from "../lib/id.js"
+import { userFacingIndexingError } from "../lib/memoryFitError.js"
 import { log } from "../observability/logger.js"
 import { withGraphClient } from "../platform/graph/client.js"
 
@@ -56,12 +57,7 @@ export function deriveRepositoryIndexingStatus(input: {
 }
 
 function sanitizeIndexingError(input: unknown): string {
-  if (input instanceof Error && input.message.trim()) {
-    return input.message.trim().slice(0, MAX_INDEXING_ERROR_CHARS)
-  }
-  const raw =
-    typeof input === "string" ? input.trim() : String(input ?? "").trim()
-  return raw.slice(0, MAX_INDEXING_ERROR_CHARS) || "Repository ingestion failed"
+  return userFacingIndexingError(input).slice(0, MAX_INDEXING_ERROR_CHARS)
 }
 
 function repositoryWithZoektJoin(db: Db) {
@@ -403,6 +399,30 @@ export async function markRepositoryIndexingReady(input: {
       indexReady: true,
       indexingStatus: "ready",
       indexingError: null,
+      indexingFailedAt: null,
+      indexingReason: null,
+      indexingStep: null,
+      indexingStepTotal: null,
+      indexingStepKey: null,
+      lastIngestedHash: input.targetHash,
+      lastIngestedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(repositories.id, input.repositoryId))
+}
+
+export async function markRepositoryIndexingReadyWithIssues(input: {
+  repositoryId: string
+  targetHash: string
+  error: unknown
+}) {
+  const db = getOrgDb()
+  await db
+    .update(repositories)
+    .set({
+      indexReady: true,
+      indexingStatus: "complete_with_issues",
+      indexingError: sanitizeIndexingError(input.error),
       indexingFailedAt: null,
       indexingReason: null,
       indexingStep: null,

--- a/apps/backend/src/openworkflow/workflows/repository-index.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-index.test.ts
@@ -124,10 +124,27 @@ describe("repositoryIndex workflow", () => {
     })
   })
 
-  it("continues SCIP when Zoekt fails and returns searchIndexOk false", async () => {
-    zoektMock.mockRejectedValueOnce(new Error("zoekt OOM"))
+  it("records Zoekt failure as a successful step result so OpenWorkflow does not retry", async () => {
+    zoektMock.mockRejectedValue(new Error("zoekt OOM"))
+    let zoektAttempts = 0
     const step = {
-      run: async (_opts: { name: string }, fn: () => unknown) => fn(),
+      run: async (
+        opts: { name: string; retryPolicy?: { maximumAttempts?: number } },
+        fn: () => unknown,
+      ) => {
+        if (opts.name !== "zoekt") return fn()
+        const max = opts.retryPolicy?.maximumAttempts ?? 1
+        let last: unknown
+        for (let attempt = 0; attempt < max; attempt += 1) {
+          zoektAttempts += 1
+          try {
+            return await fn()
+          } catch (error) {
+            last = error
+          }
+        }
+        throw last
+      },
     }
     const wf = repositoryIndex as unknown as {
       fn: (args: {
@@ -149,6 +166,7 @@ describe("repositoryIndex workflow", () => {
       step,
     })
 
+    expect(zoektAttempts).toBe(1)
     expect(scipMock).toHaveBeenCalledTimes(2)
     expect(mergeMock).toHaveBeenCalledOnce()
     expect(result).toMatchObject({

--- a/apps/backend/src/openworkflow/workflows/repository-index.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-index.test.ts
@@ -61,10 +61,7 @@ vi.mock("openworkflow", () => ({
         targetHash: string
       }
       step: {
-        run: (
-          opts: { name: string },
-          fn: () => unknown,
-        ) => Promise<unknown>
+        run: (opts: { name: string }, fn: () => unknown) => Promise<unknown>
       }
     }) => Promise<unknown>,
   ) => ({

--- a/apps/backend/src/openworkflow/workflows/repository-index.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-index.test.ts
@@ -123,10 +123,11 @@ describe("repositoryIndex workflow", () => {
     expect(result).toMatchObject({
       targetHash: "abc",
       ingestMode: "full",
+      searchIndexOk: true,
     })
   })
 
-  it("fails fast on Zoekt without starting SCIP", async () => {
+  it("continues SCIP when Zoekt fails and returns searchIndexOk false", async () => {
     zoektMock.mockRejectedValueOnce(new Error("zoekt OOM"))
     const step = {
       run: async (_opts: { name: string }, fn: () => unknown) => fn(),
@@ -142,18 +143,21 @@ describe("repositoryIndex workflow", () => {
       }) => Promise<unknown>
     }
 
-    await expect(
-      wf.fn({
-        input: {
-          repositoryId: "repo_1",
-          orgId: "org_1",
-          targetHash: "abc",
-        },
-        step,
-      }),
-    ).rejects.toThrow("zoekt OOM")
+    const result = await wf.fn({
+      input: {
+        repositoryId: "repo_1",
+        orgId: "org_1",
+        targetHash: "abc",
+      },
+      step,
+    })
 
-    expect(scipMock).not.toHaveBeenCalled()
-    expect(mergeMock).not.toHaveBeenCalled()
+    expect(scipMock).toHaveBeenCalledTimes(2)
+    expect(mergeMock).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({
+      targetHash: "abc",
+      searchIndexOk: false,
+      searchIndexError: "zoekt OOM",
+    })
   })
 })

--- a/apps/backend/src/openworkflow/workflows/repository-index.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-index.test.ts
@@ -75,6 +75,20 @@ import { repositoryIndex } from "./repository-index.js"
 describe("repositoryIndex workflow", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    cloneMock.mockResolvedValue({
+      targetHash: "abc",
+      ingestMode: "full",
+      changedPaths: [],
+      deletedPaths: [],
+      renames: [],
+    })
+    zoektMock.mockResolvedValue(undefined)
+    detectMock.mockResolvedValue({
+      detectedLanguages: ["go", "typescript"],
+      languagesToIndex: ["go", "typescript"],
+    })
+    scipMock.mockResolvedValue(undefined)
+    mergeMock.mockResolvedValue(undefined)
   })
 
   it("runs phases in order and parallelizes SCIP langs", async () => {
@@ -174,5 +188,104 @@ describe("repositoryIndex workflow", () => {
       searchIndexOk: false,
       searchIndexError: "zoekt OOM",
     })
+  })
+
+  it("maps Zoekt exit 137 to the canonical error and still runs SCIP", async () => {
+    zoektMock.mockRejectedValue(new Error("Command failed with exit code 137"))
+    const step = {
+      run: async (_opts: { name: string }, fn: () => unknown) => fn(),
+    }
+    const wf = repositoryIndex as unknown as {
+      fn: (args: {
+        input: {
+          repositoryId: string
+          orgId: string
+          targetHash: string
+        }
+        step: typeof step
+      }) => Promise<unknown>
+    }
+
+    const result = await wf.fn({
+      input: {
+        repositoryId: "repo_1",
+        orgId: "org_1",
+        targetHash: "abc",
+      },
+      step,
+    })
+
+    expect(scipMock).toHaveBeenCalled()
+    expect(result).toMatchObject({
+      searchIndexOk: false,
+      searchIndexError: "Codebase didn't fit available memory",
+    })
+  })
+
+  it("fails closed on clone task death so SCIP never starts", async () => {
+    cloneMock.mockRejectedValue(
+      new Error("Codebase didn't fit available memory"),
+    )
+    const step = {
+      run: async (_opts: { name: string }, fn: () => unknown) => fn(),
+    }
+    const wf = repositoryIndex as unknown as {
+      fn: (args: {
+        input: {
+          repositoryId: string
+          orgId: string
+          targetHash: string
+        }
+        step: typeof step
+      }) => Promise<unknown>
+    }
+
+    await expect(
+      wf.fn({
+        input: {
+          repositoryId: "repo_1",
+          orgId: "org_1",
+          targetHash: "abc",
+        },
+        step,
+      }),
+    ).rejects.toThrow("Codebase didn't fit available memory")
+
+    expect(zoektMock).not.toHaveBeenCalled()
+    expect(scipMock).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when SCIP dies after a non-fatal Zoekt OOM", async () => {
+    zoektMock.mockRejectedValue(new Error("Command failed with exit code 137"))
+    scipMock.mockRejectedValue(
+      new Error("Codebase didn't fit available memory"),
+    )
+    const step = {
+      run: async (_opts: { name: string }, fn: () => unknown) => fn(),
+    }
+    const wf = repositoryIndex as unknown as {
+      fn: (args: {
+        input: {
+          repositoryId: string
+          orgId: string
+          targetHash: string
+        }
+        step: typeof step
+      }) => Promise<unknown>
+    }
+
+    await expect(
+      wf.fn({
+        input: {
+          repositoryId: "repo_1",
+          orgId: "org_1",
+          targetHash: "abc",
+        },
+        step,
+      }),
+    ).rejects.toThrow("Codebase didn't fit available memory")
+
+    expect(detectMock).toHaveBeenCalledOnce()
+    expect(mergeMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/openworkflow/workflows/repository-index.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-index.ts
@@ -36,6 +36,27 @@ const indexRetryPolicy = {
   maximumInterval: "2m" as const,
 }
 
+function zoektStepResult(
+  value: unknown,
+): { ok: true } | { ok: false; error: string } {
+  if (
+    value &&
+    typeof value === "object" &&
+    "ok" in value &&
+    (value as { ok: unknown }).ok === false
+  ) {
+    const error = (value as { error?: unknown }).error
+    return {
+      ok: false,
+      error:
+        typeof error === "string" && error.trim()
+          ? error
+          : "Search index unavailable",
+    }
+  }
+  return { ok: true }
+}
+
 function logMilestone(step: string, fields: Record<string, unknown>): void {
   const l = getLogger()
   l.set({
@@ -114,28 +135,36 @@ export const repositoryIndex = defineWorkflow(
           ingestMode: checkout.ingestMode,
         })
 
-        let searchIndexOk = true
-        let searchIndexError: string | undefined
-        try {
-          await step.run({ name: "zoekt", retryPolicy: indexRetryPolicy }, () =>
-            wls("zoekt", () => codesearchIndexZoekt(auth)),
-          )
+        const zoektResult = zoektStepResult(
+          await step.run({ name: "zoekt" }, () =>
+            wls("zoekt", async () => {
+              try {
+                await codesearchIndexZoekt(auth)
+                return { ok: true as const }
+              } catch (error) {
+                const errorText = userFacingIndexingError(error)
+                if (isMemoryFitFailure(error)) {
+                  logMilestone("repository-index.memory_exceeded", {
+                    repositoryId: input.repositoryId,
+                    error: errorText,
+                  })
+                }
+                return { ok: false as const, error: errorText }
+              }
+            }),
+          ),
+        )
+        const searchIndexOk = zoektResult.ok
+        const searchIndexError = zoektResult.ok ? undefined : zoektResult.error
+        if (searchIndexOk) {
           logMilestone("repository-index.zoekt.done", {
             repositoryId: input.repositoryId,
           })
-        } catch (error) {
-          searchIndexOk = false
-          searchIndexError = userFacingIndexingError(error)
+        } else {
           logMilestone("repository-index.zoekt.failed", {
             repositoryId: input.repositoryId,
             error: searchIndexError,
           })
-          if (isMemoryFitFailure(error)) {
-            logMilestone("repository-index.memory_exceeded", {
-              repositoryId: input.repositoryId,
-              error: searchIndexError,
-            })
-          }
         }
 
         const languages = await step.run(

--- a/apps/backend/src/openworkflow/workflows/repository-index.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-index.ts
@@ -8,6 +8,10 @@ import {
   codesearchIndexScipLang,
   codesearchIndexZoekt,
 } from "../../domain/codeIngestion/codesearchIndexPhases.js"
+import {
+  isMemoryFitFailure,
+  userFacingIndexingError,
+} from "../../lib/memoryFitError.js"
 import { getInstallationToken } from "../../models/github-installation.js"
 import {
   createLogger,
@@ -46,12 +50,12 @@ function logMilestone(step: string, fields: Record<string, unknown>): void {
 }
 
 /**
- * Durable codesearch index pipeline: clone/checkout → zoekt (fail-fast) →
+ * Durable codesearch index pipeline: clone/checkout → zoekt (non-fatal) →
  * detect langs → parallel scip:lang → merge.
  *
- * Intentionally fail-fast on Zoekt (unlike legacy POST /index settleIndexPhases
- * which still attempted SCIP after Zoekt failure) so passed OW steps are not
- * re-run and SCIP never starts without a successful Zoekt build.
+ * Zoekt failure is recorded as `searchIndexOk: false` so SCIP and extract can
+ * still complete (lexical search degrades; graph/ast-grep remain usable).
+ * Clone or SCIP failure still fails the workflow.
  */
 export const repositoryIndex = defineWorkflow(
   { name: "repository-index", schema: repositoryIndexInputSchema },
@@ -110,14 +114,30 @@ export const repositoryIndex = defineWorkflow(
           ingestMode: checkout.ingestMode,
         })
 
-        // Fail-fast: do not start SCIP if Zoekt fails.
-        await step.run({ name: "zoekt", retryPolicy: indexRetryPolicy }, () =>
-          wls("zoekt", () => codesearchIndexZoekt(auth)),
-        )
-
-        logMilestone("repository-index.zoekt.done", {
-          repositoryId: input.repositoryId,
-        })
+        let searchIndexOk = true
+        let searchIndexError: string | undefined
+        try {
+          await step.run(
+            { name: "zoekt", retryPolicy: indexRetryPolicy },
+            () => wls("zoekt", () => codesearchIndexZoekt(auth)),
+          )
+          logMilestone("repository-index.zoekt.done", {
+            repositoryId: input.repositoryId,
+          })
+        } catch (error) {
+          searchIndexOk = false
+          searchIndexError = userFacingIndexingError(error)
+          logMilestone("repository-index.zoekt.failed", {
+            repositoryId: input.repositoryId,
+            error: searchIndexError,
+          })
+          if (isMemoryFitFailure(error)) {
+            logMilestone("repository-index.memory_exceeded", {
+              repositoryId: input.repositoryId,
+              error: searchIndexError,
+            })
+          }
+        }
 
         const languages = await step.run(
           { name: "detect-languages", retryPolicy: indexRetryPolicy },
@@ -176,6 +196,8 @@ export const repositoryIndex = defineWorkflow(
           changedPaths: checkout.changedPaths,
           deletedPaths: checkout.deletedPaths,
           renames: checkout.renames,
+          searchIndexOk,
+          searchIndexError,
         }
       },
     ),

--- a/apps/backend/src/openworkflow/workflows/repository-index.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-index.ts
@@ -117,9 +117,8 @@ export const repositoryIndex = defineWorkflow(
         let searchIndexOk = true
         let searchIndexError: string | undefined
         try {
-          await step.run(
-            { name: "zoekt", retryPolicy: indexRetryPolicy },
-            () => wls("zoekt", () => codesearchIndexZoekt(auth)),
+          await step.run({ name: "zoekt", retryPolicy: indexRetryPolicy }, () =>
+            wls("zoekt", () => codesearchIndexZoekt(auth)),
           )
           logMilestone("repository-index.zoekt.done", {
             repositoryId: input.repositoryId,

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.test.ts
@@ -80,8 +80,8 @@ describe("repositoryIngestionOrchestrator workflow", () => {
     const childError = new Error("child failed")
     const step = {
       runWorkflow: vi.fn().mockRejectedValue(childError),
-      run: vi.fn(
-        async (_opts: { name: string }, fn: () => Promise<unknown>) => fn(),
+      run: vi.fn(async (_opts: { name: string }, fn: () => Promise<unknown>) =>
+        fn(),
       ),
     }
 
@@ -141,8 +141,8 @@ describe("repositoryIngestionOrchestrator workflow", () => {
     cancelSignal.name = "CancelSignal"
     const step = {
       runWorkflow: vi.fn().mockRejectedValue(cancelSignal),
-      run: vi.fn(
-        async (_opts: { name: string }, fn: () => Promise<unknown>) => fn(),
+      run: vi.fn(async (_opts: { name: string }, fn: () => Promise<unknown>) =>
+        fn(),
       ),
     }
 
@@ -160,6 +160,28 @@ describe("repositoryIngestionOrchestrator workflow", () => {
     expect(markRepositoryIndexingFailedMock).toHaveBeenCalledWith({
       repositoryId: "repo_1",
       error: cancelSignal,
+    })
+  })
+
+  it("marks failed with the memory-fit message when the child dies mid-index", async () => {
+    const childError = new Error("Codebase didn't fit available memory")
+    const step = {
+      runWorkflow: vi.fn().mockRejectedValue(childError),
+      run: vi.fn(async (_opts: { name: string }, fn: () => Promise<unknown>) =>
+        fn(),
+      ),
+    }
+
+    await expect(
+      repositoryIngestionOrchestrator.fn({
+        input: { repositoryId: "repo_1", orgId: "org_1" },
+        step,
+      } as never),
+    ).rejects.toThrow("Codebase didn't fit available memory")
+
+    expect(markRepositoryIndexingFailedMock).toHaveBeenCalledWith({
+      repositoryId: "repo_1",
+      error: childError,
     })
   })
 })

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.reindex-tx.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.reindex-tx.test.ts
@@ -322,4 +322,36 @@ describe("repository-ingestion index workflow boundary", () => {
     expect(markRepositoryIndexingReady).not.toHaveBeenCalled()
     expect(enqueueFollowUpIfTipAheadMock).toHaveBeenCalled()
   })
+
+  it("does not mark complete with issues when the index child dies", async () => {
+    const step = {
+      run: async (
+        _opts: { name: string; retryPolicy?: { maximumAttempts?: number } },
+        fn: () => unknown,
+      ) => fn(),
+      runWorkflow: async () => {
+        throw new Error("Codebase didn't fit available memory")
+      },
+    }
+
+    const wf = repositoryIngestion as unknown as {
+      run: (args: {
+        input: { repositoryId: string; orgId: string }
+        step: typeof step
+        run?: { id: string }
+      }) => Promise<unknown>
+    }
+
+    await expect(
+      wf.run({
+        input: { repositoryId: "repo_1", orgId: "org_1" },
+        step,
+        run: { id: "wr_3" },
+      }),
+    ).rejects.toThrow("Codebase didn't fit available memory")
+
+    expect(markRepositoryIndexingReadyWithIssues).not.toHaveBeenCalled()
+    expect(markRepositoryIndexingReady).not.toHaveBeenCalled()
+    expect(enqueueFollowUpIfTipAheadMock).not.toHaveBeenCalled()
+  })
 })

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.reindex-tx.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.reindex-tx.test.ts
@@ -170,11 +170,11 @@ vi.mock("openworkflow", () => ({
   }),
 }))
 
-import { repositoryIngestion } from "./repository-ingestion.js"
 import {
   markRepositoryIndexingReady,
   markRepositoryIndexingReadyWithIssues,
 } from "../../models/repositories.js"
+import { repositoryIngestion } from "./repository-ingestion.js"
 
 describe("repository-ingestion index workflow boundary", () => {
   beforeEach(() => {

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.reindex-tx.test.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.reindex-tx.test.ts
@@ -124,6 +124,7 @@ vi.mock("../../domain/codeIngestion/queue.js", () => ({
 vi.mock("../../models/repositories.js", () => ({
   markRepositoryIndexingRunning: vi.fn().mockResolvedValue(undefined),
   markRepositoryIndexingReady: vi.fn().mockResolvedValue(undefined),
+  markRepositoryIndexingReadyWithIssues: vi.fn().mockResolvedValue(undefined),
   setRepositoryIndexingStep: vi.fn().mockResolvedValue(undefined),
 }))
 
@@ -170,6 +171,10 @@ vi.mock("openworkflow", () => ({
 }))
 
 import { repositoryIngestion } from "./repository-ingestion.js"
+import {
+  markRepositoryIndexingReady,
+  markRepositoryIndexingReadyWithIssues,
+} from "../../models/repositories.js"
 
 describe("repository-ingestion index workflow boundary", () => {
   beforeEach(() => {
@@ -274,5 +279,47 @@ describe("repository-ingestion index workflow boundary", () => {
       expect.objectContaining({ name: "repository-ingestion.root" }),
       expect.any(Function),
     )
+    expect(markRepositoryIndexingReady).toHaveBeenCalledWith({
+      repositoryId: "repo_1",
+      targetHash: "abc",
+    })
+    expect(markRepositoryIndexingReadyWithIssues).not.toHaveBeenCalled()
+  })
+
+  it("marks complete with issues when search index failed but SCIP ran", async () => {
+    const step = {
+      run: async (
+        _opts: { name: string; retryPolicy?: { maximumAttempts?: number } },
+        fn: () => unknown,
+      ) => fn(),
+      runWorkflow: async () => ({
+        ...repositoryIndexResult,
+        searchIndexOk: false,
+        searchIndexError: "Codebase didn't fit available memory",
+      }),
+    }
+
+    const wf = repositoryIngestion as unknown as {
+      run: (args: {
+        input: { repositoryId: string; orgId: string }
+        step: typeof step
+        run?: { id: string }
+      }) => Promise<unknown>
+    }
+
+    await wf.run({
+      input: { repositoryId: "repo_1", orgId: "org_1" },
+      step,
+      run: { id: "wr_2" },
+    })
+
+    expect(runWithLangfuseContextMock).toHaveBeenCalled()
+    expect(markRepositoryIndexingReadyWithIssues).toHaveBeenCalledWith({
+      repositoryId: "repo_1",
+      targetHash: "abc",
+      error: "Codebase didn't fit available memory",
+    })
+    expect(markRepositoryIndexingReady).not.toHaveBeenCalled()
+    expect(enqueueFollowUpIfTipAheadMock).toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion.ts
@@ -21,6 +21,7 @@ import type {
 import { withIngestAgentContext } from "../../graphs/codeIngestionGraph/withIngestAgentContext.js"
 import {
   markRepositoryIndexingReady,
+  markRepositoryIndexingReadyWithIssues,
   markRepositoryIndexingRunning,
   setRepositoryIndexingStep,
 } from "../../models/repositories.js"
@@ -229,6 +230,7 @@ export const repositoryIngestion = defineWorkflow(
             repositoryId: input.repositoryId,
             targetHash: reindexState.targetHash ?? resolved.hash,
             ingestMode: reindexState.ingestMode,
+            searchIndexOk: reindexState.searchIndexOk !== false,
             changedPathsCount: reindexState.changedPaths?.length ?? 0,
             deletedPathsCount: reindexState.deletedPaths?.length ?? 0,
             renamesCount: reindexState.renames?.length ?? 0,
@@ -593,10 +595,18 @@ export const repositoryIngestion = defineWorkflow(
           await step.run({ name: "mark-success" }, () =>
             wls("mark-success", () =>
               withOrgDbContext(input.orgId, () =>
-                markRepositoryIndexingReady({
-                  repositoryId: input.repositoryId,
-                  targetHash: result.targetHash,
-                }),
+                reindexState.searchIndexOk === false
+                  ? markRepositoryIndexingReadyWithIssues({
+                      repositoryId: input.repositoryId,
+                      targetHash: result.targetHash,
+                      error:
+                        reindexState.searchIndexError ??
+                        "Search index unavailable",
+                    })
+                  : markRepositoryIndexingReady({
+                      repositoryId: input.repositoryId,
+                      targetHash: result.targetHash,
+                    }),
               ),
             ),
           )

--- a/apps/backend/src/routes/v1/repositories.ts
+++ b/apps/backend/src/routes/v1/repositories.ts
@@ -26,6 +26,7 @@ const RepositoryIndexingStatusSchema = z.enum([
   "ready",
   "failed",
   "unindexing",
+  "complete_with_issues",
 ])
 
 const RepositorySchema = z

--- a/apps/codesearch/AGENTS.md
+++ b/apps/codesearch/AGENTS.md
@@ -31,7 +31,7 @@ These instructions supplement the repository-root `AGENTS.md`.
 - Look for `codesearch.index.phase.*` / `codesearch.index.queue.*` in codesearch logs and `repository-index.*` / `repository-ingestion.step.*` on the worker.
 - OpenWorkflow step failures are logged to evlog as `repository-ingestion.step.<name>.attempt_failed` (and orchestrator `…child-failed`) — do not rely on the OpenWorkflow dashboard.
 - Langfuse / LLM work starts at durable extract steps (`identify-roots`, `extract-kind:*`, `identify:*`) after retract (UI badge **`analyzing`** and later).
-- **Fail-fast Zoekt:** the OW path does not start SCIP if Zoekt fails (unlike legacy `/index` `settleIndexPhases`).
+- **Zoekt optional:** the OW path continues SCIP after Zoekt failure (`searchIndexOk: false` → `complete_with_issues`). Lexical search may be empty; graph, checkout, and ast-grep still work. Clone or SCIP failure remains fail-closed.
 
 ## Testing
 

--- a/apps/codesearch/scripts/oom-simulation-entry.ts
+++ b/apps/codesearch/scripts/oom-simulation-entry.ts
@@ -45,7 +45,7 @@ const payload = {
   error: error.message,
   memoryFit: error.message === CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
 }
-console.log(JSON.stringify(payload))
+process.stdout.write(`${JSON.stringify(payload)}\n`)
 
 if (!payload.memoryFit && exitCode !== 137) {
   process.exit(1)

--- a/apps/codesearch/scripts/oom-simulation-entry.ts
+++ b/apps/codesearch/scripts/oom-simulation-entry.ts
@@ -1,0 +1,41 @@
+import {
+  CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+  errorFromIndexerExit,
+} from "../src/domain/indexing/memoryFitError.ts"
+
+/**
+ * Drive a child process that allocates until the cgroup kills it, then
+ * classify the exit the same way zoekt-index / SCIP spawn does.
+ */
+const child = Bun.spawn(
+  [
+    "bun",
+    "-e",
+    "const chunks = []; while (true) chunks.push(new Uint8Array(8 * 1024 * 1024))",
+  ],
+  { stdout: "pipe", stderr: "pipe" },
+)
+
+const [stdout, stderr, exitCode] = await Promise.all([
+  new Response(child.stdout).text(),
+  new Response(child.stderr).text(),
+  child.exited,
+])
+
+const error = errorFromIndexerExit({
+  exitCode,
+  stderr,
+  stdout,
+  headline: `Command failed with exit code ${exitCode}`,
+})
+
+const payload = {
+  exitCode,
+  error: error.message,
+  memoryFit: error.message === CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+}
+console.log(JSON.stringify(payload))
+
+if (!payload.memoryFit && exitCode !== 137) {
+  process.exit(1)
+}

--- a/apps/codesearch/scripts/oom-simulation-entry.ts
+++ b/apps/codesearch/scripts/oom-simulation-entry.ts
@@ -4,14 +4,25 @@ import {
 } from "../src/domain/indexing/memoryFitError.ts"
 
 /**
- * Drive a child process that allocates until the cgroup kills it, then
- * classify the exit the same way zoekt-index / SCIP spawn does.
+ * Drive a child that grows RSS until the cgroup kills it, then classify the
+ * exit the same way zoekt-index / SCIP spawn does.
+ *
+ * Prefer a native allocator (`dd` into tmpfs) so the kernel SIGKILLs (137)
+ * instead of Bun raising a JS-heap RangeError first.
  */
 const child = Bun.spawn(
   [
-    "bun",
-    "-e",
-    "const chunks = []; while (true) chunks.push(new Uint8Array(8 * 1024 * 1024))",
+    "sh",
+    "-c",
+    [
+      "if [ -d /dev/shm ]; then",
+      "  i=0; while true; do",
+      "    dd if=/dev/zero of=/dev/shm/ctxpipe-oom-hog.$i bs=1M count=8 status=none || exit $?",
+      "    i=$((i + 1))",
+      "  done",
+      "fi",
+      "exec bun -e 'const chunks = []; while (true) chunks.push(Buffer.allocUnsafe(8 * 1024 * 1024))'",
+    ].join("\n"),
   ],
   { stdout: "pipe", stderr: "pipe" },
 )

--- a/apps/codesearch/scripts/oom-simulation.sh
+++ b/apps/codesearch/scripts/oom-simulation.sh
@@ -36,7 +36,7 @@ echo "oom-simulation: exit=${status} OOMKilled=${oom_killed}"
 echo "${logs}"
 
 if [[ "${oom_killed}" == "true" || "${status}" -eq 137 ]]; then
-  echo "oom-simulation: PASS (task cgroup OOM → product status failed)"
+  echo "oom-simulation: PASS (task cgroup OOM observed; does not assert repository status)"
   exit 0
 fi
 

--- a/apps/codesearch/scripts/oom-simulation.sh
+++ b/apps/codesearch/scripts/oom-simulation.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Tiny-cgroup OOM simulation for the default codesearch test suite.
-# Uses the same image as Vitest; 32 MiB is intentionally below idle+index RSS.
+# Task-cgroup OOM probe for the default codesearch test suite.
+# 32 MiB is below idle Bun RSS, so the *container* is SIGKILL'd — the product
+# maps that shape to repository status `failed`, not `complete_with_issues`.
+# Child-137 classification (API still alive) is covered by
+# `src/routes/indexPhases.zoekt.test.ts` (HTTP `{ error }` body).
 
 IMAGE="${1:?usage: oom-simulation.sh <image>}"
 CONTAINER_NAME="ctxpipe-codesearch-oom-sim-$$"
 MEMORY_LIMIT="32m"
-CANONICAL="Codebase didn't fit available memory"
 
 cleanup() {
   docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
@@ -34,14 +36,9 @@ echo "oom-simulation: exit=${status} OOMKilled=${oom_killed}"
 echo "${logs}"
 
 if [[ "${oom_killed}" == "true" || "${status}" -eq 137 ]]; then
-  echo "oom-simulation: PASS (task cgroup OOM)"
+  echo "oom-simulation: PASS (task cgroup OOM → product status failed)"
   exit 0
 fi
 
-if printf '%s' "${logs}" | grep -Fq "${CANONICAL}"; then
-  echo "oom-simulation: PASS (child classified as memory-fit)"
-  exit 0
-fi
-
-echo "oom-simulation: FAIL: expected OOMKilled, exit 137, or ${CANONICAL}" >&2
+echo "oom-simulation: FAIL: expected OOMKilled or exit 137 for task-death probe" >&2
 exit 1

--- a/apps/codesearch/scripts/oom-simulation.sh
+++ b/apps/codesearch/scripts/oom-simulation.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 # Task-cgroup OOM probe for the default codesearch test suite.
-# 32 MiB is below idle Bun RSS, so the *container* is SIGKILL'd — the product
-# maps that shape to repository status `failed`, not `complete_with_issues`.
-# Child-137 classification (API still alive) is covered by
-# `src/routes/indexPhases.zoekt.test.ts` (HTTP `{ error }` body).
+# 32 MiB is below idle Bun RSS, so the *container* is SIGKILL'd.
+# This script only asserts OOMKilled / exit 137. It does not talk to the API
+# or write repository status. Child-137 HTTP classification (API still alive)
+# is covered by `src/routes/indexPhases.zoekt.test.ts`.
 
 IMAGE="${1:?usage: oom-simulation.sh <image>}"
 CONTAINER_NAME="ctxpipe-codesearch-oom-sim-$$"

--- a/apps/codesearch/scripts/oom-simulation.sh
+++ b/apps/codesearch/scripts/oom-simulation.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tiny-cgroup OOM simulation for the default codesearch test suite.
+# Uses the same image as Vitest; 32 MiB is intentionally below idle+index RSS.
+
+IMAGE="${1:?usage: oom-simulation.sh <image>}"
+CONTAINER_NAME="ctxpipe-codesearch-oom-sim-$$"
+MEMORY_LIMIT="32m"
+CANONICAL="Codebase didn't fit available memory"
+
+cleanup() {
+  docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+set +e
+docker run \
+  --name "${CONTAINER_NAME}" \
+  --memory "${MEMORY_LIMIT}" \
+  --memory-swap "${MEMORY_LIMIT}" \
+  "${IMAGE}" \
+  bun run /app/apps/codesearch/scripts/oom-simulation-entry.ts
+status=$?
+set -e
+
+oom_killed="$(
+  docker inspect --format '{{.State.OOMKilled}}' "${CONTAINER_NAME}" 2>/dev/null ||
+    printf 'unknown'
+)"
+logs="$(docker logs "${CONTAINER_NAME}" 2>&1 || true)"
+
+echo "oom-simulation: exit=${status} OOMKilled=${oom_killed}"
+echo "${logs}"
+
+if [[ "${oom_killed}" == "true" || "${status}" -eq 137 ]]; then
+  echo "oom-simulation: PASS (task cgroup OOM)"
+  exit 0
+fi
+
+if printf '%s' "${logs}" | grep -Fq "${CANONICAL}"; then
+  echo "oom-simulation: PASS (child classified as memory-fit)"
+  exit 0
+fi
+
+echo "oom-simulation: FAIL: expected OOMKilled, exit 137, or ${CANONICAL}" >&2
+exit 1

--- a/apps/codesearch/scripts/run-vitest-docker.sh
+++ b/apps/codesearch/scripts/run-vitest-docker.sh
@@ -5,4 +5,5 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 IMAGE="${CTXPIPE_CODESEARCH_TEST_IMAGE:-ctxpipe-codesearch:test}"
 
 docker build -f "${ROOT}/apps/codesearch/Dockerfile" --target test -t "${IMAGE}" "${ROOT}"
-exec docker run --rm "${IMAGE}" "$@"
+docker run --rm "${IMAGE}" "$@"
+bash "${ROOT}/apps/codesearch/scripts/oom-simulation.sh" "${IMAGE}"

--- a/apps/codesearch/src/db/schema.ts
+++ b/apps/codesearch/src/db/schema.ts
@@ -17,6 +17,7 @@ const repositoryIndexingStatusValues = [
   "ready",
   "failed",
   "unindexing",
+  "complete_with_issues",
 ] as const
 const repositoryIndexingStatusEnum = pgEnum(
   "repository_indexing_status",

--- a/apps/codesearch/src/domain/indexing/memoryFitError.test.ts
+++ b/apps/codesearch/src/domain/indexing/memoryFitError.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import {
+  CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+  errorFromIndexerExit,
+  isMemoryFitFailure,
+  userFacingIndexingError,
+} from "./memoryFitError.js"
+
+describe("errorFromIndexerExit", () => {
+  it("maps exit 137 to the canonical memory-fit message", () => {
+    const error = errorFromIndexerExit({
+      exitCode: 137,
+      stderr: "Killed",
+      stdout: "",
+      headline: "Command failed with exit code 137",
+    })
+    expect(error.message).toBe(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY)
+    expect(isMemoryFitFailure(error)).toBe(true)
+  })
+
+  it("keeps non-OOM indexer failures as the original headline", () => {
+    const error = errorFromIndexerExit({
+      exitCode: 1,
+      stderr: "parse error",
+      stdout: "",
+      headline: "Command failed with exit code 1",
+    })
+    expect(error.message).toContain("exit code 1")
+    expect(error.message).toContain("parse error")
+    expect(isMemoryFitFailure(error)).toBe(false)
+  })
+})
+
+describe("userFacingIndexingError", () => {
+  it("rewrites fetch failed to the canonical memory message", () => {
+    expect(userFacingIndexingError(new TypeError("fetch failed"))).toBe(
+      CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+    )
+  })
+})

--- a/apps/codesearch/src/domain/indexing/memoryFitError.test.ts
+++ b/apps/codesearch/src/domain/indexing/memoryFitError.test.ts
@@ -32,9 +32,15 @@ describe("errorFromIndexerExit", () => {
 })
 
 describe("userFacingIndexingError", () => {
-  it("rewrites fetch failed to the canonical memory message", () => {
+  it("rewrites exit 137 headlines to the canonical memory message", () => {
+    expect(
+      userFacingIndexingError(new Error("Command failed with exit code 137")),
+    ).toBe(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY)
+  })
+
+  it("does not remap unrelated fetch failed", () => {
     expect(userFacingIndexingError(new TypeError("fetch failed"))).toBe(
-      CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+      "fetch failed",
     )
   })
 })

--- a/apps/codesearch/src/domain/indexing/memoryFitError.ts
+++ b/apps/codesearch/src/domain/indexing/memoryFitError.ts
@@ -3,9 +3,7 @@ export const CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY =
   "Codebase didn't fit available memory"
 
 const MEMORY_FIT_MESSAGE_RE =
-  /exit code 137\b|fetch failed|\bENOMEM\b|codebase didn't fit available memory/i
-
-const MEMORY_FIT_ERRNOS = new Set(["ECONNRESET", "EPIPE", "ENOMEM"])
+  /exit code 137\b|\bENOMEM\b|codebase didn't fit available memory/i
 
 function errorCode(error: unknown): string | undefined {
   if (!error || typeof error !== "object") return undefined
@@ -37,8 +35,7 @@ export function isMemoryFitFailure(error: unknown): boolean {
     if (item instanceof Error && MEMORY_FIT_MESSAGE_RE.test(item.message)) {
       return true
     }
-    const code = errorCode(item)
-    if (code && MEMORY_FIT_ERRNOS.has(code)) return true
+    if (errorCode(item) === "ENOMEM") return true
   }
   return false
 }

--- a/apps/codesearch/src/domain/indexing/memoryFitError.ts
+++ b/apps/codesearch/src/domain/indexing/memoryFitError.ts
@@ -1,0 +1,76 @@
+/** User-visible copy when an indexer child or the task is OOM-killed. */
+export const CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY =
+  "Codebase didn't fit available memory"
+
+const MEMORY_FIT_MESSAGE_RE =
+  /exit code 137\b|fetch failed|\bENOMEM\b|codebase didn't fit available memory/i
+
+const MEMORY_FIT_ERRNOS = new Set(["ECONNRESET", "EPIPE", "ENOMEM"])
+
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const code = (error as NodeJS.ErrnoException).code
+  return typeof code === "string" ? code : undefined
+}
+
+function collectErrors(error: unknown): unknown[] {
+  const out: unknown[] = []
+  const queue: unknown[] = [error]
+  const seen = new Set<unknown>()
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (current == null || seen.has(current)) continue
+    seen.add(current)
+    out.push(current)
+    if (current && typeof current === "object" && "cause" in current) {
+      queue.push((current as { cause: unknown }).cause)
+    }
+  }
+  return out
+}
+
+export function isMemoryFitFailure(error: unknown): boolean {
+  for (const item of collectErrors(error)) {
+    if (typeof item === "string" && MEMORY_FIT_MESSAGE_RE.test(item)) {
+      return true
+    }
+    if (item instanceof Error && MEMORY_FIT_MESSAGE_RE.test(item.message)) {
+      return true
+    }
+    const code = errorCode(item)
+    if (code && MEMORY_FIT_ERRNOS.has(code)) return true
+  }
+  return false
+}
+
+export function userFacingIndexingError(
+  error: unknown,
+  fallback = "Indexing failed",
+): string {
+  if (isMemoryFitFailure(error)) return CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim()
+  }
+  if (typeof error === "string" && error.trim()) return error.trim()
+  return fallback
+}
+
+export function errorFromIndexerExit(params: {
+  exitCode: number
+  stderr: string
+  stdout: string
+  headline: string
+}): Error {
+  if (params.exitCode === 137) {
+    return new Error(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY)
+  }
+  return new Error(
+    [
+      params.headline,
+      params.stderr.trim() ? `stderr: ${params.stderr.trim()}` : "",
+      params.stdout.trim() ? `stdout: ${params.stdout.trim()}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  )
+}

--- a/apps/codesearch/src/domain/indexing/phases.ts
+++ b/apps/codesearch/src/domain/indexing/phases.ts
@@ -26,6 +26,7 @@ import { withIndexerProcessSlot } from "./indexerProcessSemaphore.js"
 import { runScipIndexer } from "./scipIndexers.js"
 import { selectTouchedScipIndexers } from "./scipTouchedLanguages.js"
 import { INDEX_CHILD_LOG_TAIL_BYTES, readStreamTail } from "./streamTail.js"
+import { errorFromIndexerExit } from "./memoryFitError.js"
 
 export type IndexPhaseRepoContext = {
   db: Db
@@ -134,15 +135,18 @@ async function runCommand(
       subprocess.exited,
     ])
     if (exitCode !== 0) {
-      throw new Error(
-        [
-          `Command failed with exit code ${exitCode}`,
-          stderr.trim() ? `stderr: ${stderr.trim()}` : "",
-          stdout.trim() ? `stdout: ${stdout.trim()}` : "",
-        ]
-          .filter(Boolean)
-          .join("\n"),
-      )
+      if (exitCode === 137) {
+        tryEmitIndexEvent("codesearch.index.memory_exceeded", {
+          cmd: cmd[0],
+          exitCode,
+        })
+      }
+      throw errorFromIndexerExit({
+        exitCode,
+        stderr,
+        stdout,
+        headline: `Command failed with exit code ${exitCode}`,
+      })
     }
   } finally {
     if (heartbeatTimer !== undefined) clearInterval(heartbeatTimer)

--- a/apps/codesearch/src/domain/indexing/phases.ts
+++ b/apps/codesearch/src/domain/indexing/phases.ts
@@ -23,10 +23,10 @@ import { refreshPinnedRepo } from "../zoekt/pinManager.js"
 import { detectLanguages, type ScipIndexerId } from "./detectLanguages.js"
 import { withIndexerGoLimits } from "./indexerChildEnv.js"
 import { withIndexerProcessSlot } from "./indexerProcessSemaphore.js"
+import { errorFromIndexerExit } from "./memoryFitError.js"
 import { runScipIndexer } from "./scipIndexers.js"
 import { selectTouchedScipIndexers } from "./scipTouchedLanguages.js"
 import { INDEX_CHILD_LOG_TAIL_BYTES, readStreamTail } from "./streamTail.js"
-import { errorFromIndexerExit } from "./memoryFitError.js"
 
 export type IndexPhaseRepoContext = {
   db: Db

--- a/apps/codesearch/src/domain/indexing/scipIndexers.test.ts
+++ b/apps/codesearch/src/domain/indexing/scipIndexers.test.ts
@@ -229,6 +229,29 @@ describe("runScipIndexer", () => {
     }
   })
 
+  it("maps SIGKILL exit 137 to the memory-fit error", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "scip-indexers-"))
+    const checkoutPath = join(directory, "checkout")
+    const shardPath = join(directory, "shards", "go.scip")
+    await mkdir(checkoutPath)
+
+    vi.stubGlobal("Bun", {
+      spawn: vi.fn(() => fakeSubprocess(Promise.resolve(137))),
+    })
+
+    try {
+      await expect(
+        runScipIndexer({
+          indexerId: "go",
+          checkoutPath,
+          shardPath,
+        }),
+      ).rejects.toThrow("Codebase didn't fit available memory")
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it("rejects and removes an empty final shard", async () => {
     const directory = await mkdtemp(join(tmpdir(), "scip-indexers-"))
     const checkoutPath = join(directory, "checkout")

--- a/apps/codesearch/src/domain/indexing/scipIndexers.ts
+++ b/apps/codesearch/src/domain/indexing/scipIndexers.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from "node:crypto"
 import { copyFile, mkdir, rename, rm, stat } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
+import { tryEmitIndexEvent } from "../../observability/indexingLog.js"
 import type { ScipIndexerId } from "./detectLanguages.js"
 import { withIndexerGoLimits } from "./indexerChildEnv.js"
 import { withIndexerProcessSlot } from "./indexerProcessSemaphore.js"
-import { INDEX_CHILD_LOG_TAIL_BYTES, readStreamTail } from "./streamTail.js"
-import { tryEmitIndexEvent } from "../../observability/indexingLog.js"
 import { errorFromIndexerExit } from "./memoryFitError.js"
+import { INDEX_CHILD_LOG_TAIL_BYTES, readStreamTail } from "./streamTail.js"
 
 /**
  * Direct upstream SCIP indexer CLIs. These commands run from the checkout root.

--- a/apps/codesearch/src/domain/indexing/scipIndexers.ts
+++ b/apps/codesearch/src/domain/indexing/scipIndexers.ts
@@ -6,6 +6,7 @@ import { withIndexerGoLimits } from "./indexerChildEnv.js"
 import { withIndexerProcessSlot } from "./indexerProcessSemaphore.js"
 import { INDEX_CHILD_LOG_TAIL_BYTES, readStreamTail } from "./streamTail.js"
 import { tryEmitIndexEvent } from "../../observability/indexingLog.js"
+import { errorFromIndexerExit } from "./memoryFitError.js"
 
 /**
  * Direct upstream SCIP indexer CLIs. These commands run from the checkout root.
@@ -147,15 +148,18 @@ async function runIndexerProcess(input: {
       ])
 
       if (exitCode !== 0) {
-        throw new Error(
-          [
-            `SCIP indexer "${input.indexerId}" failed with exit code ${exitCode} (${input.argv.join(" ")})`,
-            stderr.trim() ? `stderr: ${stderr.trim()}` : "",
-            stdout.trim() ? `stdout: ${stdout.trim()}` : "",
-          ]
-            .filter(Boolean)
-            .join("\n"),
-        )
+        if (exitCode === 137) {
+          tryEmitIndexEvent("codesearch.index.memory_exceeded", {
+            indexerId: input.indexerId,
+            exitCode,
+          })
+        }
+        throw errorFromIndexerExit({
+          exitCode,
+          stderr,
+          stdout,
+          headline: `SCIP indexer "${input.indexerId}" failed with exit code ${exitCode} (${input.argv.join(" ")})`,
+        })
       }
     } finally {
       clearInterval(heartbeatTimer)

--- a/apps/codesearch/src/routes/indexPhases.ts
+++ b/apps/codesearch/src/routes/indexPhases.ts
@@ -2,14 +2,15 @@ import type { OpenAPIHono } from "@hono/zod-openapi"
 import { createRoute, z } from "@hono/zod-openapi"
 import type { AppEnv } from "../app/env.js"
 import { withRepositoryIndexOperation } from "../domain/indexing/indexConcurrency.js"
+import { userFacingIndexingError } from "../domain/indexing/memoryFitError.js"
 import {
+  type IndexPhaseRepoContext,
   phaseCloneCheckout,
   phaseDetectLanguages,
   phaseMarkCheckoutIndexed,
   phaseMergeScip,
   phaseScipLanguage,
   phaseZoekt,
-  type IndexPhaseRepoContext,
 } from "../domain/indexing/phases.js"
 import {
   DEFAULT_CHECKOUT_KEY,
@@ -21,7 +22,6 @@ import {
   getIndexableRepository,
 } from "../domain/repositories/service.js"
 import { zoektRepositoryName } from "../domain/zoekt/shardPrefix.js"
-import { userFacingIndexingError } from "../domain/indexing/memoryFitError.js"
 import {
   createLogger,
   flushWorkflowLog,

--- a/apps/codesearch/src/routes/indexPhases.ts
+++ b/apps/codesearch/src/routes/indexPhases.ts
@@ -21,6 +21,7 @@ import {
   getIndexableRepository,
 } from "../domain/repositories/service.js"
 import { zoektRepositoryName } from "../domain/zoekt/shardPrefix.js"
+import { userFacingIndexingError } from "../domain/indexing/memoryFitError.js"
 import {
   createLogger,
   flushWorkflowLog,
@@ -299,8 +300,7 @@ export function registerIndexPhaseRoutes(app: OpenAPIHono<AppEnv>) {
         )
         return c.json({ ok: true as const, ...result }, 200)
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Clone/checkout failed"
+        const message = userFacingIndexingError(error, "Clone/checkout failed")
         return c.json({ error: message }, 500)
       }
     })
@@ -332,8 +332,7 @@ export function registerIndexPhaseRoutes(app: OpenAPIHono<AppEnv>) {
         )
         return c.json({ ok: true as const }, 200)
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Zoekt indexing failed"
+        const message = userFacingIndexingError(error, "Zoekt indexing failed")
         return c.json({ error: message }, 500)
       }
     })
@@ -367,8 +366,10 @@ export function registerIndexPhaseRoutes(app: OpenAPIHono<AppEnv>) {
         )
         return c.json({ ok: true as const, ...result }, 200)
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Language detection failed"
+        const message = userFacingIndexingError(
+          error,
+          "Language detection failed",
+        )
         return c.json({ error: message }, 500)
       }
     })
@@ -400,8 +401,7 @@ export function registerIndexPhaseRoutes(app: OpenAPIHono<AppEnv>) {
         )
         return c.json({ ok: true as const }, 200)
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "SCIP indexing failed"
+        const message = userFacingIndexingError(error, "SCIP indexing failed")
         return c.json({ error: message }, 500)
       }
     })
@@ -434,8 +434,7 @@ export function registerIndexPhaseRoutes(app: OpenAPIHono<AppEnv>) {
         )
         return c.json({ ok: true as const }, 200)
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "SCIP merge failed"
+        const message = userFacingIndexingError(error, "SCIP merge failed")
         return c.json({ error: message }, 500)
       }
     })

--- a/apps/codesearch/src/routes/indexPhases.zoekt.test.ts
+++ b/apps/codesearch/src/routes/indexPhases.zoekt.test.ts
@@ -1,0 +1,89 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { AppEnv } from "../app/env.js"
+import { CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY } from "../domain/indexing/memoryFitError.js"
+
+const phaseZoektMock = vi.hoisted(() => vi.fn())
+const getAccessibleRepositoryMock = vi.hoisted(() => vi.fn())
+const getIndexableRepositoryMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../domain/indexing/phases.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../domain/indexing/phases.js")
+  >("../domain/indexing/phases.js")
+  return {
+    ...actual,
+    phaseZoekt: phaseZoektMock,
+  }
+})
+
+vi.mock("../domain/repositories/service.js", () => ({
+  getAccessibleRepository: getAccessibleRepositoryMock,
+  getIndexableRepository: getIndexableRepositoryMock,
+}))
+
+vi.mock("../observability/logger.js", () => ({
+  createLogger: () => ({}),
+  withLogger: (_logger: unknown, fn: () => unknown) => fn(),
+  getLogger: () => ({ set: vi.fn(), info: vi.fn() }),
+  flushWorkflowLog: vi.fn(),
+}))
+
+import { errorFromIndexerExit } from "../domain/indexing/memoryFitError.js"
+import { registerIndexPhaseRoutes } from "./indexPhases.js"
+
+function createTestApp() {
+  const app = new OpenAPIHono<AppEnv>()
+  app.use("*", async (c, next) => {
+    c.set("db", {} as AppEnv["Variables"]["db"])
+    c.set("env", { NODE_ENV: "test", PORT: 3001 } as AppEnv["Variables"]["env"])
+    c.set("auth", {
+      sub: "svc",
+      orgId: "org_mock123",
+      principal: "service",
+    } as AppEnv["Variables"]["auth"])
+    await next()
+  })
+  registerIndexPhaseRoutes(app)
+  return app
+}
+
+describe("POST /{repoId}/index/zoekt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getAccessibleRepositoryMock.mockResolvedValue({
+      id: "repo_aaaaaa",
+      orgId: "org_mock123",
+      name: "acme/web",
+      gitUrl: "https://github.com/acme/web.git",
+    })
+    getIndexableRepositoryMock.mockResolvedValue({
+      id: "repo_aaaaaa",
+      orgId: "org_mock123",
+      name: "acme/web",
+      gitUrl: "https://github.com/acme/web.git",
+      zoektRepoId: 1,
+    })
+  })
+
+  it("returns the canonical memory-fit error when zoekt-index is SIGKILL'd", async () => {
+    phaseZoektMock.mockRejectedValue(
+      errorFromIndexerExit({
+        exitCode: 137,
+        stderr: "Killed",
+        stdout: "",
+        headline: "Command failed with exit code 137",
+      }),
+    )
+    const app = createTestApp()
+    const res = await app.request("/repo_aaaaaa/index/zoekt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({
+      error: CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY,
+    })
+  })
+})

--- a/apps/docs/content/docs/(guide)/connections/ingestion.mdx
+++ b/apps/docs/content/docs/(guide)/connections/ingestion.mdx
@@ -49,8 +49,11 @@ queryable context for agents”. It spans the **backend**, **worker**, and
 - **Self-hosted**: ensure `CODESEARCH_URL` points at your codesearch service and
   that Postgres migrations have run - the codesearch app reads repository rows
   from the same logical DB model as the backend.
-- **Failures**: clone failures, private repo auth, or indexer outages surface as
-  errors on ingestion; check backend and codesearch logs.
+- **Failures**: clone or SCIP failures fail the run. If Zoekt (search index)
+  fails but SCIP succeeds, the repository is **complete with issues**: chat and
+  graph still work, lexical search may be empty, and Retry indexing starts a
+  fresh attempt. An OOM of the codesearch task is stored as
+  “Codebase didn't fit available memory”, not a raw `fetch failed`.
 
 <Callout type="info">
   Exact extractor sets and graph primitives evolve with the product; treat this

--- a/apps/docs/content/docs/self-hosting/deployment/aws.mdx
+++ b/apps/docs/content/docs/self-hosting/deployment/aws.mdx
@@ -143,6 +143,20 @@ slug as the `orgSlug` you passed to `CtxPipe`.
   org-scoped graph configuration will not line up.
 </Callout>
 
+### 7) Upgrade an existing stack
+
+A new `@ctxpipe/aws-cdk` version on npm is the release unit. It pins backend, worker, UI, codesearch, and migrate images to one git SHA and includes that release’s Fargate size profiles. After it is published:
+
+```bash
+pnpm update @ctxpipe/aws-cdk
+cdk synth
+cdk deploy
+```
+
+`cdk deploy` runs Postgres migrations, then rolls the ECS services. You do not set image tags in `CtxPipe` props, and you should not retag tasks to `:latest` yourself.
+
+This is how codesearch memory bumps (4 / 8 / 12 GiB) and ingest behaviour land together. Updating only container images, or only task memory, leaves the stack split across releases.
+
 ### Bonus: automate upgrades with CI/CD
 
 Set up CI/CD so dependency upgrades for `@ctxpipe/aws-cdk` trigger:

--- a/apps/docs/content/docs/self-hosting/deployment/aws.mdx
+++ b/apps/docs/content/docs/self-hosting/deployment/aws.mdx
@@ -246,9 +246,9 @@ through backend routing.
 
 Use `size` to tune compute and database capacity for your single-tenant workload:
 
-- `small` (default): best for pilot/small-team deployments with moderate repository churn and cost sensitivity. Aurora and Neptune both use `db.t4g.medium` — AWS’s minimum supported burstable size for these engines (dev/test oriented).
-- `medium`: better for sustained ingestion/reindex workloads where worker and codesearch need more headroom. Aurora uses `db.t4g.large`; Neptune uses memory-optimized `db.r6g.large`.
-- `large`: for high-ingestion and lower-latency expectations, with bigger tasks, scaled backend/worker replicas, and `db.r6g.xlarge` for both Aurora and Neptune.
+- `small` (default): best for pilot/small-team deployments with moderate repository churn and cost sensitivity. Aurora and Neptune both use `db.t4g.medium` — AWS’s minimum supported burstable size for these engines (dev/test oriented). Codesearch is 4 GiB (ingest peak, not idle RSS).
+- `medium`: better for sustained ingestion/reindex workloads where worker and codesearch need more headroom. Codesearch is 8 GiB. Aurora uses `db.t4g.large`; Neptune uses memory-optimized `db.r6g.large`.
+- `large`: for high-ingestion and lower-latency expectations, with bigger tasks, scaled backend/worker replicas, and `db.r6g.xlarge` for both Aurora and Neptune. Codesearch is 12 GiB.
 
 See the [package README sizing table](https://github.com/ctxpipe-ai/ctxpipe/blob/main/packages/aws-cdk/README.md#sizing-profiles) for the full preset matrix.
 

--- a/apps/docs/content/docs/self-hosting/upgrades.mdx
+++ b/apps/docs/content/docs/self-hosting/upgrades.mdx
@@ -15,9 +15,22 @@ inviting users back in.
 4. Preserve current deployment secrets and image tags or commit SHA.
 5. Confirm there are no long-running connector or ingestion jobs you need to let
    finish first.
-6. Run migrations against the target database.
+6. Run migrations against the target database (AWS CDK: this is part of
+   `cdk deploy`).
 7. Deploy backend, worker, UI, and codesearch from the same commit or release.
 8. Validate health, sign-in, repository indexing, Chat/MCP, and connectors.
+
+## AWS CDK flow
+
+Self-hosted AWS stacks upgrade by bumping `@ctxpipe/aws-cdk` and redeploying. The published package pins backend, worker, UI, codesearch, and migrate images to the same git SHA and applies that release’s Fargate size profiles.
+
+```bash
+pnpm update @ctxpipe/aws-cdk
+cdk synth
+cdk deploy
+```
+
+`cdk deploy` runs the migrate task, then updates ECS services. Do not retag services to `:latest` or mix image SHAs from different package versions. See [AWS](/docs/self-hosting/deployment/aws).
 
 ## Docker Compose flow
 

--- a/apps/ui/src/features/chat/ChatEmptyState.test.ts
+++ b/apps/ui/src/features/chat/ChatEmptyState.test.ts
@@ -31,6 +31,20 @@ describe("getChatAvailability", () => {
     ).toBe("indexing")
   })
 
+  it("enables chat when a repository completed with issues", () => {
+    expect(
+      getChatAvailability(
+        [
+          {
+            indexingStatus: "complete_with_issues",
+            indexReady: true,
+          },
+        ],
+        false,
+      ),
+    ).toBe("ready")
+  })
+
   it("directs users to repository status when no index can be queried", () => {
     expect(
       getChatAvailability(

--- a/apps/ui/src/features/chat/ChatEmptyState.tsx
+++ b/apps/ui/src/features/chat/ChatEmptyState.tsx
@@ -29,9 +29,10 @@ export function getChatAvailability(
   if (!repositories) return "ready"
   if (repositories.length === 0) return "no-repositories"
   if (
-    repositories.some(
-      (repository) => getRepositoryIndexingStatus(repository) === "ready",
-    )
+    repositories.some((repository) => {
+      const status = getRepositoryIndexingStatus(repository)
+      return status === "ready" || status === "complete_with_issues"
+    })
   ) {
     return "ready"
   }

--- a/apps/ui/src/features/repositories/components/RepositoryCard.stories.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryCard.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, fn, userEvent, within } from "storybook/test"
 import { entryPageInnerDecorators } from "../../../../.storybook/decorators/entry-page-decorators"
 import type { StoryRouteParams } from "../../../../.storybook/decorators/with-story-route"
 import { RepositoryCard } from "./RepositoryCard"
@@ -141,18 +142,28 @@ export const Failed: Story = {
 }
 
 export const CompleteWithIssues: Story = {
-  render: () => (
-    <RepositoryCard
-      repo={{
-        ...baseRepo,
-        indexReady: true,
-        indexingStatus: "complete_with_issues",
-        indexingError: "Codebase didn't fit available memory",
-        lastIngestedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
-        lastIngestedHash: "abc1234",
-      }}
-      onDelete={noop}
-      onRetry={noop}
-    />
-  ),
+  args: {
+    repo: {
+      ...baseRepo,
+      indexReady: true,
+      indexingStatus: "complete_with_issues",
+      indexingError: "Codebase didn't fit available memory",
+      lastIngestedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      lastIngestedHash: "abc1234",
+    },
+    onDelete: fn(),
+    onRetry: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Repository actions" }),
+    )
+    const retry = await within(canvasElement.ownerDocument.body).findByRole(
+      "menuitem",
+      { name: "Retry indexing" },
+    )
+    await userEvent.click(retry)
+    await expect(args.onRetry).toHaveBeenCalledTimes(1)
+  },
 }

--- a/apps/ui/src/features/repositories/components/RepositoryCard.stories.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryCard.stories.tsx
@@ -139,3 +139,20 @@ export const Failed: Story = {
     />
   ),
 }
+
+export const CompleteWithIssues: Story = {
+  render: () => (
+    <RepositoryCard
+      repo={{
+        ...baseRepo,
+        indexReady: true,
+        indexingStatus: "complete_with_issues",
+        indexingError: "Codebase didn't fit available memory",
+        lastIngestedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        lastIngestedHash: "abc1234",
+      }}
+      onDelete={noop}
+      onRetry={noop}
+    />
+  ),
+}

--- a/apps/ui/src/features/repositories/components/RepositoryCard.test.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryCard.test.tsx
@@ -1,0 +1,66 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import type { Repository } from "../types"
+import { RepositoryCard } from "./RepositoryCard"
+
+const memoryError = "Codebase didn't fit available memory"
+
+const baseRepo: Repository = {
+  id: "repo_1",
+  orgId: "org_acme",
+  zoektRepoId: 1,
+  name: "acme/web",
+  gitUrl: "https://github.com/acme/web.git",
+  indexReady: true,
+  indexingStatus: "ready",
+  indexingError: null,
+  indexingFailedAt: null,
+  indexingReason: null,
+  indexingStep: null,
+  indexingStepTotal: null,
+  indexingStepKey: null,
+  lastIngestedHash: "abc1234",
+  lastIngestedAt: "2026-01-01T00:00:00.000Z",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  githubConnectionId: null,
+}
+
+describe("RepositoryCard", () => {
+  it("shows complete with issues and the stored memory-fit error", () => {
+    const html = renderToStaticMarkup(
+      <RepositoryCard
+        repo={{
+          ...baseRepo,
+          indexingStatus: "complete_with_issues",
+          indexingError: memoryError,
+        }}
+        onDelete={vi.fn()}
+        onRetry={vi.fn()}
+        interactive={false}
+      />,
+    )
+    expect(html).toContain("complete with issues")
+    expect(html).toContain("sr-only")
+    expect(html).toContain("Codebase didn&#x27;t fit available memory")
+    expect(html).toContain("ctx-indexing-issues")
+  })
+
+  it("shows out of date with the memory-fit error after a prior-success task OOM", () => {
+    const html = renderToStaticMarkup(
+      <RepositoryCard
+        repo={{
+          ...baseRepo,
+          indexReady: false,
+          indexingStatus: "failed",
+          indexingError: memoryError,
+        }}
+        onDelete={vi.fn()}
+        onRetry={vi.fn()}
+        interactive={false}
+      />,
+    )
+    expect(html).toContain("out of date")
+    expect(html).toContain("Codebase didn&#x27;t fit available memory")
+  })
+})

--- a/apps/ui/src/features/repositories/components/RepositoryCard.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryCard.tsx
@@ -13,11 +13,8 @@ import {
   MenuTrigger,
 } from "@/components/ui/Menu"
 import { githubWebUrl } from "@/features/repositories/github-web-url"
-import {
-  formatIndexingStepLabel,
-  getRepositoryStatusDisplay,
-  type Repository,
-} from "../types"
+import { repositoryCardPresentation } from "../repositoryCardPresentation"
+import type { Repository } from "../types"
 import { RepositoryStatus } from "./RepositoryStatus"
 
 interface RepositoryCardProps {
@@ -38,54 +35,39 @@ export function RepositoryCard({
   interactive = true,
 }: RepositoryCardProps) {
   const webUrl = githubWebUrl(repo.gitUrl)
-  const status = repo.indexingStatus
-  const displayStatus = getRepositoryStatusDisplay(repo)
-  const isReady = status === "ready"
-  const isFailed = status === "failed"
-  const isCompleteWithIssues = status === "complete_with_issues"
-  const isUnindexing = status === "unindexing"
-
-  const stepLabel =
-    displayStatus === "queued" ||
-    displayStatus === "running" ||
-    displayStatus === "refreshing"
-      ? formatIndexingStepLabel(repo)
-      : null
-  const indexingDetail =
-    stepLabel ??
-    (displayStatus === "running" && repo.indexingReason === "merge"
-      ? "indexing merge"
-      : displayStatus === "running" && repo.indexingReason === "push"
-        ? "indexing recent changes"
-        : null)
-  const failedDetail =
-    displayStatus === "failed" ? repo.indexingError?.trim() || null : null
-  const issuesDetail =
-    displayStatus === "complete_with_issues"
-      ? repo.indexingError?.trim() || null
-      : null
-  const outOfDateDetail =
-    displayStatus === "out-of-date" && repo.lastIngestedHash
-      ? {
-          lastIngestedHash: repo.lastIngestedHash,
-          lastIngestedAt: repo.lastIngestedAt,
-          indexingError: repo.indexingError,
-        }
-      : null
+  const {
+    displayStatus,
+    indexingDetail,
+    failedDetail,
+    issuesDetail,
+    outOfDateDetail,
+    showRetryIndexing,
+    queryable,
+  } = repositoryCardPresentation(repo)
+  const isUnindexing = repo.indexingStatus === "unindexing"
+  const isCompleteWithIssues = displayStatus === "complete_with_issues"
 
   return (
     <div className="ctx-repo-row group">
       <div className="flex min-w-0 flex-1 items-center gap-4">
         <div
           className={`ctx-node h-10 w-10 shrink-0 transition-[color,background-color,border-color] duration-150 ease-out [&_svg]:h-4 [&_svg]:w-4 [&_svg]:transition-colors ${
-            isReady
+            displayStatus === "ready"
               ? "border-teal-400 bg-teal-400/5 [&_svg]:text-teal-400"
-              : "group-hover:border-teal-400 group-hover:bg-teal-400/5 [&_svg]:text-muted-foreground group-hover:[&_svg]:text-teal-400"
+              : isCompleteWithIssues
+                ? "border-amber-200/80 bg-amber-200/5 [&_svg]:text-amber-200"
+                : "group-hover:border-teal-400 group-hover:bg-teal-400/5 [&_svg]:text-muted-foreground group-hover:[&_svg]:text-teal-400"
           }`}
         >
           <IconGitBranch
             aria-hidden
-            className={`h-4 w-4 ${isReady ? "text-teal-400" : "text-muted-foreground"}`}
+            className={`h-4 w-4 ${
+              displayStatus === "ready"
+                ? "text-teal-400"
+                : isCompleteWithIssues
+                  ? "text-amber-200"
+                  : "text-muted-foreground"
+            }`}
           />
         </div>
         <div className="min-w-0">
@@ -105,9 +87,7 @@ export function RepositoryCard({
           indexingDetail={indexingDetail}
           failedDetail={failedDetail}
           issuesDetail={issuesDetail}
-          indexedAt={
-            isReady || isCompleteWithIssues ? repo.lastIngestedAt : null
-          }
+          indexedAt={queryable ? repo.lastIngestedAt : null}
           outOfDateDetail={outOfDateDetail}
           interactive={interactive}
         />
@@ -144,7 +124,7 @@ export function RepositoryCard({
                   <MenuSeparator />
                 </>
               ) : null}
-              {isFailed || isCompleteWithIssues ? (
+              {showRetryIndexing ? (
                 <>
                   <MenuItem
                     id="retry"

--- a/apps/ui/src/features/repositories/components/RepositoryCard.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryCard.tsx
@@ -42,6 +42,7 @@ export function RepositoryCard({
   const displayStatus = getRepositoryStatusDisplay(repo)
   const isReady = status === "ready"
   const isFailed = status === "failed"
+  const isCompleteWithIssues = status === "complete_with_issues"
   const isUnindexing = status === "unindexing"
 
   const stepLabel =
@@ -59,6 +60,10 @@ export function RepositoryCard({
         : null)
   const failedDetail =
     displayStatus === "failed" ? repo.indexingError?.trim() || null : null
+  const issuesDetail =
+    displayStatus === "complete_with_issues"
+      ? repo.indexingError?.trim() || null
+      : null
   const outOfDateDetail =
     displayStatus === "out-of-date" && repo.lastIngestedHash
       ? {
@@ -99,7 +104,10 @@ export function RepositoryCard({
           status={displayStatus}
           indexingDetail={indexingDetail}
           failedDetail={failedDetail}
-          indexedAt={isReady ? repo.lastIngestedAt : null}
+          issuesDetail={issuesDetail}
+          indexedAt={
+            isReady || isCompleteWithIssues ? repo.lastIngestedAt : null
+          }
           outOfDateDetail={outOfDateDetail}
           interactive={interactive}
         />
@@ -136,7 +144,7 @@ export function RepositoryCard({
                   <MenuSeparator />
                 </>
               ) : null}
-              {isFailed ? (
+              {isFailed || isCompleteWithIssues ? (
                 <>
                   <MenuItem
                     id="retry"

--- a/apps/ui/src/features/repositories/components/RepositoryStatus.test.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryStatus.test.tsx
@@ -34,4 +34,16 @@ describe("RepositoryStatus", () => {
       ),
     ).toContain("indexed ·")
   })
+
+  it("labels complete_with_issues and keeps the stored error for the tooltip", () => {
+    const html = renderToStaticMarkup(
+      <RepositoryStatus
+        status="complete_with_issues"
+        issuesDetail="Codebase didn't fit available memory"
+        indexedAt={new Date(Date.now() - 60 * 60 * 1000).toISOString()}
+      />,
+    )
+    expect(html).toContain("complete with issues")
+    expect(html).toContain("ctx-indexing-issues")
+  })
 })

--- a/apps/ui/src/features/repositories/components/RepositoryStatus.test.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryStatus.test.tsx
@@ -35,15 +35,33 @@ describe("RepositoryStatus", () => {
     ).toContain("indexed ·")
   })
 
-  it("labels complete_with_issues and keeps the stored error for the tooltip", () => {
+  it("labels complete_with_issues and exposes the stored error to assistive text", () => {
     const html = renderToStaticMarkup(
       <RepositoryStatus
         status="complete_with_issues"
         issuesDetail="Codebase didn't fit available memory"
         indexedAt={new Date(Date.now() - 60 * 60 * 1000).toISOString()}
+        interactive={false}
       />,
     )
     expect(html).toContain("complete with issues")
+    expect(html).toContain("sr-only")
+    expect(html).toContain("Codebase didn&#x27;t fit available memory")
     expect(html).toContain("ctx-indexing-issues")
+  })
+
+  it("exposes a prior-success task OOM as out of date with the memory-fit error", () => {
+    const html = renderToStaticMarkup(
+      <RepositoryStatus
+        status="out-of-date"
+        outOfDateDetail={{
+          lastIngestedHash: "abc123def456",
+          indexingError: "Codebase didn't fit available memory",
+        }}
+        interactive={false}
+      />,
+    )
+    expect(html).toContain("out of date")
+    expect(html).toContain("Codebase didn&#x27;t fit available memory")
   })
 })

--- a/apps/ui/src/features/repositories/components/RepositoryStatus.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryStatus.tsx
@@ -54,6 +54,11 @@ const STATUS_META: Record<
     className: "ctx-unindexing",
     dotClassName: "ctx-unindexing-dot",
   },
+  complete_with_issues: {
+    label: "complete with issues",
+    className: "ctx-indexing-issues",
+    dotClassName: "ctx-indexing-issues-dot",
+  },
 }
 
 export function RepositoryStatus(props: {
@@ -62,6 +67,8 @@ export function RepositoryStatus(props: {
   indexingDetail?: string | null
   /** Error details shown in a tooltip when status is `failed`. */
   failedDetail?: string | null
+  /** Issue details shown when status is `complete_with_issues`. */
+  issuesDetail?: string | null
   /** Last successful ingest time, shown on `ready` as `indexed · 1 hour ago`. */
   indexedAt?: string | null
   /** Prior-success + error details for `out-of-date` tooltip. */
@@ -80,7 +87,8 @@ export function RepositoryStatus(props: {
     props.status === "running" ||
     props.status === "refreshing"
   const relativeIndexed =
-    props.status === "ready" && props.indexedAt
+    (props.status === "ready" || props.status === "complete_with_issues") &&
+    props.indexedAt
       ? formatDate(props.indexedAt)
       : null
   const label =
@@ -127,12 +135,18 @@ function resolveTooltipContent(props: {
   status: RepositoryStatusState
   indexedAt?: string | null
   failedDetail?: string | null
+  issuesDetail?: string | null
   outOfDateDetail?: {
     lastIngestedHash: string
     lastIngestedAt?: string | null
     indexingError?: string | null
   } | null
 }): ReactNode {
+  if (props.status === "complete_with_issues") {
+    const issuesDetail = props.issuesDetail?.trim()
+    return issuesDetail ? <p>{issuesDetail}</p> : null
+  }
+
   if (props.status === "ready" && props.indexedAt) {
     return (
       <p>

--- a/apps/ui/src/features/repositories/components/RepositoryStatus.tsx
+++ b/apps/ui/src/features/repositories/components/RepositoryStatus.tsx
@@ -101,6 +101,7 @@ export function RepositoryStatus(props: {
   const tooltipContent =
     props.interactive === false ? null : resolveTooltipContent(props)
 
+  const description = statusDescription(props)
   const statusBadge = (
     <span
       className={
@@ -111,6 +112,7 @@ export function RepositoryStatus(props: {
     >
       <span aria-hidden className={meta.dotClassName} />
       {label}
+      {description ? <span className="sr-only">{description}</span> : null}
     </span>
   )
 
@@ -190,5 +192,27 @@ function resolveTooltipContent(props: {
     return failedDetail ? <p>{failedDetail}</p> : null
   }
 
+  return null
+}
+
+function statusDescription(props: {
+  status: RepositoryStatusState
+  failedDetail?: string | null
+  issuesDetail?: string | null
+  outOfDateDetail?: {
+    lastIngestedHash: string
+    lastIngestedAt?: string | null
+    indexingError?: string | null
+  } | null
+}): string | null {
+  if (props.status === "complete_with_issues") {
+    return props.issuesDetail?.trim() || null
+  }
+  if (props.status === "failed") {
+    return props.failedDetail?.trim() || null
+  }
+  if (props.status === "out-of-date") {
+    return props.outOfDateDetail?.indexingError?.trim() || null
+  }
   return null
 }

--- a/apps/ui/src/features/repositories/gitSourcesFilter.test.ts
+++ b/apps/ui/src/features/repositories/gitSourcesFilter.test.ts
@@ -59,4 +59,25 @@ describe("repositoryMatchesStatusFilter", () => {
       ),
     ).toBe(false)
   })
+
+  it("treats complete with issues as both indexed and needing attention", () => {
+    expect(
+      repositoryMatchesStatusFilter(
+        {
+          indexingStatus: "complete_with_issues",
+          lastIngestedHash: "abc",
+        },
+        "indexed",
+      ),
+    ).toBe(true)
+    expect(
+      repositoryMatchesStatusFilter(
+        {
+          indexingStatus: "complete_with_issues",
+          lastIngestedHash: "abc",
+        },
+        "failed",
+      ),
+    ).toBe(true)
+  })
 })

--- a/apps/ui/src/features/repositories/gitSourcesFilter.test.ts
+++ b/apps/ui/src/features/repositories/gitSourcesFilter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  gitSourceFilterCounts,
   gitSourceMatchesQuery,
   repositoryMatchesStatusFilter,
 } from "./gitSourcesFilter"
@@ -79,5 +80,27 @@ describe("repositoryMatchesStatusFilter", () => {
         "failed",
       ),
     ).toBe(true)
+  })
+
+  it("counts complete with issues in both indexed and failed chips", () => {
+    expect(
+      gitSourceFilterCounts(
+        [
+          { indexingStatus: "ready", lastIngestedHash: "abc" },
+          {
+            indexingStatus: "complete_with_issues",
+            lastIngestedHash: "abc",
+          },
+          { indexingStatus: "failed", lastIngestedHash: null },
+        ],
+        0,
+      ),
+    ).toEqual({
+      all: 3,
+      indexed: 2,
+      indexing: 0,
+      failed: 2,
+      pending: 0,
+    })
   })
 })

--- a/apps/ui/src/features/repositories/gitSourcesFilter.ts
+++ b/apps/ui/src/features/repositories/gitSourcesFilter.ts
@@ -52,3 +52,26 @@ function statusDisplayMatchesFilter(
     )
   return false
 }
+
+/** Chip counts must use the same predicate as {@link repositoryMatchesStatusFilter}. */
+export function gitSourceFilterCounts(
+  repos: Array<
+    Pick<Repository, "indexReady" | "indexingStatus" | "lastIngestedHash">
+  >,
+  pendingCount: number,
+): Record<GitSourceStatusFilter, number> {
+  const counts: Record<GitSourceStatusFilter, number> = {
+    all: repos.length + pendingCount,
+    indexed: 0,
+    indexing: 0,
+    failed: 0,
+    pending: pendingCount,
+  }
+  for (const repo of repos) {
+    const display = getRepositoryStatusDisplay(repo)
+    if (statusDisplayMatchesFilter(display, "indexed")) counts.indexed += 1
+    if (statusDisplayMatchesFilter(display, "indexing")) counts.indexing += 1
+    if (statusDisplayMatchesFilter(display, "failed")) counts.failed += 1
+  }
+  return counts
+}

--- a/apps/ui/src/features/repositories/gitSourcesFilter.ts
+++ b/apps/ui/src/features/repositories/gitSourcesFilter.ts
@@ -34,7 +34,8 @@ function statusDisplayMatchesFilter(
   display: RepositoryStatusDisplay,
   filter: GitSourceStatusFilter,
 ): boolean {
-  if (filter === "indexed") return display === "ready"
+  if (filter === "indexed")
+    return display === "ready" || display === "complete_with_issues"
   if (filter === "indexing") {
     return (
       display === "queued" ||
@@ -44,6 +45,10 @@ function statusDisplayMatchesFilter(
     )
   }
   if (filter === "failed")
-    return display === "failed" || display === "out-of-date"
+    return (
+      display === "failed" ||
+      display === "out-of-date" ||
+      display === "complete_with_issues"
+    )
   return false
 }

--- a/apps/ui/src/features/repositories/repositoryCardPresentation.test.ts
+++ b/apps/ui/src/features/repositories/repositoryCardPresentation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { repositoryCardPresentation } from "./repositoryCardPresentation"
+
+const memoryError = "Codebase didn't fit available memory"
+
+describe("repositoryCardPresentation", () => {
+  it("surfaces the stored Zoekt issue, retry, and queryable icon for complete_with_issues", () => {
+    expect(
+      repositoryCardPresentation({
+        indexingStatus: "complete_with_issues",
+        indexingError: memoryError,
+        lastIngestedHash: "abc1234",
+        lastIngestedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ).toMatchObject({
+      displayStatus: "complete_with_issues",
+      issuesDetail: memoryError,
+      failedDetail: null,
+      showRetryIndexing: true,
+      queryable: true,
+    })
+  })
+
+  it("labels first-run task OOM as failed with the memory-fit error and retry", () => {
+    expect(
+      repositoryCardPresentation({
+        indexingStatus: "failed",
+        indexingError: memoryError,
+        lastIngestedHash: null,
+        lastIngestedAt: null,
+      }),
+    ).toMatchObject({
+      displayStatus: "failed",
+      failedDetail: memoryError,
+      issuesDetail: null,
+      showRetryIndexing: true,
+      queryable: false,
+    })
+  })
+
+  it("labels task OOM after a prior success as out of date with the memory-fit error", () => {
+    expect(
+      repositoryCardPresentation({
+        indexingStatus: "failed",
+        indexingError: memoryError,
+        lastIngestedHash: "abc123def456",
+        lastIngestedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ).toMatchObject({
+      displayStatus: "out-of-date",
+      failedDetail: null,
+      issuesDetail: null,
+      showRetryIndexing: true,
+      queryable: false,
+      outOfDateDetail: {
+        lastIngestedHash: "abc123def456",
+        indexingError: memoryError,
+      },
+    })
+  })
+})

--- a/apps/ui/src/features/repositories/repositoryCardPresentation.test.ts
+++ b/apps/ui/src/features/repositories/repositoryCardPresentation.test.ts
@@ -58,4 +58,18 @@ describe("repositoryCardPresentation", () => {
       },
     })
   })
+
+  it("does not offer retry while indexing is ready", () => {
+    expect(
+      repositoryCardPresentation({
+        indexingStatus: "ready",
+        indexingError: null,
+        lastIngestedHash: "abc1234",
+        lastIngestedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ).toMatchObject({
+      displayStatus: "ready",
+      showRetryIndexing: false,
+    })
+  })
 })

--- a/apps/ui/src/features/repositories/repositoryCardPresentation.ts
+++ b/apps/ui/src/features/repositories/repositoryCardPresentation.ts
@@ -1,0 +1,74 @@
+import {
+  formatIndexingStepLabel,
+  getRepositoryIndexingStatus,
+  getRepositoryStatusDisplay,
+  type Repository,
+  type RepositoryStatusDisplay,
+} from "./types"
+
+export type RepositoryCardPresentation = {
+  displayStatus: RepositoryStatusDisplay
+  issuesDetail: string | null
+  failedDetail: string | null
+  outOfDateDetail: {
+    lastIngestedHash: string
+    lastIngestedAt?: string | null
+    indexingError?: string | null
+  } | null
+  showRetryIndexing: boolean
+  queryable: boolean
+  indexingDetail: string | null
+}
+
+export function repositoryCardPresentation(
+  repo: Pick<
+    Repository,
+    | "indexReady"
+    | "indexingStatus"
+    | "indexingError"
+    | "indexingReason"
+    | "indexingStep"
+    | "indexingStepTotal"
+    | "indexingStepKey"
+    | "lastIngestedHash"
+    | "lastIngestedAt"
+  >,
+): RepositoryCardPresentation {
+  const indexingStatus = getRepositoryIndexingStatus(repo)
+  const displayStatus = getRepositoryStatusDisplay(repo)
+  const stepLabel =
+    displayStatus === "queued" ||
+    displayStatus === "running" ||
+    displayStatus === "refreshing"
+      ? formatIndexingStepLabel(repo)
+      : null
+  const indexingDetail =
+    stepLabel ??
+    (displayStatus === "running" && repo.indexingReason === "merge"
+      ? "indexing merge"
+      : displayStatus === "running" && repo.indexingReason === "push"
+        ? "indexing recent changes"
+        : null)
+  return {
+    displayStatus,
+    issuesDetail:
+      displayStatus === "complete_with_issues"
+        ? repo.indexingError?.trim() || null
+        : null,
+    failedDetail:
+      displayStatus === "failed" ? repo.indexingError?.trim() || null : null,
+    outOfDateDetail:
+      displayStatus === "out-of-date" && repo.lastIngestedHash
+        ? {
+            lastIngestedHash: repo.lastIngestedHash,
+            lastIngestedAt: repo.lastIngestedAt,
+            indexingError: repo.indexingError,
+          }
+        : null,
+    showRetryIndexing:
+      indexingStatus === "failed" || indexingStatus === "complete_with_issues",
+    queryable:
+      displayStatus === "ready" || displayStatus === "complete_with_issues",
+    indexingDetail,
+  }
+}

--- a/apps/ui/src/features/repositories/types.test.ts
+++ b/apps/ui/src/features/repositories/types.test.ts
@@ -16,7 +16,7 @@ describe("getRepositoryStatusDisplay", () => {
     ).toBe("failed")
   })
 
-  it("maps failed with prior success to out-of-date", () => {
+  it("maps failed with prior success to out-of-date, including a memory-fit error", () => {
     expect(
       getRepositoryStatusDisplay({
         indexingStatus: "failed",

--- a/apps/ui/src/features/repositories/types.test.ts
+++ b/apps/ui/src/features/repositories/types.test.ts
@@ -57,6 +57,15 @@ describe("getRepositoryStatusDisplay", () => {
       }),
     ).toBe("queued")
   })
+
+  it("keeps complete_with_issues even when a hash was ingested", () => {
+    expect(
+      getRepositoryStatusDisplay({
+        indexingStatus: "complete_with_issues",
+        lastIngestedHash: "abc123def456",
+      }),
+    ).toBe("complete_with_issues")
+  })
 })
 
 describe("formatShortCommitHash", () => {

--- a/apps/ui/src/features/repositories/types.ts
+++ b/apps/ui/src/features/repositories/types.ts
@@ -14,6 +14,7 @@ export type RepositoryIndexingStatus =
   | "ready"
   | "failed"
   | "unindexing"
+  | "complete_with_issues"
 
 /** UI-only display labels derived from API status + prior success. */
 export type RepositoryStatusDisplay =

--- a/apps/ui/src/features/repositories/useRepositoryIndexingSummary.test.ts
+++ b/apps/ui/src/features/repositories/useRepositoryIndexingSummary.test.ts
@@ -120,6 +120,19 @@ describe("getRepositoryIndexingSummary", () => {
     })
   })
 
+  it("counts complete with issues toward failedCount", () => {
+    expect(
+      getRepositoryIndexingSummary([
+        { indexingStatus: "complete_with_issues" },
+        { indexingStatus: "ready" },
+      ]),
+    ).toMatchObject({
+      totalCount: 2,
+      activeCount: 0,
+      failedCount: 1,
+    })
+  })
+
   it("returns null singleActiveStepLabel when multiple repos are active", () => {
     expect(
       getRepositoryIndexingSummary([

--- a/apps/ui/src/features/repositories/useRepositoryIndexingSummary.ts
+++ b/apps/ui/src/features/repositories/useRepositoryIndexingSummary.ts
@@ -44,7 +44,9 @@ export function getRepositoryIndexingSummary(
     }
     if (status === "queued") queuedCount += 1
     if (status === "running") runningCount += 1
-    if (status === "failed") failedCount += 1
+    if (status === "failed" || status === "complete_with_issues") {
+      failedCount += 1
+    }
   }
 
   const singleActiveStepLabel =

--- a/apps/ui/src/routes/$orgSlug.repositories.index.tsx
+++ b/apps/ui/src/routes/$orgSlug.repositories.index.tsx
@@ -16,16 +16,12 @@ import {
   githubConnectorKeys,
 } from "@/features/connectors/queries/github-connector"
 import { useGithubConnectFlow } from "@/features/connectors/useGithubConnectFlow"
-import {
-  AddRepositoryModal,
-  getRepositoryIndexingSummary,
-  getRepositoryStatusDisplay,
-  type Repository,
-} from "@/features/repositories"
+import { AddRepositoryModal, type Repository } from "@/features/repositories"
 import { GitSourcesVirtualList } from "@/features/repositories/components/GitSourcesVirtualList"
 import { githubRepoFullNameFromGitUrl } from "@/features/repositories/github-web-url"
 import {
   type GitSourceStatusFilter,
+  gitSourceFilterCounts,
   gitSourceMatchesQuery,
   repositoryMatchesStatusFilter,
 } from "@/features/repositories/gitSourcesFilter"
@@ -387,22 +383,7 @@ export function RepositoriesPageContent({ orgSlug }: { orgSlug: string }) {
     listQuery,
     filteredRepos,
   ])
-  const indexingSummary = getRepositoryIndexingSummary(repos)
-  const filterCounts = {
-    all: repos.length + pendingCount,
-    indexed: repos.filter(
-      (repo) => getRepositoryStatusDisplay(repo) === "ready",
-    ).length,
-    indexing:
-      indexingSummary.queuedCount +
-      indexingSummary.runningCount +
-      repos.filter((repo) => repo.indexingStatus === "unindexing").length,
-    failed: repos.filter((repo) => {
-      const display = getRepositoryStatusDisplay(repo)
-      return display === "failed" || display === "out-of-date"
-    }).length,
-    pending: pendingCount,
-  }
+  const filterCounts = gitSourceFilterCounts(repos, pendingCount)
   const listIsFiltered = listQuery.trim() !== "" || statusFilter !== "all"
   const hasFilteredRows = listRows.length > 0
 

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -471,6 +471,14 @@
     @apply h-1.5 w-1.5 rounded-full bg-red-300;
   }
 
+  .ctx-indexing-issues {
+    @apply inline-flex items-center gap-1.5 font-mono text-xs text-amber-200;
+  }
+
+  .ctx-indexing-issues-dot {
+    @apply h-1.5 w-1.5 rounded-full bg-amber-200/80;
+  }
+
   .ctx-unindexing {
     @apply inline-flex items-center gap-1.5 font-mono text-xs text-red-300;
     animation: ctx-unindexing-glow 900ms ease-in-out infinite;

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -145,9 +145,9 @@ modelProvider: {
 
 | Size              | ECS task sizes (cpu/memory MiB)                                                                     | ECS desired count                               | Aurora writer   | Neptune instance | Backup retention |
 | ----------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------- | --------------- | ---------------- | ---------------- |
-| `small` (default) | backend `256/512`, worker `512/1024`, ui `256/512`, codesearch `512/1024`, migrate `256/512`        | backend `1`, worker `1`, ui `1`, codesearch `1` | `db.t4g.medium` | `db.t4g.medium`  | 7 days           |
-| `medium`          | backend `512/1024`, worker `1024/2048`, ui `256/512`, codesearch `1024/2048`, migrate `512/1024`    | backend `1`, worker `1`, ui `1`, codesearch `1` | `db.t4g.large`  | `db.r6g.large`   | 7 days           |
-| `large`           | backend `1024/2048`, worker `2048/4096`, ui `512/1024`, codesearch `2048/4096`, migrate `1024/2048` | backend `2`, worker `2`, ui `1`, codesearch `1` | `db.r6g.xlarge` | `db.r6g.xlarge`  | 14 days          |
+| `small` (default) | backend `256/512`, worker `512/1024`, ui `256/512`, codesearch `512/4096`, migrate `256/512`        | backend `1`, worker `1`, ui `1`, codesearch `1` | `db.t4g.medium` | `db.t4g.medium`  | 7 days           |
+| `medium`          | backend `512/1024`, worker `1024/2048`, ui `256/512`, codesearch `1024/8192`, migrate `512/1024`    | backend `1`, worker `1`, ui `1`, codesearch `1` | `db.t4g.large`  | `db.r6g.large`   | 7 days           |
+| `large`           | backend `1024/2048`, worker `2048/4096`, ui `512/1024`, codesearch `2048/12288`, migrate `1024/2048` | backend `2`, worker `2`, ui `1`, codesearch `1` | `db.r6g.xlarge` | `db.r6g.xlarge`  | 14 days          |
 
 
 Sizing guidance:
@@ -156,6 +156,7 @@ Sizing guidance:
 - Use `medium` when ingestion/reindex bursts are frequent and you want more headroom. Neptune moves to memory-optimized `db.r6g.large`.
 - Use `large` for high-ingestion repositories with stricter latency requirements. Aurora and Neptune both use `db.r6g.xlarge`.
 - Scale worker first when queue pressure grows; codesearch replicas stay conservative.
+- Codesearch memory is sized for **ingest peaks** (Zoekt/SCIP), not idle RSS. Fargate cannot grow a running task; `small` is 4 GiB, `medium` 8 GiB, `large` 12 GiB.
 
 Networking note:
 

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -207,6 +207,23 @@ Runtime defaults injected by the construct include:
 
 This keeps the package and service images aligned by default with no extra config in `CtxPipeProps`.
 
+## Upgrading an existing stack
+
+Bump the construct, then redeploy. Do not retag ECS services to `:latest` by hand — the package pin is what keeps images, Fargate sizes, and migrations on the same release.
+
+```bash
+pnpm update @ctxpipe/aws-cdk
+cdk synth
+cdk deploy
+```
+
+That deploy:
+
+- updates codesearch (and other) task CPU/memory from this package version’s size profiles
+- rolls backend, worker, UI, codesearch, and migrate to the SHA stamped into this package
+- runs Postgres migrations (including new enum values) before ECS services update
+
+
 ## Environment checklist
 
 

--- a/packages/aws-cdk/src/ctxpipe.ts
+++ b/packages/aws-cdk/src/ctxpipe.ts
@@ -43,7 +43,7 @@ const SIZE_PROFILES: Record<CtxPipeSize, CtxPipeSizeProfile> = {
       backend: { cpu: 256, memoryLimitMiB: 512 },
       worker: { cpu: 512, memoryLimitMiB: 1024 },
       ui: { cpu: 256, memoryLimitMiB: 512 },
-      codesearch: { cpu: 512, memoryLimitMiB: 1024 },
+      codesearch: { cpu: 512, memoryLimitMiB: 4096 },
       migrate: { cpu: 256, memoryLimitMiB: 512 },
     },
     services: {
@@ -69,7 +69,7 @@ const SIZE_PROFILES: Record<CtxPipeSize, CtxPipeSizeProfile> = {
       backend: { cpu: 512, memoryLimitMiB: 1024 },
       worker: { cpu: 1024, memoryLimitMiB: 2048 },
       ui: { cpu: 256, memoryLimitMiB: 512 },
-      codesearch: { cpu: 1024, memoryLimitMiB: 2048 },
+      codesearch: { cpu: 1024, memoryLimitMiB: 8192 },
       migrate: { cpu: 512, memoryLimitMiB: 1024 },
     },
     services: {
@@ -95,7 +95,7 @@ const SIZE_PROFILES: Record<CtxPipeSize, CtxPipeSizeProfile> = {
       backend: { cpu: 1024, memoryLimitMiB: 2048 },
       worker: { cpu: 2048, memoryLimitMiB: 4096 },
       ui: { cpu: 512, memoryLimitMiB: 1024 },
-      codesearch: { cpu: 2048, memoryLimitMiB: 4096 },
+      codesearch: { cpu: 2048, memoryLimitMiB: 12288 },
       migrate: { cpu: 1024, memoryLimitMiB: 2048 },
     },
     services: {

--- a/packages/aws-cdk/src/size-profiles.test.ts
+++ b/packages/aws-cdk/src/size-profiles.test.ts
@@ -33,6 +33,30 @@ function neptuneInstanceClasses(template: Template): string[] {
   );
 }
 
+function codesearchTaskCpuMemory(template: Template): {
+  cpu: string;
+  memory: string;
+} {
+  const resources = template.findResources("AWS::ECS::TaskDefinition");
+  for (const resource of Object.values(resources)) {
+    const properties = resource.Properties as {
+      Cpu?: string;
+      Memory?: string;
+      ContainerDefinitions?: Array<{ Name?: string }>;
+    };
+    const hasCodesearch = properties.ContainerDefinitions?.some(
+      (container) => container.Name === "codesearch",
+    );
+    if (hasCodesearch) {
+      return {
+        cpu: properties.Cpu ?? "",
+        memory: properties.Memory ?? "",
+      };
+    }
+  }
+  throw new Error("codesearch task definition not found");
+}
+
 describe("SIZE_PROFILES database instance classes", () => {
   it.each([
     ["small", "db.t4g.medium", "db.t4g.medium"],
@@ -59,4 +83,20 @@ describe("SIZE_PROFILES database instance classes", () => {
       }
     }
   });
+});
+
+describe("SIZE_PROFILES codesearch task size", () => {
+  it.each([
+    ["small", "512", "4096"],
+    ["medium", "1024", "8192"],
+    ["large", "2048", "12288"],
+  ] as const)(
+    "size %s uses codesearch cpu %s memory %s",
+    (size, cpu, memory) => {
+      expect(codesearchTaskCpuMemory(synthForSize(size))).toEqual({
+        cpu,
+        memory,
+      });
+    },
+  );
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Self-hosted codesearch ingest can die with SIGKILL (exit 137) when Zoekt/SCIP exceed Fargate memory. The worker then stored a raw `fetch failed` / `ECONNRESET`, which looked like a GitHub outage.

## Changes

- Canonical user-facing error: **Codebase didn't fit available memory** for indexer exit 137. Codesearch-phase `fetch failed` / `ECONNRESET` / `EPIPE` remap at the phase HTTP client only — extract `fetch failed` stays itself.
- Zoekt is non-fatal: the OpenWorkflow `zoekt` step **succeeds** with `{ ok: false, error }` so it is not retried; SCIP, merge, and extract continue as `complete_with_issues`.
- Task-level cgroup kill (API gone) still marks `failed` with the memory-fit message. After a prior success that displays as **out of date**.
- UI: amber “complete with issues” badge, screen-reader copy of `indexingError`, Retry indexing, chat treats the repo as ready. Filter chip **counts** use the same predicate as matching (indexed and failed both include complete-with-issues).
- CDK codesearch Fargate memory: **4 / 8 / 12 GiB**. Changeset for `@ctxpipe/aws-cdk` (**minor**). Docs: bump the package and `cdk deploy` to apply pinned images, memory, and the enum migration together.
- Default codesearch suite: Docker `--memory 32m` proves **task** OOMKilled. The script does **not** assert repository status. Child-137 HTTP `{ error }` is asserted in `indexPhases.zoekt.test.ts`.

## Customer release

After this PR merges to `main`, merge the **chore(release): version packages** PR so npm publishes `@ctxpipe/aws-cdk@3.1.0` (from 3.0.2) with the SHA-stamped GHCR pins. The customer then:

```bash
pnpm update @ctxpipe/aws-cdk
cdk deploy
```

That rolls backend/worker/UI/codesearch/migrate images, raises codesearch memory, and runs the `complete_with_issues` Postgres enum migration.

## Testing

- Backend: child 137 → `searchIndexOk: false` + SCIP continues; clone/SCIP death fail-closed; parent marks `complete_with_issues` only when the index child returns; index-child throw does not mark ready-with-issues; orchestrator task-death → `failed`.
- Codesearch: `POST /{repoId}/index/zoekt` returns canonical error on spawn 137.
- UI: presentation helper for retry/queryable; Storybook play opens the actions menu and clicks **Retry indexing**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6dfbde3-2798-41a6-9be5-4a07db87c500?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6dfbde3-2798-41a6-9be5-4a07db87c500&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

