### PR TITLE
Fix Cursor memory Stop follow-up recapture loop

### DIFF
--- a/.ai/memory/decisions/ADR-024-markdown-only-local-memory-capture.md
+++ b/.ai/memory/decisions/ADR-024-markdown-only-local-memory-capture.md
@@ -50,7 +50,7 @@ Observe appends JSON lines under `.ai/memory/events/` (`events/YYYY-MM-DD.jsonl`
 - Cursor project hooks observe **`beforeSubmitPrompt` only** (plus Stop finalize). `afterFileEdit` / `postToolUse` classified MCP schemas, grep output, and test edits as lessons; those events are not installed for Cursor and leftover tool-sourced pending ids are dismissed on summarize.
 - Cursor Stop `followup_message` is injected as a **new user turn**. Observe must ignore that payload (including nested/wrapped prompt shapes). Emitting another `followup_message` when Cursor `loop_count >= 1` would recapture the same text as a new lesson.
 - Cursor Stop `followup_message` is one-shot for never-shown **user-prompt** candidates so promotion turns cannot recapture themselves. Installed Cursor `stop` hooks set `loop_limit: 1` as a backstop (Cursor 3.11 defaults to 5).
-- This monorepo’s project hooks run the in-repo CLI from source (not `npx ctxpipe`). Published 0.3.0 still classifies the follow-up as a lesson; a stale `packages/cli/dist` has the same bug.
+- This monorepo’s project hooks run `.cursor/hooks/memory-capture.sh`: `bun packages/cli/src/cli.ts` directly (no Turbo). If bun is missing, Turbo `build --filter=ctxpipe` must succeed, then `node packages/cli/bin/ctxpipe.js`. Failed/missing Turbo fail-opens (`{}`) instead of executing unverified `dist`. Never `npx ctxpipe`. Published 0.3.0 still classifies the follow-up as a lesson until a CLI release ships the capture fix.
 - ADR-021 remains historical; new work follows this ADR.
 - Backend OpenAI-compatible proxy may remain for other product features; it is not required for local memory recall.
 

--- a/.ai/memory/decisions/ADR-024-markdown-only-local-memory-capture.md
+++ b/.ai/memory/decisions/ADR-024-markdown-only-local-memory-capture.md
@@ -47,7 +47,9 @@ Observe appends JSON lines under `.ai/memory/events/` (`events/YYYY-MM-DD.jsonl`
 - Remove AgentMemory supervisor/hydration/`ctxpipe-memory` MCP from default memory init.
 - Retire legacy memory-sync/search/handoff skills in favor of capture/promote skills and the always-apply rule.
 - Observe classifies **user prompt and assistant text only**. It must not mint candidates from tool dumps, Stop follow-up prompts, or promotion writes under durable `.ai/memory/` files.
-- Cursor Stop `followup_message` is one-shot for never-shown **user-prompt** candidates so promotion turns cannot recapture themselves.
+- Cursor Stop `followup_message` is injected as a **new user turn**. Observe must ignore that payload (including nested/wrapped prompt shapes). Emitting another `followup_message` when Cursor `loop_count >= 1` would recapture the same text as a new lesson.
+- Cursor Stop `followup_message` is one-shot for never-shown **user-prompt** candidates so promotion turns cannot recapture themselves. Installed Cursor `stop` hooks set `loop_limit: 1` as a backstop (Cursor 3.11 defaults to 5).
+- This monorepo’s project hooks run the in-repo CLI from source (not `npx ctxpipe`). Published 0.3.0 still classifies the follow-up as a lesson; a stale `packages/cli/dist` has the same bug.
 - ADR-021 remains historical; new work follows this ADR.
 - Backend OpenAI-compatible proxy may remain for other product features; it is not required for local memory recall.
 

--- a/.ai/memory/decisions/ADR-024-markdown-only-local-memory-capture.md
+++ b/.ai/memory/decisions/ADR-024-markdown-only-local-memory-capture.md
@@ -47,6 +47,7 @@ Observe appends JSON lines under `.ai/memory/events/` (`events/YYYY-MM-DD.jsonl`
 - Remove AgentMemory supervisor/hydration/`ctxpipe-memory` MCP from default memory init.
 - Retire legacy memory-sync/search/handoff skills in favor of capture/promote skills and the always-apply rule.
 - Observe classifies **user prompt and assistant text only**. It must not mint candidates from tool dumps, Stop follow-up prompts, or promotion writes under durable `.ai/memory/` files.
+- Cursor project hooks observe **`beforeSubmitPrompt` only** (plus Stop finalize). `afterFileEdit` / `postToolUse` classified MCP schemas, grep output, and test edits as lessons; those events are not installed for Cursor and leftover tool-sourced pending ids are dismissed on summarize.
 - Cursor Stop `followup_message` is injected as a **new user turn**. Observe must ignore that payload (including nested/wrapped prompt shapes). Emitting another `followup_message` when Cursor `loop_count >= 1` would recapture the same text as a new lesson.
 - Cursor Stop `followup_message` is one-shot for never-shown **user-prompt** candidates so promotion turns cannot recapture themselves. Installed Cursor `stop` hooks set `loop_limit: 1` as a backstop (Cursor 3.11 defaults to 5).
 - This monorepo’s project hooks run the in-repo CLI from source (not `npx ctxpipe`). Published 0.3.0 still classifies the follow-up as a lesson; a stale `packages/cli/dist` has the same bug.

--- a/.changeset/memory-stop-followup-recapture.md
+++ b/.changeset/memory-stop-followup-recapture.md
@@ -2,4 +2,4 @@
 "ctxpipe": patch
 ---
 
-Stop Cursor memory capture from recapturing Stop `followup_message` as a new lesson. Ignore follow-up-shaped payloads (including nested prompt JSON), honor Cursor `loop_count`, and cap the stop hook at one auto follow-up.
+Stop Cursor memory capture from recapturing Stop `followup_message` as a new lesson, and stop classifying MCP/grep/test dumps from afterFileEdit and postToolUse. Cursor hooks observe user prompts only; tool-sourced pending ids are dismissed.

--- a/.changeset/memory-stop-followup-recapture.md
+++ b/.changeset/memory-stop-followup-recapture.md
@@ -1,0 +1,5 @@
+---
+"ctxpipe": patch
+---
+
+Stop Cursor memory capture from recapturing Stop `followup_message` as a new lesson. Ignore follow-up-shaped payloads (including nested prompt JSON), honor Cursor `loop_count`, and cap the stop hook at one auto follow-up.

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -3,22 +3,23 @@
   "hooks": {
     "beforeSubmitPrompt": [
       {
-        "command": "npx -y ctxpipe memory capture observe --host cursor --event beforeSubmitPrompt"
+        "command": "bash .cursor/hooks/memory-capture.sh memory capture observe --host cursor --event beforeSubmitPrompt"
       }
     ],
     "afterFileEdit": [
       {
-        "command": "npx -y ctxpipe memory capture observe --host cursor --event afterFileEdit"
+        "command": "bash .cursor/hooks/memory-capture.sh memory capture observe --host cursor --event afterFileEdit"
       }
     ],
     "postToolUse": [
       {
-        "command": "npx -y ctxpipe memory capture observe --host cursor --event postToolUse"
+        "command": "bash .cursor/hooks/memory-capture.sh memory capture observe --host cursor --event postToolUse"
       }
     ],
     "stop": [
       {
-        "command": "npx -y ctxpipe memory capture summary"
+        "command": "bash .cursor/hooks/memory-capture.sh memory capture finalize --host cursor --event stop",
+        "loop_limit": 1
       }
     ]
   }

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -6,16 +6,6 @@
         "command": "bash .cursor/hooks/memory-capture.sh memory capture observe --host cursor --event beforeSubmitPrompt"
       }
     ],
-    "afterFileEdit": [
-      {
-        "command": "bash .cursor/hooks/memory-capture.sh memory capture observe --host cursor --event afterFileEdit"
-      }
-    ],
-    "postToolUse": [
-      {
-        "command": "bash .cursor/hooks/memory-capture.sh memory capture observe --host cursor --event postToolUse"
-      }
-    ],
     "stop": [
       {
         "command": "bash .cursor/hooks/memory-capture.sh memory capture finalize --host cursor --event stop",

--- a/.cursor/hooks/memory-capture.sh
+++ b/.cursor/hooks/memory-capture.sh
@@ -1,19 +1,33 @@
 #!/usr/bin/env bash
 # In-repo Cursor memory-capture entrypoint.
-# Prefer TypeScript source so `git pull` is what the Stop hook runs — not a
-# stale packages/cli/dist build and not published npx ctxpipe@0.3.0, which
-# recaptures followup_message as a new lesson.
+# Prefer TypeScript source so `git pull` is what the hook runs — not a stale
+# packages/cli/dist and not published npx ctxpipe, which recaptures follow-ups.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 CLI_SRC="$ROOT/packages/cli/src/cli.ts"
 CLI_BIN="$ROOT/packages/cli/bin/ctxpipe.js"
+TURBO="$ROOT/node_modules/.bin/turbo"
+
+fail_open() {
+  printf '%s\n' '{}'
+  exit 0
+}
 
 if command -v bun >/dev/null 2>&1 && [[ -f "$CLI_SRC" ]]; then
   exec bun "$CLI_SRC" "$@"
 fi
+
+# Compiled fallback only: Turbo must successfully refresh dist before we run
+# it. Never wrap bun-from-source in Turbo. Never execute an unverified dist
+# (failed/missing Turbo used to keep the stale-classifier hole open).
+# Turbo writes a banner to stdout; discard it so Cursor still sees JSON.
+if [[ ! -x "$TURBO" ]]; then
+  fail_open
+fi
+if ! "$TURBO" run build --filter=ctxpipe --output-logs=errors-only >/dev/null 2>&1; then
+  fail_open
+fi
 if [[ -f "$ROOT/packages/cli/dist/cli.js" ]]; then
   exec node "$CLI_BIN" "$@"
 fi
-# Fail-open: never fall back to npx (published 0.3.0 classifies Stop follow-ups).
-printf '%s\n' '{}'
-exit 0
+fail_open

--- a/.cursor/hooks/memory-capture.sh
+++ b/.cursor/hooks/memory-capture.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# In-repo Cursor memory-capture entrypoint.
+# Prefer TypeScript source so `git pull` is what the Stop hook runs — not a
+# stale packages/cli/dist build and not published npx ctxpipe@0.3.0, which
+# recaptures followup_message as a new lesson.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CLI_SRC="$ROOT/packages/cli/src/cli.ts"
+CLI_BIN="$ROOT/packages/cli/bin/ctxpipe.js"
+
+if command -v bun >/dev/null 2>&1 && [[ -f "$CLI_SRC" ]]; then
+  exec bun "$CLI_SRC" "$@"
+fi
+if [[ -f "$ROOT/packages/cli/dist/cli.js" ]]; then
+  exec node "$CLI_BIN" "$@"
+fi
+# Fail-open: never fall back to npx (published 0.3.0 classifies Stop follow-ups).
+printf '%s\n' '{}'
+exit 0

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@biomejs/biome": "^2.4.4",
     "concurrently": "^9.1.0",
     "portless": "^0.9.4",
-    "turbo": "^2.8.10",
+    "turbo": "^2.10.9",
     "typescript": "^5.9.3"
   },
   "pnpm": {

--- a/packages/cli/src/memory/capture.ts
+++ b/packages/cli/src/memory/capture.ts
@@ -307,13 +307,29 @@ function extractPrompt(payload: Record<string, unknown>): string {
     "transcript",
   ]
   for (const k of keys) {
-    const v = payload[k]
-    if (typeof v === "string" && v.trim()) return v
+    const extracted = extractTextish(payload[k])
+    if (extracted) return extracted
   }
-  const prompt = payload.prompt
-  if (prompt && typeof prompt === "object" && prompt !== null) {
-    const p = prompt as Record<string, unknown>
-    if (typeof p.text === "string") return p.text
+  return ""
+}
+
+/** Pull user-visible text out of Cursor's string or nested { content: [{ text }] } shapes. */
+function extractTextish(value: unknown, depth = 0): string {
+  if (depth > 5 || value == null) return ""
+  if (typeof value === "string") return value.trim() ? value : ""
+  if (typeof value === "number" || typeof value === "boolean") return ""
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => extractTextish(item, depth + 1))
+      .filter(Boolean)
+      .join("\n")
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>
+    for (const key of ["text", "content", "prompt", "message"]) {
+      const nested = extractTextish(obj[key], depth + 1)
+      if (nested) return nested
+    }
   }
   return ""
 }
@@ -471,9 +487,16 @@ export function observeCapture(opts: {
     ...(Array.isArray(opts.payload.file_paths) ? opts.payload.file_paths : []),
   ])
 
+  let payloadBlob = ""
+  try {
+    payloadBlob = JSON.stringify(opts.payload)
+  } catch {
+    payloadBlob = ""
+  }
   if (
     FOLLOWUP_PROMPT_RE.test(promptRaw) ||
-    FOLLOWUP_PROMPT_RE.test(assistantRaw)
+    FOLLOWUP_PROMPT_RE.test(assistantRaw) ||
+    FOLLOWUP_PROMPT_RE.test(payloadBlob)
   ) {
     return { ok: true, wrote: false, candidateCount: 0 }
   }
@@ -606,14 +629,31 @@ export type SummaryResult = {
   parseErrors: number
 }
 
+function stopHookLoopCount(payload: Record<string, unknown>): number {
+  const raw = payload.loop_count ?? payload.loopCount
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw
+  if (typeof raw === "string" && raw.trim()) {
+    const n = Number(raw)
+    if (Number.isFinite(n)) return n
+  }
+  return 0
+}
+
+/** True when this Stop is already a hook-injected continuation (do not emit again). */
+function isStopHookContinuation(payload: Record<string, unknown>): boolean {
+  if (payload.stop_hook_active === true || payload.stopHookActive === true) {
+    return true
+  }
+  // Cursor 3.11+ sends loop_count on stop (starts at 0; increments after each follow-up).
+  return stopHookLoopCount(payload) >= 1
+}
+
 /** Host-specific Stop/summary stdout. Empty object = allow stop / no follow-up. */
 export function formatStopHookOutput(
   host: CaptureHost,
   result: SummaryResult,
   payload: Record<string, unknown> = {},
 ): Record<string, unknown> {
-  const stopActive =
-    payload.stop_hook_active === true || payload.stopHookActive === true
   const cursorStatus =
     typeof payload.status === "string" ? payload.status.toLowerCase() : ""
   // Cursor ignores follow-ups on aborted/error stops — do not emit or ack.
@@ -623,7 +663,11 @@ export function formatStopHookOutput(
   ) {
     return {}
   }
-  if (stopActive || result.priority === "low" || !result.message.trim()) {
+  if (
+    isStopHookContinuation(payload) ||
+    result.priority === "low" ||
+    !result.message.trim()
+  ) {
     return {}
   }
   if (host === "claude") {

--- a/packages/cli/src/memory/capture.ts
+++ b/packages/cli/src/memory/capture.ts
@@ -824,8 +824,9 @@ export function markDismissed(ids: string[], opts: { cwd?: string } = {}): void 
  * Does **not** advance lifecycle — caller must acknowledgeSurfaced after delivery.
  *
  * Cursor Stop injects `followup_message` as a new user turn, so only never-shown
- * user-prompt candidates get a follow-up. Tool/edit-sourced items wait for the
- * next real user prompt. Claude/Codex may re-show unresolved surfaced ids.
+ * user-prompt candidates get a follow-up. Tool/edit-sourced items are dismissed
+ * (they are MCP/grep/test dumps, not conventions). Claude/Codex may re-show
+ * unresolved surfaced ids.
  */
 export function summarizeCapture(
   opts: { cwd?: string; host?: CaptureHost } = {},
@@ -836,10 +837,25 @@ export function summarizeCapture(
   const lifecycle = readLifecycle(repoRoot)
   const closed = closedIds(lifecycle)
   const surfaced = new Set(lifecycle.surfaced)
-  const pending = all.filter((c) => {
+  let pending = all.filter((c) => {
     const id = typeof c.candidateId === "string" ? c.candidateId : ""
     return id && !closed.has(id)
   })
+
+  if (host === "cursor") {
+    const noiseIds = pending
+      .filter((c) => !isUserPromptEvent(String(c.sourceEventType ?? "")))
+      .map((c) => String(c.candidateId ?? ""))
+      .filter(Boolean)
+    if (noiseIds.length > 0) {
+      markDismissed(noiseIds, { cwd: opts.cwd })
+      const nextClosed = closedIds(readLifecycle(repoRoot))
+      pending = all.filter((c) => {
+        const id = typeof c.candidateId === "string" ? c.candidateId : ""
+        return id && !nextClosed.has(id)
+      })
+    }
+  }
 
   const parseNote =
     parseErrors > 0

--- a/packages/cli/src/memory/hooks.ts
+++ b/packages/cli/src/memory/hooks.ts
@@ -21,7 +21,9 @@ const CURSOR_HOOKS = {
   afterFileEdit: [{ command: OBSERVE("cursor", "afterFileEdit") }],
   postToolUse: [{ command: OBSERVE("cursor", "postToolUse") }],
   // finalize reads workspace_roots from stdin so user-scoped hooks hit the right repo.
-  stop: [{ command: FINALIZE("cursor", "stop") }],
+  // Cursor 3.11 defaults to 5 auto follow-ups; cap at 1 as a backstop if observe
+  // ever mints the injected follow-up prompt (the root-cause filter is in capture.ts).
+  stop: [{ command: FINALIZE("cursor", "stop"), loop_limit: 1 }],
 }
 
 const CLAUDE_HOOK_BLOCK = {

--- a/packages/cli/src/memory/hooks.ts
+++ b/packages/cli/src/memory/hooks.ts
@@ -18,11 +18,8 @@ const FINALIZE = (host: string, event: string) =>
 
 const CURSOR_HOOKS = {
   beforeSubmitPrompt: [{ command: OBSERVE("cursor", "beforeSubmitPrompt") }],
-  afterFileEdit: [{ command: OBSERVE("cursor", "afterFileEdit") }],
-  postToolUse: [{ command: OBSERVE("cursor", "postToolUse") }],
-  // finalize reads workspace_roots from stdin so user-scoped hooks hit the right repo.
-  // Cursor 3.11 defaults to 5 auto follow-ups; cap at 1 as a backstop if observe
-  // ever mints the injected follow-up prompt (the root-cause filter is in capture.ts).
+  // afterFileEdit / postToolUse mint tool dumps (MCP schemas, grep, test edits).
+  // Cursor capture is prompt + Stop only; those events are stripped on merge.
   stop: [{ command: FINALIZE("cursor", "stop"), loop_limit: 1 }],
 }
 
@@ -150,6 +147,15 @@ function mergeCursorHooks(existing: Record<string, unknown>): Record<string, unk
   for (const [key, ours] of Object.entries(CURSOR_HOOKS)) {
     const prev = Array.isArray(hooks[key]) ? (hooks[key] as unknown[]) : []
     hooks[key] = dedupeHookEntries(prev, ours)
+  }
+  // Drop legacy Cursor observe hooks that classified MCP/grep/test dumps as lessons.
+  for (const key of ["afterFileEdit", "postToolUse"]) {
+    const prev = Array.isArray(hooks[key]) ? (hooks[key] as unknown[]) : []
+    const kept = prev
+      .map((entry) => stripCtxpipeFromHookEntry(entry))
+      .filter((entry): entry is NonNullable<typeof entry> => entry != null)
+    if (kept.length === 0) delete hooks[key]
+    else hooks[key] = kept
   }
   return {
     ...existing,

--- a/packages/cli/test/memory-init.test.ts
+++ b/packages/cli/test/memory-init.test.ts
@@ -59,13 +59,19 @@ describe("memory init (end-to-end)", () => {
 
     const hooks = JSON.parse(
       readFileSync(join(cwd, ".cursor", "hooks.json"), "utf8"),
-    ) as { hooks?: Record<string, Array<{ command: string }>> }
+    ) as {
+      hooks?: Record<
+        string,
+        Array<{ command: string; loop_limit?: number | null }>
+      >
+    }
     expect(hooks.hooks?.beforeSubmitPrompt?.[0]?.command).toMatch(
       /memory capture observe --host cursor/,
     )
     expect(hooks.hooks?.stop?.[0]?.command).toMatch(
       /memory capture finalize --host cursor --event stop/,
     )
+    expect(hooks.hooks?.stop?.[0]?.loop_limit).toBe(1)
 
     const gitignore = readFileSync(join(cwd, ".gitignore"), "utf8")
     expect(gitignore).toContain(".ai/memory/events/**")

--- a/packages/cli/test/memory-init.test.ts
+++ b/packages/cli/test/memory-init.test.ts
@@ -72,6 +72,8 @@ describe("memory init (end-to-end)", () => {
       /memory capture finalize --host cursor --event stop/,
     )
     expect(hooks.hooks?.stop?.[0]?.loop_limit).toBe(1)
+    expect(hooks.hooks?.afterFileEdit).toBeUndefined()
+    expect(hooks.hooks?.postToolUse).toBeUndefined()
 
     const gitignore = readFileSync(join(cwd, ".gitignore"), "utf8")
     expect(gitignore).toContain(".ai/memory/events/**")

--- a/packages/cli/test/memory/capture.test.ts
+++ b/packages/cli/test/memory/capture.test.ts
@@ -568,6 +568,10 @@ describe("memory/capture", () => {
     expect(
       formatStopHookOutput("cursor", summary, {}),
     ).toEqual({})
+    const lifecycle = JSON.parse(
+      readFileSync(join(cwd, ".ai", "memory", "events", "lifecycle.json"), "utf8"),
+    ) as { dismissed?: string[] }
+    expect(lifecycle.dismissed).toContain("toolsrc000000001")
   })
 
   it("emits a Cursor follow-up once for a never-shown user-prompt candidate", () => {

--- a/packages/cli/test/memory/capture.test.ts
+++ b/packages/cli/test/memory/capture.test.ts
@@ -401,6 +401,22 @@ describe("memory/capture", () => {
     expect(out).toEqual({})
   })
 
+  it("suppresses Cursor Stop follow-up when loop_count is already 1", () => {
+    const out = formatStopHookOutput(
+      "cursor",
+      {
+        priority: "high",
+        message:
+          "Memory candidates (2 pending). Promote via skills/rules — do not auto-write ADRs from hooks.",
+        candidates: [],
+        surfacedIds: ["abc"],
+        parseErrors: 0,
+      },
+      { status: "completed", loop_count: 1 },
+    )
+    expect(out).toEqual({})
+  })
+
   it("formats Codex Stop output with decision block + reason", () => {
     const out = formatStopHookOutput(
       "codex",
@@ -576,5 +592,59 @@ describe("memory/capture", () => {
     expect(second.priority).toBe("low")
     expect(second.candidates).toEqual([])
     expect(formatStopHookOutput("cursor", second, {})).toEqual({})
+  })
+
+  it("does not recapture an injected Cursor Stop follow-up as a new lesson", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-capture-recapture-"))
+    const firstObserve = observeCapture({
+      host: "cursor",
+      eventType: "beforeSubmitPrompt",
+      cwd,
+      payload: {
+        prompt: "From now on always colocate Zod with routes",
+        sessionId: "recapture",
+      },
+    })
+    expect(firstObserve.wrote).toBe(true)
+    const first = summarizeCapture({ cwd, host: "cursor" })
+    const injected = formatStopHookOutput("cursor", first, {
+      status: "completed",
+      loop_count: 0,
+    })
+    expect(injected.followup_message).toBeTruthy()
+    acknowledgeSurfaced(first.surfacedIds, { cwd })
+
+    const followUpPrompt = String(injected.followup_message)
+    expect(followUpPrompt).toContain("Memory candidates (")
+    expect(
+      observeCapture({
+        host: "cursor",
+        eventType: "beforeSubmitPrompt",
+        cwd,
+        payload: { prompt: followUpPrompt, sessionId: "recapture" },
+      }).wrote,
+    ).toBe(false)
+
+    expect(
+      observeCapture({
+        host: "cursor",
+        eventType: "beforeSubmitPrompt",
+        cwd,
+        payload: {
+          prompt: {
+            content: [{ type: "text", text: followUpPrompt }],
+          },
+          sessionId: "recapture",
+        },
+      }).wrote,
+    ).toBe(false)
+
+    const second = summarizeCapture({ cwd, host: "cursor" })
+    expect(
+      formatStopHookOutput("cursor", second, {
+        status: "completed",
+        loop_count: 1,
+      }),
+    ).toEqual({})
   })
 })

--- a/packages/cli/test/memory/memory-capture-sh.test.ts
+++ b/packages/cli/test/memory/memory-capture-sh.test.ts
@@ -1,0 +1,136 @@
+import { execFileSync } from "node:child_process"
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../..")
+const WRAPPER_SRC = join(REPO_ROOT, ".cursor/hooks/memory-capture.sh")
+
+function pathWithoutBun(extra: string[] = []): string {
+  const filtered = (process.env.PATH ?? "")
+    .split(":")
+    .filter((dir) => dir.length > 0 && !existsSync(join(dir, "bun")))
+  return [...extra, ...filtered].join(":")
+}
+
+function seedWrapperRepo(opts: { turbo?: "ok" | "fail" | "missing" } = {}): {
+  cwd: string
+  wrapper: string
+  bunLog: string
+  turboLog: string
+  nodeLog: string
+} {
+  const turboMode = opts.turbo ?? "ok"
+  const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-memory-capture-sh-"))
+  const wrapper = join(cwd, ".cursor/hooks/memory-capture.sh")
+  mkdirSync(dirname(wrapper), { recursive: true })
+  mkdirSync(join(cwd, "packages/cli/src"), { recursive: true })
+  mkdirSync(join(cwd, "packages/cli/bin"), { recursive: true })
+  mkdirSync(join(cwd, "packages/cli/dist"), { recursive: true })
+  mkdirSync(join(cwd, "node_modules/.bin"), { recursive: true })
+  writeFileSync(wrapper, readFileSync(WRAPPER_SRC, "utf8"))
+  chmodSync(wrapper, 0o755)
+  writeFileSync(join(cwd, "packages/cli/src/cli.ts"), "export {}\n")
+  writeFileSync(join(cwd, "packages/cli/dist/cli.js"), "export {}\n")
+
+  const bunLog = join(cwd, "bun.log")
+  const turboLog = join(cwd, "turbo.log")
+  const nodeLog = join(cwd, "node.log")
+
+  const bun = join(cwd, "fake-bin/bun")
+  mkdirSync(dirname(bun), { recursive: true })
+  writeFileSync(
+    bun,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > '${bunLog}'\nprintf '%s\\n' '{"via":"bun"}'\n`,
+  )
+  chmodSync(bun, 0o755)
+
+  if (turboMode !== "missing") {
+    const exitCode = turboMode === "fail" ? 1 : 0
+    writeFileSync(
+      join(cwd, "node_modules/.bin/turbo"),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > '${turboLog}'\nexit ${exitCode}\n`,
+    )
+    chmodSync(join(cwd, "node_modules/.bin/turbo"), 0o755)
+  }
+
+  writeFileSync(
+    join(cwd, "packages/cli/bin/ctxpipe.js"),
+    `#!/usr/bin/env node\nimport { writeFileSync } from "node:fs"\nwriteFileSync(${JSON.stringify(nodeLog)}, process.argv.slice(2).join(" "))\nprocess.stdout.write(JSON.stringify({ via: "node" }) + "\\n")\n`,
+  )
+
+  return { cwd, wrapper, bunLog, turboLog, nodeLog }
+}
+
+describe("in-repo memory-capture.sh", () => {
+  it("runs bun from source without invoking turbo", () => {
+    const { cwd, wrapper, bunLog, turboLog, nodeLog } = seedWrapperRepo()
+    const stdout = execFileSync("bash", [wrapper, "memory", "capture", "observe"], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${join(cwd, "fake-bin")}:${pathWithoutBun()}`,
+      },
+    })
+    expect(JSON.parse(stdout)).toEqual({ via: "bun" })
+    expect(readFileSync(bunLog, "utf8")).toContain("packages/cli/src/cli.ts")
+    expect(() => readFileSync(turboLog, "utf8")).toThrow()
+    expect(() => readFileSync(nodeLog, "utf8")).toThrow()
+  })
+
+  it("refreshes dist with turbo then runs node when bun is missing", () => {
+    const { cwd, wrapper, bunLog, turboLog, nodeLog } = seedWrapperRepo()
+    const stdout = execFileSync("bash", [wrapper, "memory", "capture", "finalize"], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: pathWithoutBun(),
+      },
+    })
+    expect(JSON.parse(stdout)).toEqual({ via: "node" })
+    expect(() => readFileSync(bunLog, "utf8")).toThrow()
+    expect(readFileSync(turboLog, "utf8")).toMatch(
+      /run build --filter=ctxpipe/,
+    )
+    expect(readFileSync(nodeLog, "utf8")).toContain("memory capture finalize")
+  })
+
+  it("fail-opens instead of running stale dist when turbo fails", () => {
+    const { cwd, wrapper, nodeLog } = seedWrapperRepo({ turbo: "fail" })
+    const stdout = execFileSync("bash", [wrapper, "memory", "capture", "finalize"], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: pathWithoutBun(),
+      },
+    })
+    expect(JSON.parse(stdout)).toEqual({})
+    expect(() => readFileSync(nodeLog, "utf8")).toThrow()
+  })
+
+  it("fail-opens instead of running stale dist when turbo is missing", () => {
+    const { cwd, wrapper, nodeLog } = seedWrapperRepo({ turbo: "missing" })
+    const stdout = execFileSync("bash", [wrapper, "memory", "capture", "finalize"], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: pathWithoutBun(),
+      },
+    })
+    expect(JSON.parse(stdout)).toEqual({})
+    expect(() => readFileSync(nodeLog, "utf8")).toThrow()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^0.9.4
         version: 0.9.4
       turbo:
-        specifier: ^2.8.10
-        version: 2.8.10
+        specifier: ^2.10.9
+        version: 2.10.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -61,16 +61,16 @@ importers:
         version: 3.1077.0
       '@better-auth/api-key':
         specifier: ^1.6.23
-        version: 1.6.23(4415905e19c5d68d143faa241a6d9e46)
+        version: 1.6.23(dc1840556b897b564739e831df4193a3)
       '@better-auth/infra':
         specifier: ^0.3.5
-        version: 0.3.5(6844ecd5d3ef311c853ba1070e513d5b)
+        version: 0.3.5(1e8eabba48683a28ebb7087d86f3787b)
       '@better-auth/oauth-provider':
         specifier: ^1.6.23
-        version: 1.6.23(c0c8ac9752fb861954f3b62c000f8ff9)
+        version: 1.6.23(a34639ce28922af22d03bea87d7ef958)
       '@better-auth/passkey':
         specifier: ^1.6.23
-        version: 1.6.23(146c62a2080fcc7967d2514fa60f9439)
+        version: 1.6.23(1b2f6b7f3dae9589129983208a668570)
       '@hono/mcp':
         specifier: ^0.2.3
         version: 0.2.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.27))(hono@4.12.27)(zod@4.3.6)
@@ -351,13 +351,13 @@ importers:
         version: 1.2.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.7(zod@3.25.76))
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))
       '@better-auth/oauth-provider':
         specifier: ^1.5.6
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.7(zod@3.25.76))
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))
       '@better-auth/passkey':
         specifier: ^1.5.6
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.7(zod@4.3.6))(nanostores@1.2.0)
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))(nanostores@1.2.0)
       '@cosmograph/react':
         specifier: 2.2.1
         version: 2.2.1(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -366,7 +366,7 @@ importers:
         version: 1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@daveyplate/better-auth-ui':
         specifier: ^3.4.0
-        version: 3.4.0(56b7578c6209d33868ca502c2dc32fe1)
+        version: 3.4.0(6b2f5b4ed8290211e67c7ce00b1a3872)
       '@scure/base':
         specifier: ^2.0.0
         version: 2.0.0
@@ -6441,6 +6441,36 @@ packages:
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
+  '@turbo/darwin-64@2.10.9':
+    resolution: {integrity: sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.10.9':
+    resolution: {integrity: sha512-aqtpPkiIC4IUas8Vv27oJ3aDfTuP1d5wofd01dZ7gfhHRrIKuFdqQb4imvNnVFahcOViF9Jh8Oi7feDoz8/ciA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.10.9':
+    resolution: {integrity: sha512-XyAneUBsS5uNOUOjBSs81zyigMVwwhVUd3u7F2JFMKGQk6F7eNAiOEBASJ+aHLldjYsOEjhfW+5gWIqwziyFFw==}
+    cpu: [x64]
+    os: [android, linux]
+
+  '@turbo/linux-arm64@2.10.9':
+    resolution: {integrity: sha512-5jAcldLnkuWIjujGhCn2MGIeUwW8IVNOq9Sce4EEzzgLcxmhTasbV0RiW6ZkaRdOjmOCGzeNXPLkDJEOIucOLw==}
+    cpu: [arm64]
+    os: [android, linux]
+
+  '@turbo/windows-64@2.10.9':
+    resolution: {integrity: sha512-u1xGpGlefzuhBedbt/VR2nWdftfFVZwPeDg9e5uZl68sV1fL3HNYTNr5VyHkzgtPK2VTYg1x4OKZuGrh1Gvhtg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.10.9':
+    resolution: {integrity: sha512-W2Ub165Qv0iMFljbYKxxbZN+2dVSngnzEjQNEFXtnz5oJVx9XSypmNmUvMtuYMeZ3kdVC1zI7yd/rtuX+SDnbg==}
+    cpu: [arm64]
+    os: [win32]
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -12728,38 +12758,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo-darwin-64@2.8.10:
-    resolution: {integrity: sha512-A03fXh+B7S8mL3PbdhTd+0UsaGrhfyPkODvzBDpKRY7bbeac4MDFpJ7I+Slf2oSkCEeSvHKR7Z4U71uKRUfX7g==}
-    cpu: [x64]
-    os: [darwin]
-
-  turbo-darwin-arm64@2.8.10:
-    resolution: {integrity: sha512-sidzowgWL3s5xCHLeqwC9M3s9M0i16W1nuQF3Mc7fPHpZ+YPohvcbVFBB2uoRRHYZg6yBnwD4gyUHKTeXfwtXA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  turbo-linux-64@2.8.10:
-    resolution: {integrity: sha512-YK9vcpL3TVtqonB021XwgaQhY9hJJbKKUhLv16osxV0HkcQASQWUqR56yMge7puh6nxU67rQlTq1b7ksR1T3KA==}
-    cpu: [x64]
-    os: [linux]
-
-  turbo-linux-arm64@2.8.10:
-    resolution: {integrity: sha512-3+j2tL0sG95iBJTm+6J8/45JsETQABPqtFyYjVjBbi6eVGdtNTiBmHNKrbvXRlQ3ZbUG75bKLaSSDHSEEN+btQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  turbo-windows-64@2.8.10:
-    resolution: {integrity: sha512-hdeF5qmVY/NFgiucf8FW0CWJWtyT2QPm5mIsX0W1DXAVzqKVXGq+Zf+dg4EUngAFKjDzoBeN6ec2Fhajwfztkw==}
-    cpu: [x64]
-    os: [win32]
-
-  turbo-windows-arm64@2.8.10:
-    resolution: {integrity: sha512-QGdr/Q8LWmj+ITMkSvfiz2glf0d7JG0oXVzGL3jxkGqiBI1zXFj20oqVY0qWi+112LO9SVrYdpHS0E/oGFrMbQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  turbo@2.8.10:
-    resolution: {integrity: sha512-OxbzDES66+x7nnKGg2MwBA1ypVsZoDTLHpeaP4giyiHSixbsiTaMyeJqbEyvBdp5Cm28fc+8GG6RdQtic0ijwQ==}
+  turbo@2.10.9:
+    resolution: {integrity: sha512-Yl9+ukxH+UmPtKidpDkjn82tvPoEvFNb9UACd9vUomN1Ft0cwl3rx0P8yC1D93W9EOsWRMjllvIDG8y25sFOog==}
     hasBin: true
 
   tw-animate-css@1.4.0:
@@ -14730,28 +14730,20 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/api-key@1.6.23(4415905e19c5d68d143faa241a6d9e46)':
+  '@better-auth/api-key@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
-      '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4))(drizzle-kit@1.0.0-beta.22)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      better-call: 2.0.2(zod@4.3.6)
-      zod: 4.3.6
-
-  '@better-auth/api-key@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.7(zod@3.25.76))':
-    dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
-      '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      better-call: 1.3.7(zod@3.25.76)
-      zod: 4.3.6
-
-  '@better-auth/api-key@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))':
-    dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 2.0.2(zod@3.25.76)
+      zod: 4.3.6
+
+  '@better-auth/api-key@1.6.23(dc1840556b897b564739e831df4193a3)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+      better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4))(drizzle-kit@1.0.0-beta.22)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-call: 1.3.7(zod@4.3.6)
       zod: 4.3.6
 
   '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)':
@@ -14760,7 +14752,7 @@ snapshots:
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.7(zod@3.25.76)
+      better-call: 1.3.7(zod@4.3.6)
       jose: 6.2.2
       kysely: 0.29.3
       nanostores: 1.2.0
@@ -14768,13 +14760,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)':
+  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 2.0.2(zod@4.3.6)
+      better-call: 2.0.2(zod@3.25.76)
       jose: 6.2.2
       kysely: 0.29.3
       nanostores: 1.2.0
@@ -14782,21 +14774,21 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
-      '@better-auth/utils': 0.4.2
-
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))':
-    dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6)
 
-  '@better-auth/infra@0.3.5(6844ecd5d3ef311c853ba1070e513d5b)':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/infra@0.3.5(1e8eabba48683a28ebb7087d86f3787b)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4))(drizzle-kit@1.0.0-beta.22)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -14812,9 +14804,9 @@ snapshots:
     optionalDependencies:
       kysely: 0.29.3
 
-  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.3
@@ -14824,9 +14816,9 @@ snapshots:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
@@ -14834,52 +14826,52 @@ snapshots:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.7(zod@3.25.76))':
+  '@better-auth/oauth-provider@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-call: 2.0.2(zod@3.25.76)
+      jose: 6.2.2
+      zod: 4.3.6
+
+  '@better-auth/oauth-provider@1.6.23(a34639ce28922af22d03bea87d7ef958)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      better-call: 1.3.7(zod@3.25.76)
-      jose: 6.2.2
-      zod: 4.3.6
-
-  '@better-auth/oauth-provider@1.6.23(c0c8ac9752fb861954f3b62c000f8ff9)':
-    dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
-      '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
       better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4))(drizzle-kit@1.0.0-beta.22)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      better-call: 2.0.2(zod@4.3.6)
+      better-call: 1.3.7(zod@4.3.6)
       jose: 6.2.2
       zod: 4.3.6
 
-  '@better-auth/passkey@1.6.23(146c62a2080fcc7967d2514fa60f9439)':
+  '@better-auth/passkey@1.6.23(1b2f6b7f3dae9589129983208a668570)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.3
       better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4))(drizzle-kit@1.0.0-beta.22)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      better-call: 2.0.2(zod@4.3.6)
+      better-call: 1.3.7(zod@4.3.6)
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.7(zod@4.3.6))(nanostores@1.2.0)':
+  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))(nanostores@1.2.0)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.3
       better-auth: 1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      better-call: 1.3.7(zod@3.25.76)
+      better-call: 2.0.2(zod@3.25.76)
       nanostores: 1.2.0
       zod: 4.3.6
 
@@ -14888,9 +14880,9 @@ snapshots:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
@@ -14899,9 +14891,9 @@ snapshots:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
-  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -15252,10 +15244,10 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@daveyplate/better-auth-ui@3.4.0(56b7578c6209d33868ca502c2dc32fe1)':
+  '@daveyplate/better-auth-ui@3.4.0(6b2f5b4ed8290211e67c7ce00b1a3872)':
     dependencies:
-      '@better-auth/api-key': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))
-      '@better-auth/passkey': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.7(zod@4.3.6))(nanostores@1.2.0)
+      '@better-auth/api-key': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))
+      '@better-auth/passkey': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@2.0.2(zod@3.25.76))(nanostores@1.2.0)
       '@better-fetch/fetch': 1.3.1
       '@captchafox/react': 1.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -21319,6 +21311,24 @@ snapshots:
       minimatch: 10.2.2
       path-browserify: 1.0.1
 
+  '@turbo/darwin-64@2.10.9':
+    optional: true
+
+  '@turbo/darwin-arm64@2.10.9':
+    optional: true
+
+  '@turbo/linux-64@2.10.9':
+    optional: true
+
+  '@turbo/linux-arm64@2.10.9':
+    optional: true
+
+  '@turbo/windows-64@2.10.9':
+    optional: true
+
+  '@turbo/windows-arm64@2.10.9':
+    optional: true
+
   '@types/aria-query@5.0.4': {}
 
   '@types/aws-lambda@8.10.161': {}
@@ -22335,17 +22345,17 @@ snapshots:
   better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.28.1)))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.7(zod@3.25.76)
+      better-call: 1.3.7(zod@4.3.6)
       defu: 6.1.4
       jose: 6.2.2
       kysely: 0.29.3
@@ -22365,12 +22375,12 @@ snapshots:
   better-auth@1.6.23(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.162.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4))(drizzle-kit@1.0.0-beta.22)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.13.6(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-beta.22(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(bun-types@1.3.9)(gel@2.2.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.18.0)(postgres@3.4.8)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6))
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.1.1
@@ -22394,15 +22404,6 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.7(zod@3.25.76):
-    dependencies:
-      '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 3.25.76
-
   better-call@1.3.7(zod@4.3.6):
     dependencies:
       '@better-auth/utils': 0.4.2
@@ -22420,15 +22421,6 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 3.25.76
-
-  better-call@2.0.2(zod@4.3.6):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.3.1
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 4.3.6
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -28792,32 +28784,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo-darwin-64@2.8.10:
-    optional: true
-
-  turbo-darwin-arm64@2.8.10:
-    optional: true
-
-  turbo-linux-64@2.8.10:
-    optional: true
-
-  turbo-linux-arm64@2.8.10:
-    optional: true
-
-  turbo-windows-64@2.8.10:
-    optional: true
-
-  turbo-windows-arm64@2.8.10:
-    optional: true
-
-  turbo@2.8.10:
+  turbo@2.10.9:
     optionalDependencies:
-      turbo-darwin-64: 2.8.10
-      turbo-darwin-arm64: 2.8.10
-      turbo-linux-64: 2.8.10
-      turbo-linux-arm64: 2.8.10
-      turbo-windows-64: 2.8.10
-      turbo-windows-arm64: 2.8.10
+      '@turbo/darwin-64': 2.10.9
+      '@turbo/darwin-arm64': 2.10.9
+      '@turbo/linux-64': 2.10.9
+      '@turbo/linux-arm64': 2.10.9
+      '@turbo/windows-64': 2.10.9
+      '@turbo/windows-arm64': 2.10.9
 
   tw-animate-css@1.4.0: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cursor Stop `followup_message` is injected as a **new user turn**. Yesterday’s [#287](https://github.com/ctxpipe-ai/ctxpipe/pull/287) raised the classifier bar in *source*, but:

1. **Project hooks still ran `npx -y ctxpipe` (published 0.3.0).** That build classifies `do not auto-write ADRs from hooks` as a lesson, mints a new candidate whose excerpt is the follow-up text, and emits another `followup_message`. That is the recapture loop (Cursor’s default `loop_limit` is 5).
2. Switching hooks to `node packages/cli/bin/ctxpipe.js` can hit the **same bug via a stale `packages/cli/dist`**.
3. **`afterFileEdit` / `postToolUse` classified MCP schemas, file reads, grep, and test edits as lessons.**

## Change

- Observe ignores follow-up-shaped payloads, including nested Cursor prompt JSON.
- Stop output honors Cursor `loop_count >= 1` (no second follow-up on the continuation turn).
- Cursor hooks observe **`beforeSubmitPrompt` only** (plus Stop finalize). `afterFileEdit` / `postToolUse` are not installed; `memory init` strips leftover ctxpipe observe entries on those events.
- Cursor summarize **dismisses tool-sourced pending ids** so dumps already in `candidates.jsonl` cannot be followed up.
- This repo’s `.cursor/hooks.json` runs **`.cursor/hooks/memory-capture.sh`**: `bun packages/cli/src/cli.ts` **directly** (no Turbo on that path). If bun is missing, Turbo `build --filter=ctxpipe` must succeed before `node` runs `dist`; failed/missing Turbo fail-opens (`{}`) instead of executing unverified dist. Never npx. `loop_limit: 1` remains as a backstop.
- Bump Turborepo **2.8.10 → 2.10.9** (cache-hit on this repo is tens of ms, not ~200ms).

## Sol review (adversarial)

Verdict: **partial**. Fresh sessions using bun likely stop the loop; this is not a full product fix.

- Customer `memory init` still installs `npx -y ctxpipe`, and npm still serves **0.3.0**. The wrapper is private remediation until a CLI release ships.
- Already-running Cursor sessions keep the old hook snapshot; a restart is required.
- Recapture filtering is heuristic (`FOLLOWUP_PROMPT_RE` can also drop real prompts that quote the follow-up text).
- Auto-dismiss of candidates without `sourceEventType` can drop pre-schema legitimate items.
- The Turbo bump does not itself stop the loop.

To call the root cause fixed: publish `ctxpipe@0.3.1`, fail-open rather than run unverified dist (done in this PR), add a unique follow-up sentinel, and verify on a **newly started** Cursor session.

## Test plan

- `pnpm --filter ctxpipe exec vitest run test/memory/memory-capture-sh.test.ts test/memory/capture.test.ts test/memory-init.test.ts` — 43 passed
- Wrapper: bun-from-source does not invoke Turbo; bun-less path requires a successful Turbo build; Turbo fail/missing fail-opens and does not run node dist
- Recapture test: injected Stop follow-up is not minted; `loop_count: 1` emits `{}`
- `memory init --agents cursor` does not install `afterFileEdit` / `postToolUse`

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://ctxpipe.slack.com/archives/C0AMVSR0EBW/p1787148733040509?thread_ts=1787148733.040509&cid=C0AMVSR0EBW)

<div><a href="https://cursor.com/agents/bc-5843a2d4-05a3-5b01-be8b-7ec2638ac642?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5843a2d4-05a3-5b01-be8b-7ec2638ac642&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

