### PR TITLE
Document Notion setup and harden connector status

### DIFF
--- a/.ai/memory/lessons-learned.md
+++ b/.ai/memory/lessons-learned.md
@@ -214,6 +214,12 @@ Highest-priority confirmed rules for agents. Migrated from former `patterns.md` 
 - **Date:** 2026-08-19
 - **Source:** user correction during Slack `slack_sync_targets` unification (PR #267)
 
+### Connector product vs self-host docs
+- **Rule:** scoped-mirror connectors (Linear, Notion) need a **hosted product page** under `apps/docs/content/docs/(guide)/connections/source-connectors/<slug>.mdx` and a **self-host operator page** under `apps/docs/content/docs/self-hosting/<slug>.mdx`. Use Linear's hosted page as the structural template (managed-app callout, config-in-git, setup steps, layout, webhooks, troubleshooting). Copy Linear's headings, not Linear's provider-specific content. The hosted page describes user setup; it does not document creating the provider OAuth app — that stays on the self-host page, with a User guide pointer back. Add the slug to `source-connectors/meta.json` and cross-link connected-sources / context-repository.
+- **Category:** convention
+- **Date:** 2026-08-20
+- **Source:** notion-docs branch; Linear hosted guide as template
+
 ### Tool organization
 - **Rule:** reusable agent tools under `src/tools`; graph-specific instructions and nodes under `src/graphs/<graphName>/`
 - **Category:** convention

--- a/.ai/memory/lessons-learned.md
+++ b/.ai/memory/lessons-learned.md
@@ -616,3 +616,9 @@ Highest-priority confirmed rules for agents. Migrated from former `patterns.md` 
 - **Date:** 2026-08-19
 - **Source:** slack-connector PR-267 live diagnosis (499 webhook retries and three replacing worker deploys)
 
+### Connector status must not hold DB transactions across provider calls
+- **Rule:** Do not fetch GitHub/provider state from a frequently polled connector status endpoint while `withNetworkOrgContext` keeps the request-wide org transaction open. In production, 3-second status polling exhausted GitHub quota; Octokit back-off left Postgres transactions idle, `idle-in-transaction` termination destabilised the pool, and auth/MCP/connectors queued for 30–120 seconds. Status reads should use persisted or bounded-cache state, provider calls need short timeouts outside DB transactions, and stable connector screens must not poll every few seconds.
+- **Category:** reliability
+- **Date:** 2026-08-20
+- **Source:** production Railway incident diagnosis (GitHub quota exhaustion → idle transaction termination → pg-pool acquisition timeouts)
+

--- a/.changeset/connector-status-polling-hotfix.md
+++ b/.changeset/connector-status-polling-hotfix.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Ship DB-only Linear and Notion status reads and stop stable connector-page polling to prevent GitHub throttling from exhausting PostgreSQL connections.

--- a/apps/backend/src/routes/v1/connectors-linear.test.ts
+++ b/apps/backend/src/routes/v1/connectors-linear.test.ts
@@ -293,7 +293,7 @@ describe("Linear connector routes", () => {
     )
   })
 
