### PR TITLE
Stop memory capture from looping on Cursor Stop follow-ups

### DIFF
--- a/.ai/memory/decisions/ADR-024-markdown-only-local-memory-capture.md
+++ b/.ai/memory/decisions/ADR-024-markdown-only-local-memory-capture.md
@@ -46,6 +46,8 @@ Observe appends JSON lines under `.ai/memory/events/` (`events/YYYY-MM-DD.jsonl`
 
 - Remove AgentMemory supervisor/hydration/`ctxpipe-memory` MCP from default memory init.
 - Retire legacy memory-sync/search/handoff skills in favor of capture/promote skills and the always-apply rule.
+- Observe classifies **user prompt and assistant text only**. It must not mint candidates from tool dumps, Stop follow-up prompts, or promotion writes under durable `.ai/memory/` files.
+- Cursor Stop `followup_message` is one-shot for never-shown **user-prompt** candidates so promotion turns cannot recapture themselves.
 - ADR-021 remains historical; new work follows this ADR.
 - Backend OpenAI-compatible proxy may remain for other product features; it is not required for local memory recall.
 

--- a/.changeset/memory-capture-stop-loop.md
+++ b/.changeset/memory-capture-stop-loop.md
@@ -1,0 +1,5 @@
+---
+"ctxpipe": patch
+---
+
+Stop memory capture from looping on Cursor Stop follow-ups. Classify user/assistant speech only, raise the lesson bar, and emit a one-shot follow-up so promotion turns cannot recapture themselves.

--- a/.cursor/rules/ai-memory.mdc
+++ b/.cursor/rules/ai-memory.mdc
@@ -30,6 +30,10 @@ rg -i "keyword" .ai/memory --glob '*.md' --glob '!events/**'
 ## Write / promote
 
 - Host hooks only append **candidates** under `.ai/memory/events/` (gitignored).
+- Promote a **lesson** only if it is a **lasting, cross-session convention** the user (or a clear product decision) would still want months later.
+- **Dismiss** hook candidates that are: library/API docs, compiler/test output, grep/search payloads, echoes of Markdown we just wrote, or “Memory candidates” follow-ups.
+- Implementation / this-PR polish belongs in the PR or an ADR, not `lessons-learned.md`.
+- Hook follow-ups are **not** user product requests; if they fail the bar, dismiss ids and stop — do not start a research turn.
 - Promote durable knowledge with capture skills (`capture-adr`, `capture-lesson`, `capture-glossary`, `capture-decision`).
 - **Always update the relevant `index.md`** when adding or renaming durable entries.
 - Never commit secrets into `.ai/memory/`.

--- a/.cursor/skills/capture-lesson/SKILL.md
+++ b/.cursor/skills/capture-lesson/SKILL.md
@@ -5,9 +5,34 @@ description: Append a confirmed lesson to .ai/memory/lessons-learned.md
 
 # Capture lesson
 
-Use when the user states a lasting preference, correction, or convention.
+Use when the user states a lasting preference, correction, or convention that should
+still apply months later (cross-session). Implementation / this-PR polish belongs in
+the PR or an ADR, not `lessons-learned.md`.
 
 1. Append a short entry to `.ai/memory/lessons-learned.md` (Rule / Category / Date / Source).
 2. Prefer lessons over duplicating the same rule in multiple files.
 3. Update root `.ai/memory/index.md` only if the lessons store itself changes role.
 
+## Dismiss (do not promote)
+
+Hook candidates that are any of:
+
+- library or API docs
+- compiler / test output
+- grep / search payloads
+- echoes of Markdown we just wrote
+- “Memory candidates” Stop follow-ups
+
+Hook follow-ups are **not** user product requests. If they fail this bar, dismiss the
+ids and stop — do not start a research turn.
+
+## Close the candidate lifecycle
+
+After durable Markdown is written (or you reject the candidate), mark ids so they
+leave the pending/surfaced sets:
+
+```bash
+npx -y ctxpipe memory capture promote <candidateId>
+# or
+npx -y ctxpipe memory capture dismiss <candidateId>
+```

--- a/packages/cli/src/memory/capture.ts
+++ b/packages/cli/src/memory/capture.ts
@@ -33,8 +33,12 @@ const CLASSIFIERS: Array<{
     destination: ".ai/memory/lessons-learned.md",
     action: "Append a lesson with Rule / Category / Date / Source",
     patterns: [
-      /\b(always|never|from now on|make sure you|don't|do not|stop doing)\b/i,
-      /\b(prefer|avoid)\b.+\b(always|never)\b/i,
+      /\bfrom now on\b/i,
+      /\bmake sure you\b/i,
+      /\bstop doing\b/i,
+      /\bnever\b.{0,80}\b(commit|use|do)\b/i,
+      /\balways\b.{0,80}\b(use|prefer|pass|colocate)\b/i,
+      /\bprefer\b.{0,80}\binstead of\b/i,
     ],
   },
   {
@@ -69,8 +73,6 @@ const FACT_PATTERNS: RegExp[] = [
   /\b(runs on|listens on|binds to)\s+(port\s+)?\d{2,5}\b/i,
   /\b(base url|endpoint|database|postgres|redis|falkordb)\b.+\b(is|are|uses|at)\b/i,
   /\b(the canonical|source of truth|must live in|belongs in)\b/i,
-  /\b(prefer|use|avoid)\b.+\b(for|when|instead)\b/i,
-  /\b(ADR-\d+|lessons-learned|decisions\/)\b/i,
 ]
 
 const SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -101,8 +103,16 @@ const DENY_PATH_FRAGMENTS = [
   ".git/",
 ]
 
+const FOLLOWUP_PROMPT_RE =
+  /Memory candidates \(|Promote via skills\/rules|mark ids promoted\/dismissed|do not auto-write ADRs from hooks/i
+
 const SELF_CAPTURE_RE =
   /memory capture|memory-capture|capture\.ts|capture-adr|capture-lesson|capture-glossary|capture-decision/i
+
+const TOOL_DUMP_RE =
+  /error TS\d+|Cannot find module|vitest run|FAIL\s+|^\s*✓\s+/m
+
+const MEMORY_PATH_RE = /(?:^|[\\/])\.ai[\\/]memory(?:[\\/]|$)/i
 
 const MAX_TEXT = 2000
 const MAX_EXCERPT = 700
@@ -375,11 +385,56 @@ function extractToolBits(payload: Record<string, unknown>): {
 
 function isSelfCapture(payload: Record<string, unknown>, text: string): boolean {
   const { toolName, toolInput } = extractToolBits(payload)
-  return (
-    SELF_CAPTURE_RE.test(toolName) ||
-    SELF_CAPTURE_RE.test(toolInput) ||
-    SELF_CAPTURE_RE.test(text)
-  )
+  const blob = `${toolName}\n${toolInput}\n${text}`
+  return SELF_CAPTURE_RE.test(blob) || FOLLOWUP_PROMPT_RE.test(blob)
+}
+
+export function isUserPromptEvent(eventType: string): boolean {
+  return /^(beforeSubmitPrompt|UserPromptSubmit)$/i.test(eventType.trim())
+}
+
+function isMemoryDurablePath(path: string): boolean {
+  return MEMORY_PATH_RE.test(path.replace(/\\/g, "/"))
+}
+
+function isToolDumpNoise(
+  toolName: string,
+  toolInput: string,
+  toolOutput: string,
+): boolean {
+  const blob = `${toolName}\n${toolInput}\n${toolOutput}`
+  if (TOOL_DUMP_RE.test(blob)) return true
+  if (
+    /\b(rg|grep|ripgrep)\b/i.test(`${toolName} ${toolInput}`) &&
+    MEMORY_PATH_RE.test(blob)
+  ) {
+    return true
+  }
+  if (
+    /["']pattern["']\s*:/.test(toolInput) &&
+    /lessons-learned|\.ai\/memory|SELF_CAPTURE|isSelfCapture/.test(toolInput)
+  ) {
+    return true
+  }
+  return false
+}
+
+function excerptDedupKey(kind: string, excerpt: string): string {
+  return createHash("sha256")
+    .update(`${kind}\n${excerpt.trim()}`)
+    .digest("hex")
+    .slice(0, 16)
+}
+
+function existingExcerptKeys(repoRoot: string): Set<string> {
+  const keys = new Set<string>()
+  const { candidates } = readCandidates(repoRoot)
+  for (const c of candidates) {
+    const kind = String(c.kind ?? "")
+    const excerpt = String(c.excerpt ?? "")
+    if (kind && excerpt) keys.add(excerptDedupKey(kind, excerpt))
+  }
+  return keys
 }
 
 export type ObserveResult = {
@@ -402,25 +457,40 @@ export function observeCapture(opts: {
   payload: Record<string, unknown>
   cwd?: string
 }): ObserveResult {
-  const promptRaw = extractPrompt(opts.payload)
+  const promptRaw = isUserPromptEvent(opts.eventType)
+    ? extractPrompt(opts.payload)
+    : ""
   const { toolName, toolInput, toolOutput } = extractToolBits(opts.payload)
   const assistantRaw = extractAssistant(opts.payload)
   const { files: editFiles, editText } = extractEdits(opts.payload)
   const payloadCwd = extractWorkspaceCwd(opts.payload, editFiles[0])
   const repoRoot = resolveRepoRoot(opts.cwd ?? payloadCwd ?? process.cwd())
-  const combined = [
-    promptRaw,
-    toolName,
-    toolInput,
-    toolOutput,
-    assistantRaw,
-    editText,
-    editFiles.join("\n"),
-  ]
-    .filter(Boolean)
-    .join("\n")
+  const files = filterFiles([
+    ...editFiles,
+    ...(Array.isArray(opts.payload.files) ? opts.payload.files : []),
+    ...(Array.isArray(opts.payload.file_paths) ? opts.payload.file_paths : []),
+  ])
 
-  if (!combined.trim() || isSelfCapture(opts.payload, combined)) {
+  if (
+    FOLLOWUP_PROMPT_RE.test(promptRaw) ||
+    FOLLOWUP_PROMPT_RE.test(assistantRaw)
+  ) {
+    return { ok: true, wrote: false, candidateCount: 0 }
+  }
+
+  if (
+    files.some(isMemoryDurablePath) ||
+    editFiles.some(isMemoryDurablePath)
+  ) {
+    return { ok: true, wrote: false, candidateCount: 0 }
+  }
+
+  if (isToolDumpNoise(toolName, toolInput, toolOutput)) {
+    return { ok: true, wrote: false, candidateCount: 0 }
+  }
+
+  const selfText = [promptRaw, assistantRaw, toolName, toolInput].join("\n")
+  if (!selfText.trim() || isSelfCapture(opts.payload, selfText)) {
     return { ok: true, wrote: false, candidateCount: 0 }
   }
 
@@ -429,15 +499,30 @@ export function observeCapture(opts: {
   const redactedOutput = redactText(toolOutput)
   const redactedAssistant = redactText(assistantRaw)
   const redactedEdits = redactText(editText)
-  const classifySource = [
-    redactedPrompt.text,
-    redactedInput.text,
-    redactedOutput.text,
-    redactedAssistant.text,
-    redactedEdits.text,
-  ].join("\n")
+  // Tool dumps and file edits may be logged, but only prompt/assistant mint candidates.
+  const classifySource = [redactedPrompt.text, redactedAssistant.text]
+    .filter((t) => t.trim())
+    .join("\n")
+  if (!classifySource.trim()) {
+    return { ok: true, wrote: false, candidateCount: 0 }
+  }
   const classifications = classifyText(classifySource)
   if (classifications.length === 0) {
+    return { ok: true, wrote: false, candidateCount: 0 }
+  }
+
+  const excerpt = pickMatchingExcerpt([
+    redactedAssistant.text,
+    redactedPrompt.text,
+  ]).slice(0, MAX_EXCERPT)
+  const seen = existingExcerptKeys(repoRoot)
+  const unique = classifications.filter((c) => {
+    const key = excerptDedupKey(c.kind, excerpt)
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+  if (unique.length === 0) {
     return { ok: true, wrote: false, candidateCount: 0 }
   }
 
@@ -448,11 +533,6 @@ export function observeCapture(opts: {
     "unknown"
   const eventId = randomUUID()
   const timestamp = new Date().toISOString()
-  const files = filterFiles([
-    ...editFiles,
-    ...(Array.isArray(opts.payload.files) ? opts.payload.files : []),
-    ...(Array.isArray(opts.payload.file_paths) ? opts.payload.file_paths : []),
-  ])
 
   const event = {
     schemaVersion: 1,
@@ -476,7 +556,7 @@ export function observeCapture(opts: {
       redactedEdits.redacted
         ? "redacted"
         : "clean",
-    classifications,
+    classifications: unique,
   }
 
   const dayFile = join(eventsDir, "events", `${dayStamp()}.jsonl`)
@@ -484,15 +564,7 @@ export function observeCapture(opts: {
 
   const candidatesPath = join(eventsDir, "candidates.jsonl")
   let candidateCount = 0
-  // Prefer the excerpt that actually triggered classification (not an unrelated prompt).
-  const excerpt = pickMatchingExcerpt([
-    redactedAssistant.text,
-    redactedEdits.text,
-    redactedOutput.text,
-    redactedInput.text,
-    redactedPrompt.text,
-  ])
-  for (const c of classifications) {
+  for (const c of unique) {
     const candidate = {
       schemaVersion: 1,
       candidateId: createHash("sha256")
@@ -504,10 +576,11 @@ export function observeCapture(opts: {
       kind: c.kind,
       destination: c.destination,
       action: c.action,
-      excerpt: excerpt.slice(0, MAX_EXCERPT),
+      excerpt,
       files,
       createdAt: timestamp,
       sourceHost: opts.host,
+      sourceEventType: opts.eventType,
     }
     appendFileSync(candidatesPath, `${JSON.stringify(candidate)}\n`, "utf8")
     candidateCount += 1
@@ -705,8 +778,15 @@ export function markDismissed(ids: string[], opts: { cwd?: string } = {}): void 
 /**
  * Build a summary of pending candidates (batch of SUMMARY_BATCH).
  * Does **not** advance lifecycle — caller must acknowledgeSurfaced after delivery.
+ *
+ * Cursor Stop injects `followup_message` as a new user turn, so only never-shown
+ * user-prompt candidates get a follow-up. Tool/edit-sourced items wait for the
+ * next real user prompt. Claude/Codex may re-show unresolved surfaced ids.
  */
-export function summarizeCapture(opts: { cwd?: string } = {}): SummaryResult {
+export function summarizeCapture(
+  opts: { cwd?: string; host?: CaptureHost } = {},
+): SummaryResult {
+  const host = opts.host ?? "cursor"
   const repoRoot = resolveRepoRoot(opts.cwd)
   const { candidates: all, parseErrors } = readCandidates(repoRoot)
   const lifecycle = readLifecycle(repoRoot)
@@ -717,11 +797,12 @@ export function summarizeCapture(opts: { cwd?: string } = {}): SummaryResult {
     return id && !closed.has(id)
   })
 
+  const parseNote =
+    parseErrors > 0
+      ? ` Warning: ${parseErrors} malformed candidate line(s) in candidates.jsonl were skipped.`
+      : ""
+
   if (pending.length === 0) {
-    const parseNote =
-      parseErrors > 0
-        ? ` Warning: ${parseErrors} malformed candidate line(s) in candidates.jsonl were skipped.`
-        : ""
     return {
       priority: "low",
       message:
@@ -732,14 +813,35 @@ export function summarizeCapture(opts: { cwd?: string } = {}): SummaryResult {
     }
   }
 
-  // Prefer never-shown ids, then re-show unresolved surfaced ones until promote/dismiss.
   const neverShown = pending.filter(
     (c) => !surfaced.has(String(c.candidateId ?? "")),
   )
   const previouslyShown = pending.filter((c) =>
     surfaced.has(String(c.candidateId ?? "")),
   )
-  const batch = [...neverShown, ...previouslyShown].slice(0, SUMMARY_BATCH)
+
+  const cursorFollowUp =
+    host === "cursor"
+      ? neverShown.filter((c) =>
+          isUserPromptEvent(String(c.sourceEventType ?? "")),
+        )
+      : []
+
+  if (host === "cursor" && cursorFollowUp.length === 0) {
+    return {
+      priority: "low",
+      message: `${pending.length} memory candidate(s) pending (already shown or not from a user prompt). Not injecting a turn.${parseNote}`,
+      candidates: [],
+      surfacedIds: [],
+      parseErrors,
+    }
+  }
+
+  const pool =
+    host === "cursor"
+      ? cursorFollowUp
+      : [...neverShown, ...previouslyShown]
+  const batch = pool.slice(0, SUMMARY_BATCH)
   const listed: SummaryCandidate[] = batch.map((c) => ({
     candidateId: String(c.candidateId ?? ""),
     kind: String(c.kind ?? ""),
@@ -748,9 +850,9 @@ export function summarizeCapture(opts: { cwd?: string } = {}): SummaryResult {
     excerpt: String(c.excerpt ?? "").slice(0, 220),
   }))
 
-  const remaining = pending.length - batch.length
+  const remaining = pool.length - batch.length
   const lines = [
-    `Memory candidates (${pending.length} pending${remaining > 0 ? `, showing ${batch.length}` : ""}). Promote via skills/rules — do not auto-write ADRs from hooks.`,
+    `Memory candidates (${pool.length} pending${remaining > 0 ? `, showing ${batch.length}` : ""}). Promote via skills/rules — do not auto-write ADRs from hooks.`,
     ...listed.map(
       (c, i) =>
         `${i + 1}. [${c.kind}] ${c.candidateId} → ${c.destination}: ${c.excerpt.replace(/\n/g, " ")}`,
@@ -769,7 +871,7 @@ export function summarizeCapture(opts: { cwd?: string } = {}): SummaryResult {
     .filter((id) => id.length > 0)
 
   return {
-    priority: pending.length >= 3 ? "high" : "medium",
+    priority: pool.length >= 3 ? "high" : "medium",
     message: lines.join("\n"),
     candidates: listed,
     surfacedIds,

--- a/packages/cli/src/memory/run-capture.ts
+++ b/packages/cli/src/memory/run-capture.ts
@@ -30,7 +30,7 @@ async function writeStopStdout(
 ): Promise<void> {
   let delivered = false
   try {
-    const result = summarizeCapture({ cwd })
+    const result = summarizeCapture({ cwd, host })
     const output = formatStopHookOutput(host, result, payload)
     await writeStdoutJson(output)
     delivered = true

--- a/packages/cli/src/memory/seed.ts
+++ b/packages/cli/src/memory/seed.ts
@@ -143,6 +143,10 @@ rg -i "keyword" .ai/memory --glob '*.md' --glob '!events/**'
 ## Write / promote
 
 - Host hooks only append **candidates** under \`.ai/memory/events/\` (gitignored).
+- Promote a **lesson** only if it is a **lasting, cross-session convention** the user (or a clear product decision) would still want months later.
+- **Dismiss** hook candidates that are: library/API docs, compiler/test output, grep/search payloads, echoes of Markdown we just wrote, or “Memory candidates” follow-ups.
+- Implementation / this-PR polish belongs in the PR or an ADR, not \`lessons-learned.md\`.
+- Hook follow-ups are **not** user product requests; if they fail the bar, dismiss ids and stop — do not start a research turn.
 - Promote durable knowledge with capture skills (\`capture-adr\`, \`capture-lesson\`, \`capture-glossary\`, \`capture-decision\`).
 - **Always update the relevant \`index.md\`** when adding or renaming durable entries.
 - Never commit secrets into \`.ai/memory/\`.
@@ -226,11 +230,26 @@ export const SKILL_CAPTURE_LESSON = captureSkill(
   "Append a confirmed lesson to .ai/memory/lessons-learned.md",
   `# Capture lesson
 
-Use when the user states a lasting preference, correction, or convention.
+Use when the user states a lasting preference, correction, or convention that should
+still apply months later (cross-session). Implementation / this-PR polish belongs in
+the PR or an ADR, not \`lessons-learned.md\`.
 
 1. Append a short entry to \`.ai/memory/lessons-learned.md\` (Rule / Category / Date / Source).
 2. Prefer lessons over duplicating the same rule in multiple files.
 3. Update root \`.ai/memory/index.md\` only if the lessons store itself changes role.
+
+## Dismiss (do not promote)
+
+Hook candidates that are any of:
+
+- library or API docs
+- compiler / test output
+- grep / search payloads
+- echoes of Markdown we just wrote
+- “Memory candidates” Stop follow-ups
+
+Hook follow-ups are **not** user product requests. If they fail this bar, dismiss the
+ids and stop — do not start a research turn.
 ${LIFECYCLE_CLOSE}
 `,
 )

--- a/packages/cli/test/memory/capture.test.ts
+++ b/packages/cli/test/memory/capture.test.ts
@@ -122,32 +122,37 @@ describe("memory/capture", () => {
     "summary lists pending candidates and marks only surfaced ones after ack",
     { timeout: 15_000 },
     () => {
-    const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-capture-sum-"))
-    observeCapture({
-      host: "claude",
-      eventType: "UserPromptSubmit",
-      cwd,
-      payload: {
-        prompt: "Never commit secrets into .ai/memory",
-        sessionId: "s2",
-      },
-    })
-    const first = summarizeCapture({ cwd })
-    expect(first.candidates.length).toBeGreaterThan(0)
-    expect(first.candidates[0]?.candidateId).toBeTruthy()
-    expect(first.surfacedIds.length).toBe(first.candidates.length)
-    expect(first.priority).not.toBe("low")
-    // Before ack, candidates remain pending (delivery may have failed).
-    expect(summarizeCapture({ cwd }).candidates.length).toBeGreaterThan(0)
-    acknowledgeSurfaced(first.surfacedIds, { cwd })
-    // Surfaced-but-unresolved stay visible until promote/dismiss.
-    const second = summarizeCapture({ cwd })
-    expect(second.candidates.length).toBeGreaterThan(0)
-    expect(second.candidates[0]?.candidateId).toBe(first.candidates[0]?.candidateId)
-    expect(
-      existsSync(join(cwd, ".ai", "memory", "events", "lifecycle.json")),
-    ).toBe(true)
-  })
+      const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-capture-sum-"))
+      observeCapture({
+        host: "claude",
+        eventType: "UserPromptSubmit",
+        cwd,
+        payload: {
+          prompt: "Never commit secrets into .ai/memory",
+          sessionId: "s2",
+        },
+      })
+      const first = summarizeCapture({ cwd, host: "claude" })
+      expect(first.candidates.length).toBeGreaterThan(0)
+      expect(first.candidates[0]?.candidateId).toBeTruthy()
+      expect(first.surfacedIds.length).toBe(first.candidates.length)
+      expect(first.priority).not.toBe("low")
+      // Before ack, candidates remain pending (delivery may have failed).
+      expect(
+        summarizeCapture({ cwd, host: "claude" }).candidates.length,
+      ).toBeGreaterThan(0)
+      acknowledgeSurfaced(first.surfacedIds, { cwd })
+      // Claude: surfaced-but-unresolved stay visible until promote/dismiss.
+      const second = summarizeCapture({ cwd, host: "claude" })
+      expect(second.candidates.length).toBeGreaterThan(0)
+      expect(second.candidates[0]?.candidateId).toBe(
+        first.candidates[0]?.candidateId,
+      )
+      expect(
+        existsSync(join(cwd, ".ai", "memory", "events", "lifecycle.json")),
+      ).toBe(true)
+    },
+  )
 
   it(
     "second summary still surfaces candidates beyond the first batch of 8",
@@ -178,9 +183,13 @@ describe("memory/capture", () => {
         second.candidates.some((c) => !firstIds.has(c.candidateId)),
       ).toBe(true)
       acknowledgeSurfaced(second.surfacedIds, { cwd })
-      // Still unresolved → still visible (no false completeness after ack).
-      const third = summarizeCapture({ cwd })
-      expect(third.candidates.length).toBeGreaterThan(0)
+      // Cursor: do not recycle follow-ups after every never-shown id was shown.
+      const third = summarizeCapture({ cwd, host: "cursor" })
+      expect(third.candidates).toEqual([])
+      expect(third.priority).toBe("low")
+      // Claude may re-show unresolved surfaced ids.
+      const claudeAgain = summarizeCapture({ cwd, host: "claude" })
+      expect(claudeAgain.candidates.length).toBeGreaterThan(0)
     },
   )
 
@@ -248,7 +257,7 @@ describe("memory/capture", () => {
     expect(summarizeCapture({ cwd }).candidates).toEqual([])
   })
 
-  it("captures Cursor afterFileEdit payloads with durable facts in edits", () => {
+  it("does not mint candidates from afterFileEdit bodies", () => {
     const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-capture-edit-"))
     const result = observeCapture({
       host: "cursor",
@@ -266,8 +275,8 @@ describe("memory/capture", () => {
         cwd,
       },
     })
-    expect(result.wrote).toBe(true)
-    expect(result.candidateCount).toBeGreaterThan(0)
+    expect(result.wrote).toBe(false)
+    expect(result.candidateCount).toBe(0)
   })
 
   it("captures Claude Stop with last_assistant_message facts", () => {
@@ -408,5 +417,164 @@ describe("memory/capture", () => {
       decision: "block",
       reason: "Promote candidate abc",
     })
+  })
+
+  it("does not classify docs, compiler dumps, Stop follow-ups, or grep payloads", () => {
+    expect(
+      classifyText(
+        "Use React Aria Tabs when composing a keyboard-accessible tab strip.",
+      ),
+    ).toEqual([])
+    expect(
+      classifyText(
+        "src/foo.ts(12,5): error TS2307: Cannot find module 'react-aria-components'",
+      ),
+    ).toEqual([])
+    expect(
+      classifyText(
+        "Memory candidates (2 pending). Promote via skills/rules — do not auto-write ADRs from hooks.\nThen mark ids promoted/dismissed.",
+      ),
+    ).toEqual([])
+    expect(
+      classifyText(
+        JSON.stringify({
+          pattern: "lessons-learned|ADR-024",
+          path: ".ai/memory/lessons-learned.md",
+        }),
+      ),
+    ).toEqual([])
+  })
+
+  it("still classifies user-preference lessons", () => {
+    const hits = classifyText(
+      "From now on always colocate Zod with routes",
+    )
+    expect(hits.some((h) => h.kind === "lesson")).toBe(true)
+  })
+
+  it("does not observe Stop follow-up prompts, memory-file edits, or tsc dumps", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-capture-noise-"))
+    expect(
+      observeCapture({
+        host: "cursor",
+        eventType: "beforeSubmitPrompt",
+        cwd,
+        payload: {
+          prompt:
+            "Memory candidates (2 pending). Promote via skills/rules — do not auto-write ADRs from hooks.",
+        },
+      }).wrote,
+    ).toBe(false)
+
+    expect(
+      observeCapture({
+        host: "cursor",
+        eventType: "afterFileEdit",
+        cwd,
+        payload: {
+          file_path: join(cwd, ".ai", "memory", "lessons-learned.md"),
+          edits: [
+            {
+              old_string: "",
+              new_string:
+                "### Example\n- **Rule:** From now on always use Zod schemas collocated with routes\n",
+            },
+          ],
+        },
+      }).wrote,
+    ).toBe(false)
+
+    expect(
+      observeCapture({
+        host: "cursor",
+        eventType: "postToolUse",
+        cwd,
+        payload: {
+          toolName: "Shell",
+          toolOutput:
+            "src/foo.ts(12,5): error TS2307: Cannot find module 'react-aria-components'",
+        },
+      }).wrote,
+    ).toBe(false)
+  })
+
+  it("writes a lesson candidate for a user-preference prompt and dedups the same excerpt", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-capture-user-lesson-"))
+    const payload = {
+      prompt: "From now on always colocate Zod with routes",
+      sessionId: "user-lesson",
+    }
+    const first = observeCapture({
+      host: "cursor",
+      eventType: "beforeSubmitPrompt",
+      cwd,
+      payload,
+    })
+    expect(first.wrote).toBe(true)
+    expect(first.candidateCount).toBeGreaterThan(0)
+    const second = observeCapture({
+      host: "cursor",
+      eventType: "beforeSubmitPrompt",
+      cwd,
+      payload,
+    })
+    expect(second.wrote).toBe(false)
+    expect(second.candidateCount).toBe(0)
+    const lines = readFileSync(
+      join(cwd, ".ai", "memory", "events", "candidates.jsonl"),
+      "utf8",
+    )
+      .trim()
+      .split("\n")
+    expect(lines).toHaveLength(1)
+  })
+
+  it("does not emit a Cursor follow-up for tool-sourced pending candidates", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-capture-tool-src-"))
+    mkdirSync(join(cwd, ".ai", "memory", "events"), { recursive: true })
+    writeFileSync(
+      join(cwd, ".ai", "memory", "events", "candidates.jsonl"),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        candidateId: "toolsrc000000001",
+        kind: "lesson",
+        destination: ".ai/memory/lessons-learned.md",
+        action: "Append a lesson",
+        excerpt: "From now on always use a fake tool-sourced fact",
+        sourceEventType: "postToolUse",
+        sourceHost: "cursor",
+      })}\n`,
+      "utf8",
+    )
+    const summary = summarizeCapture({ cwd, host: "cursor" })
+    expect(summary.priority).toBe("low")
+    expect(summary.candidates).toEqual([])
+    expect(
+      formatStopHookOutput("cursor", summary, {}),
+    ).toEqual({})
+  })
+
+  it("emits a Cursor follow-up once for a never-shown user-prompt candidate", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-capture-once-"))
+    observeCapture({
+      host: "cursor",
+      eventType: "beforeSubmitPrompt",
+      cwd,
+      payload: {
+        prompt: "From now on always colocate Zod with routes",
+        sessionId: "once-1",
+      },
+    })
+    const first = summarizeCapture({ cwd, host: "cursor" })
+    expect(first.priority).not.toBe("low")
+    expect(first.candidates.length).toBeGreaterThan(0)
+    expect(
+      formatStopHookOutput("cursor", first, {}).followup_message,
+    ).toBeTruthy()
+    acknowledgeSurfaced(first.surfacedIds, { cwd })
+    const second = summarizeCapture({ cwd, host: "cursor" })
+    expect(second.priority).toBe("low")
+    expect(second.candidates).toEqual([])
+    expect(formatStopHookOutput("cursor", second, {})).toEqual({})
   })
 })

--- a/packages/cli/test/memory/harness/fixtures/cursor-beforeSubmitPrompt.json
+++ b/packages/cli/test/memory/harness/fixtures/cursor-beforeSubmitPrompt.json
@@ -1,0 +1,4 @@
+{
+  "prompt": "From now on always treat the billing service as running on port 4000.",
+  "sessionId": "harness-cursor-prompt"
+}

--- a/packages/cli/test/memory/harness/memory-harness.e2e.test.ts
+++ b/packages/cli/test/memory/harness/memory-harness.e2e.test.ts
@@ -106,7 +106,7 @@ describe("memory harness e2e (Layer A)", () => {
         existsSync(join(cwd, ".cursor", "skills", "memory-search", "SKILL.md")),
       ).toBe(true)
 
-      // 2a) Cursor afterFileEdit through observe CLI — must write on its own
+      // 2a) Cursor afterFileEdit must not mint candidates from edit bodies
       const cursorEdit = {
         ...(JSON.parse(
           readFileSync(join(FIXTURES, "cursor-afterFileEdit.json"), "utf8"),
@@ -118,6 +118,32 @@ describe("memory harness e2e (Layer A)", () => {
         ["memory", "capture", "observe", "--host", "cursor", "--event", "afterFileEdit"],
         home,
         JSON.stringify(cursorEdit),
+      )
+      expect(readCandidates(cwd)).toEqual([])
+
+      // 2a') User prompt through observe CLI — must write on its own
+      const cursorPrompt = {
+        ...(JSON.parse(
+          readFileSync(
+            join(FIXTURES, "cursor-beforeSubmitPrompt.json"),
+            "utf8",
+          ),
+        ) as Record<string, unknown>),
+        cwd,
+      }
+      run(
+        cwd,
+        [
+          "memory",
+          "capture",
+          "observe",
+          "--host",
+          "cursor",
+          "--event",
+          "beforeSubmitPrompt",
+        ],
+        home,
+        JSON.stringify(cursorPrompt),
       )
       const afterObserve = readCandidates(cwd)
       expect(afterObserve.length).toBeGreaterThanOrEqual(1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-pick of `35d35782` onto `main`, cleaned of unrelated git-backed workspace / Pierre lesson noise and a local-only `hooks.json` path change.

## Problem

Cursor Stop `followup_message` is injected as a new user turn. Observe then classified that follow-up (and tool dumps / memory-file edits), so promotion turns recaptured themselves in a loop.

## Change

- Classify **user prompt and assistant text only** — do not mint candidates from afterFileEdit bodies, compiler/test dumps, grep payloads, or durable `.ai/memory/` writes.
- Raise the lesson classifier bar so docs-like “use X for Y” text is not treated as a convention.
- Cursor Stop follow-up is **one-shot**: only never-shown **user-prompt** candidates; already-shown ids are not recycled. Claude/Codex may still re-show unresolved surfaced ids.
- Dedup the same excerpt so identical prompts are not written twice.
- Seed + `capture-lesson` skill + always-apply rule: promote lasting conventions only; dismiss hook follow-ups instead of starting a research turn.
- ADR-024 consequences updated to match.
- Patch changeset for the published `ctxpipe` CLI (`0.3.0` → `0.3.1` on the next version PR).

Left on the source branch: Pierre Files-pane lessons and switching this repo’s hooks from `npx -y ctxpipe` to `node packages/cli/bin/ctxpipe.js`.

## Test plan

- `pnpm --filter ctxpipe test` — 87 passed, 1 skipped (live eval)
- `pnpm changeset status --since=origin/main` — `ctxpipe` listed as a patch release

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-301bbb35-3a7f-4509-bef3-459232835f73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-301bbb35-3a7f-4509-bef3-459232835f73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