-  it("counts live scopes from the target branch", async () => {
+  it("returns live status without reading GitHub scope config", async () => {
     mocks.getTarget.mockResolvedValueOnce({
       repositoryId: "repo_1",
       repositoryName: "acme/context",
@@ -312,12 +312,10 @@ describe("Linear connector routes", () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toMatchObject({
-      selectedScopeCount: scopes.length,
+      selectedScopeCount: null,
     })
     expect(mocks.getPullHead).not.toHaveBeenCalled()
-    expect(mocks.loadConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ branch: "main" }),
-    )
+    expect(mocks.loadConfig).not.toHaveBeenCalled()
   })
 
   it("does not claim a config pull request for a target-only patch", async () => {

--- a/apps/backend/src/routes/v1/connectors-linear.ts
+++ b/apps/backend/src/routes/v1/connectors-linear.ts
@@ -130,7 +130,7 @@ const getStatusRoute = createRoute({
             installationStatus: z.string().nullable(),
             workspaceName: z.string().nullable(),
             isGithubLinked: z.boolean(),
-            selectedScopeCount: z.number().int(),
+            selectedScopeCount: z.number().int().nullable(),
             setupPhase: z.string(),
             pendingConfigPullUrl: z.string().nullable(),
             pendingConfigPrCreating: z.boolean(),
@@ -146,7 +146,7 @@ const getStatusRoute = createRoute({
         },
       },
       description:
-        "Current Linear setup status, with git-backed scope count and the repository binding from connection config",
+        "Current Linear setup status and repository binding. Scope count is omitted so this frequently polled route never calls GitHub.",
     },
     400: {
       content: { "application/json": { schema: ErrorResponseSchema } },
@@ -570,18 +570,13 @@ export const linearConnectorRoutes = new OpenAPIHono<AppEnv>()
         ? getLinearBindingWithRepoByConnectionId(orgId, connection.id)
         : Promise.resolve(undefined),
     ])
-    const scopes = await loadLinearScopesFromGit({
-      orgId,
-      env: c.var.env,
-      binding,
-    })
     return c.json(
       {
         isInstalled: connection?.status === "installed",
         installationStatus: connection?.status ?? null,
         workspaceName: connection?.workspaceName ?? null,
         isGithubLinked,
-        selectedScopeCount: scopes.length,
+        selectedScopeCount: null,
         setupPhase: binding?.setupPhase ?? "draft",
         pendingConfigPullUrl: binding?.pendingConfigPullUrl ?? null,
         pendingConfigPrCreating: binding?.pendingConfigPrCreating ?? false,

--- a/apps/backend/src/routes/v1/connectors-notion.test.ts
+++ b/apps/backend/src/routes/v1/connectors-notion.test.ts
@@ -151,6 +151,19 @@ describe("Notion connector config", () => {
     releaseNotionConfigPrCreationClaimMock.mockResolvedValue(undefined)
   })
 
+  it("returns live status without reading GitHub scope config", async () => {
+    const response = await app().request(
+      "/demo/api/v1/connectors/notion/status?connectionId=con_1",
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      selectedResourceCount: null,
+      setupPhase: "live",
+    })
+    expect(loadNotionScopeFromRepoMock).not.toHaveBeenCalled()
+  })
+
   it("enqueues the config workflow with the requested resources when the git scope differs", async () => {
     const response = await patchResources()
 

--- a/apps/backend/src/routes/v1/connectors-notion.ts
+++ b/apps/backend/src/routes/v1/connectors-notion.ts
@@ -57,7 +57,7 @@ const NotionStatusResponseSchema = z
     installationStatus: z.string().nullable(),
     workspaceName: z.string().nullable(),
     isGithubLinked: z.boolean(),
-    selectedResourceCount: z.number(),
+    selectedResourceCount: z.number().nullable(),
     syncTargetConfigured: z.boolean(),
     setupPhase: z.string(),
     pendingConfigPullUrl: z.string().nullable(),
@@ -752,11 +752,6 @@ notionConnectorRoutes
         ? getNotionBindingWithRepoByConnectionId(orgId, connection.id)
         : Promise.resolve(undefined),
     ])
-    const resources = await loadNotionResourcesFromGit({
-      orgId,
-      env: c.var.env,
-      binding,
-    })
     return c.json(
       {
         isInstalled:
@@ -764,7 +759,7 @@ notionConnectorRoutes
         installationStatus: connection?.status ?? null,
         workspaceName: connection?.workspaceName ?? null,
         isGithubLinked,
-        selectedResourceCount: resources.length,
+        selectedResourceCount: null,
         syncTargetConfigured: Boolean(binding),
         setupPhase: binding?.setupPhase ?? "draft",
         pendingConfigPullUrl: binding?.pendingConfigPullUrl ?? null,

--- a/apps/docs/content/docs/(guide)/connections/connected-sources.mdx
+++ b/apps/docs/content/docs/(guide)/connections/connected-sources.mdx
@@ -16,7 +16,7 @@ become visible, reviewable context.
 | **Confluence** | Select spaces and pages, sync them into a chosen GitHub repository, then ingest that repo-backed content into ctx|. |
 | **Slack** | Mention the bot in a thread (`app_mention`) to capture that specific thread as Markdown into a chosen GitHub repository — intent-based capture, not a continuous channel mirror. |
 | **Linear** | Select workspace scope, review draft `linear/config.yaml` on a pull request branch, then make that YAML live on the target branch by merging it. The connection config keeps the repository binding. |
-| **Notion** | Select pages and databases, sync them into a chosen GitHub repository as Markdown, then ingest that repo-backed content into ctx|. |
+| **Notion** | Select pages and databases, review draft `notion/config.yaml` on a pull request branch, then make that YAML live on the target branch by merging it. The connection config keeps the repository binding. |
 | **Repo-native docs** | README files, `docs/**`, ADRs, `AGENTS.md`, skills, and similar files are ingested with the repository. |
 
 ## What belongs in Git
@@ -63,5 +63,6 @@ webhooks before the corresponding connector is available — see
   <Card title="Confluence connector" href="/docs/connections/source-connectors/confluence" description="Sync selected Confluence spaces and pages into Git-backed context." />
   <Card title="Slack connector" href="/docs/connections/source-connectors/slack" description="Capture specific Slack threads on demand into Git-backed Markdown." />
   <Card title="Linear connector" href="/docs/connections/source-connectors/linear" description="Mirror reviewable Linear workspace context into a GitHub repository." />
+  <Card title="Notion connector" href="/docs/connections/source-connectors/notion" description="Mirror reviewable Notion pages and databases into a GitHub repository." />
   <Card title="ctx| MCP" href="/docs/mcp/mcp-docs" description="How agents connect to ctx| after sources are ingested." />
 </Cards>

--- a/apps/docs/content/docs/(guide)/connections/context-repository.mdx
+++ b/apps/docs/content/docs/(guide)/connections/context-repository.mdx
@@ -106,6 +106,6 @@ they apply, and use Git history to understand when connector context changed.
 - [Confluence connector](/docs/connections/source-connectors/confluence)
 - [Slack connector](/docs/connections/source-connectors/slack)
 - [Linear connector](/docs/connections/source-connectors/linear)
-- [Self-host Notion](/docs/self-hosting/notion)
+- [Notion connector](/docs/connections/source-connectors/notion)
 - [Manage repositories](/docs/git-repositories/manage-repositories)
 - [Ingestion](/docs/connections/ingestion)

--- a/apps/docs/content/docs/(guide)/connections/index.mdx
+++ b/apps/docs/content/docs/(guide)/connections/index.mdx
@@ -36,10 +36,10 @@ Linear connector lets you choose teams, projects, documents, and initiatives,
 and the Notion connector lets you choose pages and databases. Each connector
 copies its selected content into a GitHub repository, then updates that
 Git-backed source when upstream content changes.
-For Linear, the configuration pull request branch holds the draft
-`linear/config.yaml`, the target branch holds the live YAML after merge, and
-the connection record's `config` stores the repository binding rather than a
-second copy of scope.
+For Linear and Notion, the configuration pull request branch holds the draft
+`linear/config.yaml` or `notion/config.yaml`, the target branch holds the live
+YAML after merge, and the connection record's `config` stores the repository
+binding rather than a second copy of scope.
 
 This gives you:
 

--- a/apps/docs/content/docs/(guide)/connections/source-connectors/github.mdx
+++ b/apps/docs/content/docs/(guide)/connections/source-connectors/github.mdx
@@ -7,11 +7,11 @@ GitHub is the first source connector most teams set up. It gives ctx| access to
 the repositories your organization chooses, and those repositories become the
 base for code search, file reads, knowledge graph ingestion, and agent context.
 
-GitHub also supports other connectors. When a source like Confluence or Linear
-needs to become visible and reviewable, ctx| syncs selected content into a
+GitHub also supports other connectors. When a source like Confluence, Linear, or
+Notion needs to become visible and reviewable, ctx| syncs selected content into a
 GitHub repository first, then ingests it through the same Git-backed pipeline.
-For Linear, the configuration pull request branch is the draft scope and the
-target branch becomes the live scope after merge.
+For Linear and Notion, the configuration pull request branch is the draft scope
+and the target branch becomes the live scope after merge.
 
 You can connect GitHub during onboarding, or later from the **Connectors** page.
 
@@ -79,3 +79,5 @@ Use the **Git repositories** section for setup and operations:
   ingestion.
 - [Linear connector](/docs/connections/source-connectors/linear) covers the
   reviewable `linear/config.yaml` scope and Git-backed Linear mirror.
+- [Notion connector](/docs/connections/source-connectors/notion) covers the
+  reviewable `notion/config.yaml` scope and Git-backed Notion mirror.

--- a/apps/docs/content/docs/(guide)/connections/source-connectors/meta.json
+++ b/apps/docs/content/docs/(guide)/connections/source-connectors/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Source connectors",
-  "pages": ["github", "confluence", "slack", "linear"]
+  "pages": ["github", "confluence", "slack", "linear", "notion"]
 }

--- a/apps/docs/content/docs/(guide)/connections/source-connectors/notion.mdx
+++ b/apps/docs/content/docs/(guide)/connections/source-connectors/notion.mdx
@@ -1,0 +1,220 @@
+---
+title: Notion connector
+description: Connect a Notion workspace, review its Git-backed scope, and keep selected pages and databases available to ctx|.
+---
+
+The **Notion connector** mirrors selected workspace context into a GitHub
+repository, then sends that repository through the normal ctx| ingestion
+pipeline. The generated `notion/config.yaml` pull request makes the scope
+reviewable before content sync begins.
+
+ctx| reads Notion pages and databases. It does not create or update Notion
+content.
+
+<Callout title="Fully managed app flow">
+  The hosted ctx| service supplies the Notion OAuth application and webhook
+  configuration. Self-hosted operators must register their own public
+  integration before authorisation can succeed. See
+  [Self-host Notion](/docs/self-hosting/notion).
+</Callout>
+
+## What is mirrored
+
+You can select pages and databases that the ctx| Notion integration can already
+see. Their related content can include:
+
+- Selected pages as Markdown, including descendant pages added later.
+- Selected databases as an index page, a `table.csv` snapshot, and one Markdown
+  file per row (properties plus page body).
+- Headings, lists, tasks, quotes, code, and in-scope page links rewritten to
+  relative Git paths when the target is also mirrored.
+- External image and file URLs when Notion stores them as public links.
+
+Notion-hosted file and image uploads are not copied into Git. The Markdown keeps
+a caption stub instead of an expiring Notion download URL. Page comments are not
+mirrored.
+
+<Callout title="Page sharing is the access gate">
+  Notion only lists pages and databases already shared with the ctx| integration.
+  Share those resources during the OAuth picker, or later in Notion, then choose
+  **Refresh Notion resources** in setup. Review the selected scope and the
+  generated pull request before merging it. Repository access becomes the
+  practical access boundary for the mirrored files.
+</Callout>
+
+## Prerequisites
+
+- Permission to authorize an application in the Notion workspace and share the
+  pages or databases that should be mirrored.
+- A ctx| GitHub connection with access to the destination repository.
+- Permission to merge the generated configuration pull request.
+
+## Configuration source of truth
+
+Notion scope exists only in `notion/config.yaml`:
+
+- **Draft scope** is the YAML on the generated configuration pull request's
+  branch.
+- **Live scope** is the YAML on the selected target branch after that pull
+  request is merged.
+
+ctx| does not keep a second draft or live scope in PostgreSQL. The Notion
+connection's `connections.config` stores only the repository binding and setup
+state, including the repository, target branch, enabled state, and pending
+configuration pull request metadata.
+
+## Setup flow
+
+<Steps>
+  <Step>
+    ### Connect Notion
+
+    Open **Connectors**, choose **Add connection**, then select **Notion**.
+    Authorize the ctx| application in the Notion popup and share the pages or
+    databases the connector should be allowed to read.
+  </Step>
+
+  <Step>
+    ### Confirm GitHub
+
+    Notion content is stored in Git before ingestion. If GitHub is not connected
+    for this ctx| organization, complete the GitHub App installation first.
+  </Step>
+
+  <Step>
+    ### Choose a context repository
+
+    Select an existing connected repository. A dedicated private repository
+    usually gives the clearest ownership and access boundary; create it in
+    GitHub first, grant the ctx| GitHub App access, then refresh the repository
+    list in ctx|.
+  </Step>
+
+  <Step>
+    ### Select scope
+
+    Select at least one page or database. Page selection includes that page's
+    child pages, including pages added later. Database selection includes the
+    database rows. Keep the selection narrow when the workspace holds mixed
+    private and shared notes.
+  </Step>
+
+  <Step>
+    ### Merge the configuration pull request
+
+    ctx| opens a pull request containing `notion/config.yaml`. Review the
+    selected pages and databases, then merge it.
+
+    The pull request branch YAML is the draft. The target branch YAML becomes
+    live only after merge; the setup dialog submits scope to that Git workflow
+    rather than storing another copy.
+  </Step>
+
+  <Step>
+    ### Wait for initial sync and ingestion
+
+    After GitHub reports the merge, ctx| performs the first Notion mirror and
+    starts repository ingestion. The connector reaches **Connected** when the
+    mirror succeeds. Repository indexing may continue afterwards; see
+    [Ingestion](/docs/connections/ingestion) for the indexing lifecycle.
+  </Step>
+</Steps>
+
+## Files in the repository
+
+Mirrored files live under `notion/`:
+
+- Pages: `notion/pages/<slug>--<id>/index.md`, with child pages nested under
+  their ancestors.
+- Databases: `notion/databases/<slug>--<id>/index.md`, `table.csv`, and
+  `rows/<slug>--<id>/index.md`.
+
+Paths include stable Notion IDs, so renaming a page or database does not create
+a second copy.
+
+Do not hand-edit generated content. Change scope through **Manage scope** and
+review the replacement configuration pull request.
+
+## Keeping content current
+
+Notion sends signed webhook events to ctx| when supported entities change.
+While the connector is live, ctx| validates the event against the Git scope,
+directly enqueues an OpenWorkflow entity-sync run, updates the affected files,
+and starts another repository ingestion. Incremental updates re-mirror the
+affected top-level resource (a page subtree or a database), not a single block.
+Events that arrive before the connector is live (including during initial sync)
+are skipped — the same trade-off as Linear and Confluence — rather than buffered
+in a Notion-specific dirty-entity table. Missed webhook events are not
+automatically backfilled: repair webhook delivery, then update the affected
+pages or databases in Notion again so fresh events are delivered, or use content
+retry / remirror after a failed initial sync.
+
+## Verify the complete flow
+
+1. Complete Notion OAuth and confirm the expected workspace appears.
+2. Share at least one page or database with the ctx| integration, then select
+   it in setup.
+3. Open and merge the generated `notion/config.yaml` pull request.
+4. Confirm the connector reaches **Connected** and the repository contains
+   generated files under `notion/`.
+5. Edit a mirrored page in Notion and confirm the matching Git file changes.
+6. Confirm the destination repository reaches an indexed state in ctx|.
+
+Steps 3 and 4 test the GitHub push webhook and initial mirror. Step 5 separately
+tests Notion webhook delivery.
+
+## Troubleshooting
+
+### Authorization fails
+
+Allow popups and retry. On fully managed ctx|, report persistent OAuth errors to
+support. On a self-hosted deployment, ask the operator to verify that Notion
+OAuth credentials are configured and that the callback URI matches exactly.
+
+### No pages or databases appear
+
+The integration can only list resources already shared with it. Share the page
+or database with the ctx| Notion app in Notion, then choose **Refresh Notion
+resources**. Empty search results usually mean a sharing problem, not a missing
+workspace.
+
+### No pull request appears
+
+Confirm that at least one page or database is selected and that the GitHub App
+has write access to the destination repository. Empty repositories are
+supported; ctx| initializes the default branch before opening the pull request.
+If setup reports that pull request creation failed, open the connector and
+choose **Retry configuration pull request**.
+
+### The connector stays on “Approve configuration”
+
+The configuration pull request must be merged, not merely approved. Confirm
+that `notion/config.yaml` reached the default branch and that GitHub webhooks
+for the ctx| GitHub App are healthy.
+
+### Content sync failed
+
+Open the connector and choose **Retry content sync**. This retries the mirror
+without opening another configuration pull request. If it fails again, ask the
+operator to check worker logs, Notion token refresh, GitHub write access, and
+outbound access to `api.notion.com`.
+
+### Changes in Notion do not arrive
+
+Initial sync can still succeed when webhooks are misconfigured. Ask the
+operator to verify the Notion integration webhook URL and signing secret. See
+[Self-host Notion](/docs/self-hosting/notion) for the exact settings.
+
+### Notion authorization was revoked
+
+Open the connector and authorize Notion again. Incremental updates stop while
+the workspace authorization is revoked. Pages unshared from the integration
+disappear from the searchable list; they remain in Git until you remove them
+from scope and merge the replacement configuration pull request.
+
+### Removing the connector
+
+Removing the connector deletes its ctx| authorization and repository binding
+from the connection record. It does not delete `notion/config.yaml`, generated
+files, or Git history from the destination repository; remove those in GitHub
+if they are no longer required.

--- a/apps/docs/content/docs/self-hosting/notion.mdx
+++ b/apps/docs/content/docs/self-hosting/notion.mdx
@@ -77,6 +77,11 @@ Pages are written as Markdown under `notion/pages/`. Databases are written
 under `notion/databases/`, with one `table.csv` snapshot per database and one
 Markdown file per row for task- and knowledge-oriented retrieval.
 
+## User guide
+
+See [Notion connector](/docs/connections/source-connectors/notion) for scope,
+repository layout, review workflow, and user-facing recovery steps.
+
 ## Related pages
 
 - [Connector context repository](/docs/connections/context-repository)

--- a/apps/ui/src/features/connectors/components/ConfluenceConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/ConfluenceConnectionCard.tsx
@@ -21,10 +21,7 @@ import {
   fetchAtlassianConnectorStatus,
   fetchOrgAtlassianOauth,
 } from "../queries/atlassian-connector"
-import {
-  CONNECTORS_PAGE_POLL_INTERVAL_MS,
-  orgConnectionsKeys,
-} from "../queries/org-connections"
+import { orgConnectionsKeys } from "../queries/org-connections"
 import { ConfluenceMark } from "./ConfluenceMark"
 import {
   ConnectorListItem,
@@ -57,7 +54,6 @@ export function ConfluenceConnectionCard({
   } = useQuery({
     queryKey: atlassianConnectorKeys.status(orgSlug, connectionId),
     queryFn: () => fetchAtlassianConnectorStatus(orgSlug, connectionId),
-    refetchInterval: CONNECTORS_PAGE_POLL_INTERVAL_MS,
   })
 
   const {
@@ -67,7 +63,6 @@ export function ConfluenceConnectionCard({
   } = useQuery({
     queryKey: atlassianConnectorKeys.orgAtlassianOauth(orgSlug, connectionId),
     queryFn: () => fetchOrgAtlassianOauth(orgSlug, connectionId),
-    refetchInterval: CONNECTORS_PAGE_POLL_INTERVAL_MS,
   })
 
   const oauthForCard = oauthSuccess ? orgOauthData : undefined

--- a/apps/ui/src/features/connectors/components/GithubConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/GithubConnectionCard.tsx
@@ -9,10 +9,7 @@ import { AlertDialog } from "@/components/ui/AlertDialog"
 import { Modal } from "@/components/ui/Modal"
 import { githubConnectorKeys } from "@/features/connectors/queries/github-connector"
 import { resolveConnectorHealth } from "../connectorHealth"
-import {
-  CONNECTORS_PAGE_POLL_INTERVAL_MS,
-  orgConnectionsKeys,
-} from "../queries/org-connections"
+import { orgConnectionsKeys } from "../queries/org-connections"
 import {
   ConnectorListItem,
   ConnectorRemoveMenu,
@@ -53,7 +50,6 @@ export function GithubConnectionCard({
     refetch,
   } = useQuery({
     queryKey: githubConnectorKeys.installation(orgSlug, connectionId),
-    refetchInterval: CONNECTORS_PAGE_POLL_INTERVAL_MS,
     queryFn: async () => {
       const qs = new URLSearchParams({ connectionId })
       const res = await fetch(

--- a/apps/ui/src/features/connectors/components/LinearConnectionCard.stories.tsx
+++ b/apps/ui/src/features/connectors/components/LinearConnectionCard.stories.tsx
@@ -13,7 +13,7 @@ const connected: LinearConnectorStatus = {
   installationStatus: "installed",
   workspaceName: "Acme Product",
   isGithubLinked: true,
-  selectedScopeCount: 4,
+  selectedScopeCount: null,
   setupPhase: "live",
   pendingConfigPullUrl: null,
   pendingConfigPrCreating: false,

--- a/apps/ui/src/features/connectors/components/LinearConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/LinearConnectionCard.tsx
@@ -13,6 +13,7 @@ import {
 import {
   getLinearCardPrimaryCta,
   getLinearSetupCurrentIndex,
+  getLinearStatusRefetchInterval,
   LINEAR_SETUP_STEPS,
 } from "../linear-setup-model"
 import {
@@ -46,6 +47,10 @@ export function LinearConnectionCard({
   const statusQuery = useQuery({
     queryKey: linearConnectorKeys.status(orgSlug, connectionId),
     queryFn: () => fetchLinearConnectorStatus(orgSlug, connectionId),
+    refetchInterval: (query) =>
+      query.state.status === "error"
+        ? false
+        : getLinearStatusRefetchInterval(query.state.data),
   })
   const removeMutation = useMutation({
     mutationFn: () => deleteLinearConnector(orgSlug, connectionId),

--- a/apps/ui/src/features/connectors/components/LinearConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/LinearConnectionCard.tsx
@@ -20,10 +20,7 @@ import {
   fetchLinearConnectorStatus,
   linearConnectorKeys,
 } from "../queries/linear-connector"
-import {
-  CONNECTORS_PAGE_POLL_INTERVAL_MS,
-  orgConnectionsKeys,
-} from "../queries/org-connections"
+import { orgConnectionsKeys } from "../queries/org-connections"
 import {
   ConnectorListItem,
   ConnectorRemoveMenu,
@@ -49,7 +46,6 @@ export function LinearConnectionCard({
   const statusQuery = useQuery({
     queryKey: linearConnectorKeys.status(orgSlug, connectionId),
     queryFn: () => fetchLinearConnectorStatus(orgSlug, connectionId),
-    refetchInterval: CONNECTORS_PAGE_POLL_INTERVAL_MS,
   })
   const removeMutation = useMutation({
     mutationFn: () => deleteLinearConnector(orgSlug, connectionId),
@@ -94,7 +90,11 @@ export function LinearConnectionCard({
         }
         workspace={connectorDash(status?.workspaceName)}
         scope={
-          status ? formatSelectedItemCount(status.selectedScopeCount) : "—"
+          status?.selectedScopeCount != null
+            ? formatSelectedItemCount(status.selectedScopeCount)
+            : status?.setupPhase === "live"
+              ? "Configured"
+              : "—"
         }
         syncRepository={formatSyncRepositoryLine(status?.syncTarget ?? null)}
         actionLabel={

--- a/apps/ui/src/features/connectors/components/NotionConnectionCard.stories.tsx
+++ b/apps/ui/src/features/connectors/components/NotionConnectionCard.stories.tsx
@@ -13,7 +13,7 @@ const statusComplete = {
   installationStatus: "installed",
   workspaceName: "Acme",
   isGithubLinked: true,
-  selectedResourceCount: 2,
+  selectedResourceCount: null,
   syncTargetConfigured: true,
   setupPhase: "live",
   pendingConfigPullUrl: null,

--- a/apps/ui/src/features/connectors/components/NotionConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/NotionConnectionCard.tsx
@@ -70,8 +70,7 @@ export function NotionConnectionCard({
     onError: (e: Error) => toast.error(e.message),
   })
   const failureAction = status ? getNotionFailureAction(status) : null
-  const live =
-    status?.setupPhase === "live" && (status.selectedResourceCount ?? 0) > 0
+  const live = status?.setupPhase === "live"
   const health = resolveConnectorHealth({
     statusError: isError,
     checking: isPending || !status,
@@ -95,7 +94,11 @@ export function NotionConnectionCard({
         }
         workspace={connectorDash(status?.workspaceName)}
         scope={
-          status ? formatSelectedItemCount(status.selectedResourceCount) : "—"
+          status?.selectedResourceCount != null
+            ? formatSelectedItemCount(status.selectedResourceCount)
+            : live
+              ? "Configured"
+              : "—"
         }
         syncRepository={formatSyncRepositoryLine(status?.syncTarget ?? null)}
         actionLabel={
@@ -124,7 +127,7 @@ export function NotionConnectionCard({
         {!failureAction &&
         status &&
         status.setupPhase !== "live" &&
-        status.selectedResourceCount > 0 ? (
+        (status.selectedResourceCount ?? 0) > 0 ? (
           <p className="text-xs text-muted-foreground">
             Merge the open pull request for{" "}
             <code className="rounded-none bg-muted px-1 py-0.5 text-[11px]">

--- a/apps/ui/src/features/connectors/components/SlackConnectionCard.tsx
+++ b/apps/ui/src/features/connectors/components/SlackConnectionCard.tsx
@@ -7,10 +7,7 @@ import { toast } from "sonner"
 import { AlertDialog } from "@/components/ui/AlertDialog"
 import { Modal } from "@/components/ui/Modal"
 import { resolveConnectorHealth } from "../connectorHealth"
-import {
-  CONNECTORS_PAGE_POLL_INTERVAL_MS,
-  orgConnectionsKeys,
-} from "../queries/org-connections"
+import { orgConnectionsKeys } from "../queries/org-connections"
 import {
   deleteSlackConnector,
   fetchSlackConnectorStatus,
@@ -46,7 +43,6 @@ export function SlackConnectionCard({
   } = useQuery({
     queryKey: slackConnectorKeys.status(orgSlug, connectionId),
     queryFn: () => fetchSlackConnectorStatus(orgSlug, connectionId),
-    refetchInterval: CONNECTORS_PAGE_POLL_INTERVAL_MS,
   })
 
   const removeMutation = useMutation({

--- a/apps/ui/src/features/connectors/components/linear-setup/LinearSetupWizard.tsx
+++ b/apps/ui/src/features/connectors/components/linear-setup/LinearSetupWizard.tsx
@@ -8,6 +8,7 @@ import { Modal } from "@/components/ui/Modal"
 import { Spinner } from "@/components/ui/spinner"
 import {
   getLinearSetupCurrentIndex,
+  getLinearStatusRefetchInterval,
   getLinearWizardBodyId,
   LINEAR_SETUP_STEPS,
 } from "../../linear-setup-model"
@@ -54,16 +55,8 @@ export function LinearSetupWizard({
     queryFn: () => fetchLinearConnectorStatus(orgSlug, connectionId),
     enabled: isOpen && Boolean(connectionId),
     refetchInterval: (query) => {
-      if (!isOpen) return false
-      const status = query.state.data as LinearConnectorStatus | undefined
-      if (
-        status?.pendingConfigPrCreating ||
-        status?.setupPhase === "awaiting_merge" ||
-        status?.setupPhase === "initial_sync"
-      ) {
-        return 2000
-      }
-      return false
+      if (!isOpen || query.state.status === "error") return false
+      return getLinearStatusRefetchInterval(query.state.data)
     },
   })
 

--- a/apps/ui/src/features/connectors/linear-setup-model.test.ts
+++ b/apps/ui/src/features/connectors/linear-setup-model.test.ts
@@ -42,12 +42,19 @@ describe("Linear setup model", () => {
       "target",
     )
     expect(
-      getLinearWizardBodyId({ ...liveStatus, selectedScopeCount: 0 }),
+      getLinearWizardBodyId({
+        ...liveStatus,
+        selectedScopeCount: null,
+        setupPhase: "draft",
+      }),
     ).toBe("scope")
     expect(
       getLinearWizardBodyId({ ...liveStatus, setupPhase: "awaiting_merge" }),
     ).toBe("merge")
     expect(getLinearWizardBodyId(liveStatus)).toBe("complete")
+    expect(
+      getLinearWizardBodyId({ ...liveStatus, selectedScopeCount: null }),
+    ).toBe("complete")
     expect(getLinearCardPrimaryCta(liveStatus)).toEqual({
       kind: "manage_scope",
       label: "Manage scope",

--- a/apps/ui/src/features/connectors/linear-setup-model.test.ts
+++ b/apps/ui/src/features/connectors/linear-setup-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   getLinearCardPrimaryCta,
   getLinearSetupCurrentIndex,
+  getLinearStatusRefetchInterval,
   getLinearWizardBodyId,
   LINEAR_SETUP_STEPS,
 } from "./linear-setup-model"
@@ -23,6 +24,43 @@ const liveStatus = {
     branch: "main",
   },
 } satisfies LinearConnectorStatus
+
+describe("Linear status polling", () => {
+  it("polls only while persisted setup is transitional", () => {
+    expect(
+      getLinearStatusRefetchInterval({
+        pendingConfigPrCreating: true,
+        setupPhase: "draft",
+      }),
+    ).toBe(2000)
+    expect(
+      getLinearStatusRefetchInterval({
+        pendingConfigPrCreating: false,
+        setupPhase: "awaiting_merge",
+      }),
+    ).toBe(2000)
+    expect(
+      getLinearStatusRefetchInterval({
+        pendingConfigPrCreating: false,
+        setupPhase: "initial_sync",
+      }),
+    ).toBe(2000)
+  })
+
+  it.each([
+    "draft",
+    "live",
+    "config_failed",
+    "sync_failed",
+  ] as const)("stops polling in %s", (setupPhase) => {
+    expect(
+      getLinearStatusRefetchInterval({
+        pendingConfigPrCreating: false,
+        setupPhase,
+      }),
+    ).toBe(false)
+  })
+})
 
 describe("Linear setup model", () => {
   it("routes each incomplete server state to the first unfinished step", () => {

--- a/apps/ui/src/features/connectors/linear-setup-model.ts
+++ b/apps/ui/src/features/connectors/linear-setup-model.ts
@@ -15,6 +15,21 @@ function stepIndex(id: LinearSetupStepId): number {
   return LINEAR_SETUP_STEPS.findIndex((step) => step.id === id)
 }
 
+export function getLinearStatusRefetchInterval(
+  status:
+    | Pick<LinearConnectorStatus, "pendingConfigPrCreating" | "setupPhase">
+    | undefined,
+): number | false {
+  if (
+    status?.pendingConfigPrCreating ||
+    status?.setupPhase === "awaiting_merge" ||
+    status?.setupPhase === "initial_sync"
+  ) {
+    return 2000
+  }
+  return false
+}
+
 export function getLinearSetupCurrentIndex(
   status: LinearConnectorStatus,
 ): number {

--- a/apps/ui/src/features/connectors/linear-setup-model.ts
+++ b/apps/ui/src/features/connectors/linear-setup-model.ts
@@ -29,8 +29,8 @@ export function getLinearSetupCurrentIndex(
   ) {
     return stepIndex("scope")
   }
-  // Git-backed selectedScopeCount stays 0 while the config PR is creating and
-  // can stay 0 until the PR-head YAML is readable — do not bounce to scope.
+  // Git scope is loaded only inside setup. Status polling must stay DB-only, so
+  // the count is null and lifecycle state drives progress here.
   if (
     status.pendingConfigPrCreating ||
     status.pendingConfigPullUrl ||
@@ -41,9 +41,8 @@ export function getLinearSetupCurrentIndex(
   ) {
     return stepIndex("merge")
   }
-  if (status.selectedScopeCount === 0) return stepIndex("scope")
   if (status.setupPhase === "live") return LINEAR_SETUP_STEPS.length
-  return stepIndex("merge")
+  return stepIndex("scope")
 }
 
 export function getLinearWizardBodyId(

--- a/apps/ui/src/features/connectors/notion-setup-model.test.ts
+++ b/apps/ui/src/features/connectors/notion-setup-model.test.ts
@@ -23,7 +23,7 @@ describe("Notion setup model", () => {
   it("shows completion when initial setup becomes live", () => {
     expect(
       shouldShowNotionSetupComplete(
-        { setupPhase: "live", selectedResourceCount: 2 },
+        { setupPhase: "live", selectedResourceCount: null },
         false,
       ),
     ).toBe(true)
@@ -36,6 +36,19 @@ describe("Notion setup model", () => {
         true,
       ),
     ).toBe(false)
+  })
+
+  it("uses lifecycle state when status omits the Git-backed count", () => {
+    const live = {
+      isGithubLinked: true,
+      syncTargetConfigured: true,
+      selectedResourceCount: null,
+      setupPhase: "live",
+      pendingConfigPullUrl: null,
+    }
+
+    expect(getNotionSetupCurrentIndex(live)).toBe(NOTION_SETUP_STEPS.length)
+    expect(getNotionCardCtaLabel(live)).toBe("Manage scope")
   })
 
   it("treats reordered scope as unchanged", () => {

--- a/apps/ui/src/features/connectors/notion-setup-model.ts
+++ b/apps/ui/src/features/connectors/notion-setup-model.ts
@@ -2,7 +2,7 @@ import type { NotionResource } from "./types"
 
 type SetupStatus = {
   setupPhase: string
-  selectedResourceCount: number
+  selectedResourceCount: number | null
   pendingConfigPullUrl?: string | null
   pendingConfigPrCreating?: boolean
 }
@@ -44,8 +44,8 @@ export function getNotionSetupCurrentIndex(
   ) {
     return 2
   }
-  // Git-backed selectedResourceCount stays 0 while the config PR is creating
-  // and can stay 0 until the PR-head YAML is readable — do not bounce to scope.
+  // Git scope is loaded only inside setup. Status polling must stay DB-only, so
+  // the count is null and lifecycle state drives progress here.
   if (
     status.pendingConfigPrCreating ||
     status.pendingConfigPullUrl ||
@@ -56,14 +56,13 @@ export function getNotionSetupCurrentIndex(
   ) {
     return 3
   }
-  if (status.selectedResourceCount === 0) return 2
   if (status.setupPhase === "live") return NOTION_SETUP_STEPS.length
-  return 3
+  return 2
 }
 
 export function getNotionCardCtaLabel(status: SetupStatus): string {
   if (getNotionFailureAction(status)) return "Review failure"
-  if (status.setupPhase === "live" && status.selectedResourceCount > 0) {
+  if (status.setupPhase === "live") {
     return "Manage scope"
   }
   if (
@@ -96,9 +95,5 @@ export function shouldShowNotionSetupComplete(
   status: SetupStatus,
   manageScope: boolean,
 ): boolean {
-  return (
-    !manageScope &&
-    status.setupPhase === "live" &&
-    status.selectedResourceCount > 0
-  )
+  return !manageScope && status.setupPhase === "live"
 }

--- a/apps/ui/src/features/connectors/queries/linear-connector.ts
+++ b/apps/ui/src/features/connectors/queries/linear-connector.ts
@@ -28,7 +28,8 @@ export type LinearConnectorStatus = {
   installationStatus: string | null
   workspaceName: string | null
   isGithubLinked: boolean
-  selectedScopeCount: number
+  /** Null on status reads; exact scope is loaded only when setup is opened. */
+  selectedScopeCount: number | null
   setupPhase: LinearSetupPhase
   pendingConfigPullUrl: string | null
   pendingConfigPrCreating: boolean

--- a/apps/ui/src/features/connectors/queries/org-connections.ts
+++ b/apps/ui/src/features/connectors/queries/org-connections.ts
@@ -5,9 +5,6 @@ export type OrgConnectionListItem = {
   updatedAt: string
 }
 
-/** Refetch connector data on this interval while the org connectors page is open. */
-export const CONNECTORS_PAGE_POLL_INTERVAL_MS = 3000
-
 export const orgConnectionsKeys = {
   list: (orgSlug: string) => ["org-connections", orgSlug] as const,
 }

--- a/apps/ui/src/features/connectors/types.ts
+++ b/apps/ui/src/features/connectors/types.ts
@@ -102,7 +102,8 @@ export interface NotionConnectorStatus {
   installationStatus: string | null
   workspaceName: string | null
   isGithubLinked: boolean
-  selectedResourceCount: number
+  /** Null on status reads; exact scope is loaded only when setup is opened. */
+  selectedResourceCount: number | null
   syncTargetConfigured: boolean
   setupPhase: string
   pendingConfigPullUrl: string | null

--- a/apps/ui/src/routes/$orgSlug.connectors.tsx
+++ b/apps/ui/src/routes/$orgSlug.connectors.tsx
@@ -32,7 +32,6 @@ import { GithubSelfHostedWizardModal } from "@/features/connectors/components/Gi
 import { SlackSetupDialog } from "@/features/connectors/components/SlackSetupDialog"
 import { atlassianConnectorKeys } from "@/features/connectors/queries/atlassian-connector"
 import {
-  CONNECTORS_PAGE_POLL_INTERVAL_MS,
   fetchOrgConnections,
   orgConnectionsKeys,
   sortOrgConnectionsForDisplay,
@@ -111,15 +110,12 @@ export function ConnectorsPageContent({ orgSlug }: { orgSlug: string }) {
     string | undefined
   >(undefined)
 
-  useGithubConnectorBootstrap(orgSlug, {
-    refetchInterval: CONNECTORS_PAGE_POLL_INTERVAL_MS,
-  })
+  useGithubConnectorBootstrap(orgSlug)
 
   const { data: connections, isPending: connectionsPending } = useQuery({
     queryKey: orgConnectionsKeys.list(orgSlug),
     queryFn: () => fetchOrgConnections(orgSlug),
     enabled: true,
-    refetchInterval: CONNECTORS_PAGE_POLL_INTERVAL_MS,
   })
 
   const items = sortOrgConnectionsForDisplay(connections ?? [])


### PR DESCRIPTION
## Summary
- add hosted and self-hosted Notion connector documentation with the relevant cross-links
- make Linear and Notion status reads DB-only and remove stable connector-page polling
- use connector lifecycle state when Git-backed scope counts are intentionally omitted

## Test plan
- [x] `pnpm --filter @ctxpipe/backend exec vitest run src/routes/v1/connectors-linear.test.ts src/routes/v1/connectors-notion.test.ts`
- [x] `pnpm --filter @ctxpipe/ui exec vitest run src/features/connectors/linear-setup-model.test.ts src/features/connectors/notion-setup-model.test.ts`
- [x] `pnpm --filter @ctxpipe/ui build`
- [x] Biome lint on all hotfix files
- [ ] Full backend build remains blocked by existing repository-wide TypeScript errors outside this change