### PR TITLE
Fix Slack OAuth scope drift diagnostics

### DIFF
--- a/.ai/memory/lessons-learned.md
+++ b/.ai/memory/lessons-learned.md
@@ -622,3 +622,9 @@ Highest-priority confirmed rules for agents. Migrated from former `patterns.md` 
 - **Date:** 2026-08-20
 - **Source:** production Railway incident diagnosis (GitHub quota exhaustion → idle transaction termination → pg-pool acquisition timeouts)
 
+### Distributed OAuth connectors require a clean external-workspace acceptance test
+- **Rule:** Never treat a provider workspace that already hosts the development app as proof that a new customer installation works. OAuth grants can be workspace-specific, additive, and contaminated by dashboard installs or earlier re-authorisations; Slack can also silently suppress Events API delivery when the installed token lacks an event scope. Before shipping a distributed connector, install it through the product OAuth flow into a fresh second workspace, inspect the returned and live token scopes, exercise the real webhook-to-durable-output path, and test re-authorisation after a required scope changes. Keep provider app configuration in a committed manifest and CI-check its scopes against the backend request.
+- **Category:** testing
+- **Date:** 2026-08-21
+- **Source:** user-confirmed Slack connector production incident (ctxpipe workspace passed because its historical grant masked the fresh Tru Rec installation path)
+

--- a/.changeset/slack-oauth-scope-diagnostics.md
+++ b/.changeset/slack-oauth-scope-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Ship explicit Slack app-mention permissions, installation diagnostics, and safe OAuth failure handling for hosted and self-hosted connectors.

--- a/apps/backend/src/routes/v1/connectors-slack.test.ts
+++ b/apps/backend/src/routes/v1/connectors-slack.test.ts
@@ -8,6 +8,21 @@ const getTargetMock = vi.hoisted(() => vi.fn())
 const bindRepositoryMock = vi.hoisted(() => vi.fn())
 const enqueueIngestionMock = vi.hoisted(() => vi.fn())
 const assertOAuthConfiguredMock = vi.hoisted(() => vi.fn())
+const exchangeOAuthCodeMock = vi.hoisted(() => vi.fn())
+const verifyInstallationMock = vi.hoisted(() => vi.fn())
+const upsertConnectionMock = vi.hoisted(() => vi.fn())
+const SlackOAuthMissingScopesErrorMock = vi.hoisted(
+  () =>
+    class SlackOAuthMissingScopesError extends Error {
+      readonly missingScopes: string[]
+
+      constructor(missingScopes: string[]) {
+        super(`Missing Slack scopes: ${missingScopes.join(", ")}`)
+        this.name = "SlackOAuthMissingScopesError"
+        this.missingScopes = missingScopes
+      }
+    },
+)
 const SlackRepositoryNotFoundErrorMock = vi.hoisted(
   () =>
     class SlackRepositoryNotFoundError extends Error {
@@ -40,7 +55,7 @@ vi.mock("../../models/slack-connector.js", () => ({
   SLACK_SETUP_PHASES: ["draft", "live"] as const,
   SlackRepositoryNotFoundError: SlackRepositoryNotFoundErrorMock,
   SlackTeamAlreadyConnectedError: class SlackTeamAlreadyConnectedError extends Error {},
-  upsertSlackConnectionFromOAuth: vi.fn(),
+  upsertSlackConnectionFromOAuth: upsertConnectionMock,
 }))
 vi.mock("../../observability/logger.js", () => ({
   getLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
@@ -50,14 +65,21 @@ vi.mock("../../openworkflow/enqueue-repository-ingestion.js", () => ({
 }))
 vi.mock("../../services/slack/client.js", () => ({
   assertSlackOAuthConfigured: assertOAuthConfiguredMock,
-  exchangeSlackOAuthCode: vi.fn(),
+  botTokenFromConnection: vi.fn(() => "xoxb-test"),
+  exchangeSlackOAuthCode: exchangeOAuthCodeMock,
   fetchSlackUserProfile: vi.fn(),
   getSlackOAuthAuthorizeUrl: vi.fn(
-    () => "https://slack.com/oauth/v2/authorize",
+    ({ state }: { state: string }) =>
+      `https://slack.com/oauth/v2/authorize?state=${state}`,
   ),
+  SlackOAuthMissingScopesError: SlackOAuthMissingScopesErrorMock,
+  verifySlackInstallation: verifyInstallationMock,
 }))
 
-import { slackConnectorRoutes } from "./connectors-slack.js"
+import {
+  slackConnectorRoutes,
+  slackOAuthCallbackRoutes,
+} from "./connectors-slack.js"
 
 const connection = {
   id: "con_1",
@@ -78,6 +100,10 @@ function testApp() {
     await next()
   })
   app.route("/:orgSlug/api/v1/connectors/slack", slackConnectorRoutes as never)
+  app.route(
+    "/api/v1/connectors/slack",
+    slackOAuthCallbackRoutes as never,
+  )
   return app
 }
 
@@ -107,6 +133,17 @@ describe("Slack connector routes", () => {
       branch: "main",
       enabled: true,
       setupPhase: "live",
+    })
+    verifyInstallationMock.mockResolvedValue({
+      appId: "A_CTXPIPE",
+      storedTeamId: "T_TRU",
+      storedBotUserId: "U_BOT",
+      reportedTeamId: "T_TRU",
+      reportedBotUserId: "U_BOT",
+      botId: "B_BOT",
+      grantedScopes: ["app_mentions:read", "chat:write"],
+      missingScopes: ["channels:history"],
+      identityMatches: true,
     })
   })
 
@@ -153,6 +190,53 @@ describe("Slack connector routes", () => {
     await expect(response.json()).resolves.toMatchObject({
       code: "slack_oauth_not_configured",
     })
+  })
+
+  it("verifies the live Slack token without returning the token", async () => {
+    const response = await testApp().request(
+      "/acme/api/v1/connectors/slack/verify?connectionId=con_1",
+      { method: "POST" },
+    )
+
+    expect(response.status).toBe(200)
+    const result = await response.json()
+    expect(result).toMatchObject({
+      appId: "A_CTXPIPE",
+      storedTeamId: "T_TRU",
+      reportedTeamId: "T_TRU",
+      grantedScopes: ["app_mentions:read", "chat:write"],
+      missingScopes: ["channels:history"],
+      identityMatches: true,
+    })
+    expect(JSON.stringify(result)).not.toContain("xoxb-test")
+    expect(verifyInstallationMock).toHaveBeenCalledWith({
+      connection,
+      botToken: "xoxb-test",
+    })
+  })
+
+  it("relays missing OAuth scopes without persisting the token", async () => {
+    const startResponse = await testApp().request(
+      "/acme/api/v1/connectors/slack/oauth/start",
+    )
+    const { authorizationUrl } = (await startResponse.json()) as {
+      authorizationUrl: string
+    }
+    const state = new URL(authorizationUrl).searchParams.get("state")
+    expect(state).toBeTruthy()
+    exchangeOAuthCodeMock.mockRejectedValue(
+      new SlackOAuthMissingScopesErrorMock(["app_mentions:read"]),
+    )
+
+    const response = await testApp().request(
+      `/api/v1/connectors/slack/oauth/callback?code=oauth-code&state=${encodeURIComponent(state ?? "")}`,
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain(
+      "Slack did not grant required permissions: app_mentions:read",
+    )
+    expect(upsertConnectionMock).not.toHaveBeenCalled()
   })
 
   it("binds a context repository and reports the connector as live", async () => {

--- a/apps/backend/src/routes/v1/connectors-slack.ts
+++ b/apps/backend/src/routes/v1/connectors-slack.ts
@@ -19,9 +19,12 @@ import { getLogger } from "../../observability/logger.js"
 import { enqueueRepositoryIngestionWorkflow } from "../../openworkflow/enqueue-repository-ingestion.js"
 import {
   assertSlackOAuthConfigured,
+  botTokenFromConnection,
   exchangeSlackOAuthCode,
   fetchSlackUserProfile,
   getSlackOAuthAuthorizeUrl,
+  SlackOAuthMissingScopesError,
+  verifySlackInstallation,
 } from "../../services/slack/client.js"
 
 const ErrorResponseSchema = z
@@ -62,6 +65,20 @@ const SlackStatusResponseSchema = z
       .nullable(),
   })
   .openapi("SlackConnectorStatusResponse")
+
+const SlackVerificationResponseSchema = z
+  .object({
+    appId: z.string().nullable(),
+    storedTeamId: z.string().nullable(),
+    storedBotUserId: z.string().nullable(),
+    reportedTeamId: z.string().nullable(),
+    reportedBotUserId: z.string().nullable(),
+    botId: z.string().nullable(),
+    grantedScopes: z.array(z.string()),
+    missingScopes: z.array(z.string()),
+    identityMatches: z.boolean(),
+  })
+  .openapi("SlackConnectorVerificationResponse")
 
 const getOAuthStartRoute = createRoute({
   method: "get",
@@ -109,6 +126,9 @@ const getOAuthCallbackRoute = createRoute({
     409: {
       description: "Slack workspace already connected to another organization",
     },
+    502: {
+      description: "Slack OAuth token exchange failed",
+    },
   },
 })
 
@@ -132,6 +152,40 @@ const getStatusRoute = createRoute({
     401: {
       content: { "application/json": { schema: ErrorResponseSchema } },
       description: "Unauthorized",
+    },
+  },
+})
+
+const verifyInstallationRoute = createRoute({
+  method: "post",
+  path: "/verify",
+  request: { query: ConnectionIdQuerySchema },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: SlackVerificationResponseSchema },
+      },
+      description: "Verify Slack token identity and granted bot scopes",
+    },
+    400: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Multiple Slack connections; pass connectionId",
+    },
+    401: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unauthorized",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unknown connectionId",
+    },
+    409: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Slack connection is not installed",
+    },
+    502: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Slack token verification failed",
     },
   },
 })
@@ -425,10 +479,38 @@ export const slackOAuthCallbackRoutes = new OpenAPIHono<AppEnv>().openapi(
     if (!state || state.userId !== user.id) {
       return c.json({ error: "Invalid Slack OAuth state" }, 400)
     }
-    const token = await exchangeSlackOAuthCode({
-      env,
-      code: query.code,
-    })
+    let token: Awaited<ReturnType<typeof exchangeSlackOAuthCode>>
+    try {
+      token = await exchangeSlackOAuthCode({
+        env,
+        code: query.code,
+      })
+    } catch (error) {
+      if (error instanceof SlackOAuthMissingScopesError) {
+        getLogger().warn("slack_oauth_missing_required_scopes", {
+          orgId: state.orgId,
+          missingScopes: error.missingScopes,
+        })
+        return slackSetupRelayResponse(
+          {
+            orgSlug: state.orgSlug,
+            error: `Slack did not grant required permissions: ${error.missingScopes.join(", ")}`,
+          },
+          400,
+        )
+      }
+      getLogger().error(
+        error instanceof Error ? error : new Error(String(error)),
+        { step: "slack.oauth.exchange", orgId: state.orgId },
+      )
+      return slackSetupRelayResponse(
+        {
+          orgSlug: state.orgSlug,
+          error: "Slack authorization failed. Please try again.",
+        },
+        502,
+      )
+    }
     const teamId = token.team?.id
     const botToken = token.access_token
     if (!teamId || !botToken) {
@@ -530,6 +612,45 @@ slackConnectorRoutes
       },
       200,
     )
+  })
+  .openapi(verifyInstallationRoute, async (c) => {
+    if (!c.get("user") || !c.get("session")) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+    const orgId = c.get("orgId")
+    if (!orgId) return c.json({ error: "Unauthorized" }, 401)
+    const { connectionId } = ConnectionIdQuerySchema.parse({
+      connectionId: c.req.query("connectionId") ?? undefined,
+    })
+    const installed = await resolveInstalledSlack(orgId, connectionId ?? null)
+    if ("error" in installed) {
+      return c.json({ error: installed.error }, installed.status)
+    }
+    try {
+      const verification = await verifySlackInstallation({
+        connection: installed.connection,
+        botToken: botTokenFromConnection(installed.connection, c.var.env),
+      })
+      getLogger().info("slack_installation_verified", {
+        connectionId: installed.connection.id,
+        appId: verification.appId,
+        storedTeamId: verification.storedTeamId,
+        reportedTeamId: verification.reportedTeamId,
+        identityMatches: verification.identityMatches,
+        grantedScopes: verification.grantedScopes,
+        missingScopes: verification.missingScopes,
+      })
+      return c.json(verification, 200)
+    } catch (error) {
+      getLogger().error(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          step: "slack.installation.verify",
+          connectionId: installed.connection.id,
+        },
+      )
+      return c.json({ error: "Slack token verification failed" }, 502)
+    }
   })
   .openapi(patchConfigRoute, async (c) => {
     if (!c.get("user") || !c.get("session")) {

--- a/apps/backend/src/routes/webhooks/slack/slack.test.ts
+++ b/apps/backend/src/routes/webhooks/slack/slack.test.ts
@@ -8,6 +8,7 @@ const revokeMock = vi.hoisted(() => vi.fn())
 const runWorkflowMock = vi.hoisted(() => vi.fn())
 const verifySignatureMock = vi.hoisted(() => vi.fn())
 const postStatusMock = vi.hoisted(() => vi.fn())
+const logInfoMock = vi.hoisted(() => vi.fn())
 
 vi.mock("../../../models/slack-connector.js", () => ({
   getSlackConnectionByTeamId: getConnectionMock,
@@ -17,7 +18,7 @@ vi.mock("../../../models/slack-connector.js", () => ({
 vi.mock("../../../observability/logger.js", () => ({
   getLogger: () => ({
     error: vi.fn(),
-    info: vi.fn(),
+    info: logInfoMock,
     warn: vi.fn(),
   }),
 }))
@@ -66,6 +67,7 @@ function mentionRequest(overrides?: {
     },
     body: JSON.stringify({
       type: "event_callback",
+      api_app_id: "A_CTXPIPE",
       team_id: "T1",
       event_id: "Ev1",
       event: {
@@ -122,6 +124,12 @@ describe("Slack webhook", () => {
       },
     )
     expect(postStatusMock).not.toHaveBeenCalled()
+    expect(logInfoMock).toHaveBeenCalledWith("slack_webhook_event_received", {
+      apiAppId: "A_CTXPIPE",
+      teamId: "T1",
+      eventType: "app_mention",
+      eventId: "Ev1",
+    })
   })
 
   it("posts a terminal failure after 200 when enqueue fails", async () => {

--- a/apps/backend/src/routes/webhooks/slack/slack.ts
+++ b/apps/backend/src/routes/webhooks/slack/slack.ts
@@ -19,6 +19,7 @@ import { verifySlackRequestSignature } from "../../../services/slack/verify-sign
 const SlackEventEnvelopeSchema = z.object({
   type: z.string(),
   challenge: z.string().optional(),
+  api_app_id: z.string().optional(),
   team_id: z.string().optional(),
   event_id: z.string().optional(),
   event: z
@@ -80,6 +81,12 @@ export function registerSlackWebhookRoute(app: OpenAPIHono<AppEnv>) {
 
     const event = parsed.data.event
     const teamId = parsed.data.team_id
+    getLogger().info("slack_webhook_event_received", {
+      apiAppId: parsed.data.api_app_id,
+      teamId,
+      eventType: event.type,
+      eventId: parsed.data.event_id,
+    })
 
     if (event.type === "app_uninstalled" || event.type === "tokens_revoked") {
       if (teamId) {

--- a/apps/backend/src/services/slack/client.test.ts
+++ b/apps/backend/src/services/slack/client.test.ts
@@ -1,5 +1,165 @@
-import { describe, expect, it } from "vitest"
-import { capSlackThreadMessages } from "./client.js"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { Env } from "../../config/env.js"
+import {
+  capSlackThreadMessages,
+  exchangeSlackOAuthCode,
+  getSlackOAuthAuthorizeUrl,
+  type SlackOAuthMissingScopesError,
+  verifySlackInstallation,
+} from "./client.js"
+import { SLACK_BOT_SCOPES } from "./scopes.js"
+
+const env = {
+  AUTH_BASE_URL: "https://ctxpipe.example",
+  SLACK_CLIENT_ID: "slack-client",
+  SLACK_CLIENT_SECRET: "slack-secret",
+} as Env
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("Slack OAuth client", () => {
+  it("requests every required bot scope, including app mentions", () => {
+    const url = new URL(
+      getSlackOAuthAuthorizeUrl({ env, state: "signed-state" }),
+    )
+
+    expect(url.origin + url.pathname).toBe(
+      "https://slack.com/oauth/v2/authorize",
+    )
+    expect(url.searchParams.get("scope")?.split(",")).toEqual([
+      "app_mentions:read",
+      "channels:history",
+      "channels:read",
+      "groups:history",
+      "groups:read",
+      "chat:write",
+      "files:read",
+      "users:read",
+    ])
+    expect(url.searchParams.get("state")).toBe("signed-state")
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://ctxpipe.example/api/v1/connectors/slack/oauth/callback",
+    )
+  })
+
+  it("rejects a token missing a required bot scope", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            access_token: "xoxb-test",
+            scope: SLACK_BOT_SCOPES.filter(
+              (scope) => scope !== "app_mentions:read",
+            ).join(","),
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+
+    await expect(
+      exchangeSlackOAuthCode({ env, code: "oauth-code" }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<SlackOAuthMissingScopesError>>({
+        name: "SlackOAuthMissingScopesError",
+        missingScopes: ["app_mentions:read"],
+      }),
+    )
+  })
+
+  it("accepts additive scopes returned in any order", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            access_token: "xoxb-test",
+            scope: ["reactions:read", ...SLACK_BOT_SCOPES]
+              .reverse()
+              .join(","),
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+
+    await expect(
+      exchangeSlackOAuthCode({ env, code: "oauth-code" }),
+    ).resolves.toMatchObject({ access_token: "xoxb-test" })
+  })
+
+  it("verifies an installed bot identity and its live token scopes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            team_id: "T_TRU",
+            user_id: "U_BOT",
+            bot_id: "B_BOT",
+          }),
+          {
+            status: 200,
+            headers: {
+              "x-oauth-scopes":
+                "chat:write,app_mentions:read,channels:history",
+            },
+          },
+        ),
+      ),
+    )
+
+    await expect(
+      verifySlackInstallation({
+        connection: {
+          id: "con_tru",
+          orgId: "org_tru",
+          botTokenEnc: "unused",
+          teamId: "T_TRU",
+          teamName: "Tru Rec",
+          botUserId: "U_BOT",
+          botHandle: "ctxpipe",
+          appId: "A_CTXPIPE",
+          ownerUserId: "user_1",
+          status: "installed",
+          lastEventPayload: null,
+          repositoryId: "repo_1",
+          branch: "main",
+          enabled: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        botToken: "xoxb-test",
+      }),
+    ).resolves.toEqual({
+      appId: "A_CTXPIPE",
+      storedTeamId: "T_TRU",
+      storedBotUserId: "U_BOT",
+      reportedTeamId: "T_TRU",
+      reportedBotUserId: "U_BOT",
+      botId: "B_BOT",
+      grantedScopes: [
+        "app_mentions:read",
+        "channels:history",
+        "chat:write",
+      ],
+      missingScopes: [
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "files:read",
+        "users:read",
+      ],
+      identityMatches: true,
+    })
+  })
+})
 
 describe("capSlackThreadMessages", () => {
   it("keeps short threads intact", () => {

--- a/apps/backend/src/services/slack/client.ts
+++ b/apps/backend/src/services/slack/client.ts
@@ -4,7 +4,11 @@ import {
   parseSlackConnectionStored,
 } from "../../lib/connection-config.js"
 import type { SlackConnectionShape } from "../../models/connection-rows.js"
-import { slackBotScopeString } from "./scopes.js"
+import {
+  missingSlackBotScopes,
+  parseSlackScopes,
+  slackBotScopeString,
+} from "./scopes.js"
 
 const SLACK_API = "https://slack.com/api"
 
@@ -35,6 +39,70 @@ export class SlackApiError extends Error {
     this.slackError = input.slackError
     this.status = input.status
     this.retryAfterSeconds = input.retryAfterSeconds
+  }
+}
+
+export class SlackOAuthMissingScopesError extends Error {
+  readonly missingScopes: string[]
+
+  constructor(missingScopes: string[]) {
+    super(
+      `Slack OAuth token is missing required bot scopes: ${missingScopes.join(", ")}`,
+    )
+    this.name = "SlackOAuthMissingScopesError"
+    this.missingScopes = missingScopes
+  }
+}
+
+export type SlackInstallationVerification = {
+  appId: string | null
+  storedTeamId: string | null
+  storedBotUserId: string | null
+  reportedTeamId: string | null
+  reportedBotUserId: string | null
+  botId: string | null
+  grantedScopes: string[]
+  missingScopes: string[]
+  identityMatches: boolean
+}
+
+export async function verifySlackInstallation(input: {
+  connection: SlackConnectionShape
+  botToken: string
+}): Promise<SlackInstallationVerification> {
+  const res = await fetch(`${SLACK_API}/auth.test`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${input.botToken}` },
+  })
+  const json = (await res.json()) as {
+    ok: boolean
+    error?: string
+    team_id?: string
+    user_id?: string
+    bot_id?: string
+  }
+  if (!res.ok || !json.ok) {
+    throw new SlackApiError({
+      slackError: json.error ?? `http_${res.status}`,
+      status: res.status,
+    })
+  }
+
+  const grantedScopes = parseSlackScopes(res.headers.get("x-oauth-scopes"))
+  const reportedTeamId = json.team_id ?? null
+  const reportedBotUserId = json.user_id ?? null
+  return {
+    appId: input.connection.appId,
+    storedTeamId: input.connection.teamId,
+    storedBotUserId: input.connection.botUserId,
+    reportedTeamId,
+    reportedBotUserId,
+    botId: json.bot_id ?? null,
+    grantedScopes,
+    missingScopes: missingSlackBotScopes(grantedScopes),
+    identityMatches:
+      reportedTeamId === input.connection.teamId &&
+      reportedBotUserId === input.connection.botUserId,
   }
 }
 
@@ -86,6 +154,10 @@ export async function exchangeSlackOAuthCode(input: {
     throw new Error(
       `Slack OAuth token exchange failed (${json.error ?? res.status})`,
     )
+  }
+  const missingScopes = missingSlackBotScopes(parseSlackScopes(json.scope))
+  if (missingScopes.length > 0) {
+    throw new SlackOAuthMissingScopesError(missingScopes)
   }
   return json
 }

--- a/apps/backend/src/services/slack/scopes.ts
+++ b/apps/backend/src/services/slack/scopes.ts
@@ -1,7 +1,8 @@
 /**
  * Bot token scopes for the Slack connector (intent capture, not channel mirror).
- * `app_mention` events do not require a scope of their own; the bot must still
- * be invited to any channel where capture is requested (ADR-025 §7).
+ * `app_mentions:read` is required for Slack to deliver `app_mention` events;
+ * the bot must also be invited to any channel where capture is requested
+ * (ADR-025 §7).
  * `channels:read` / `groups:read` are for `conversations.info` (human-readable
  * channel names in git paths), not for workspace channel catalogues.
  * `chat:write` powers the capturing → captured status reply in-thread.
@@ -9,6 +10,7 @@
  * do not download binaries into git (ADR-025).
  */
 export const SLACK_BOT_SCOPES = [
+  "app_mentions:read",
   "channels:history",
   "channels:read",
   "groups:history",
@@ -16,9 +18,24 @@ export const SLACK_BOT_SCOPES = [
   "chat:write",
   "files:read",
   "users:read",
-  "team:read",
 ] as const
 
 export function slackBotScopeString(): string {
   return SLACK_BOT_SCOPES.join(",")
+}
+
+export function parseSlackScopes(scopeHeader: string | null | undefined) {
+  return [
+    ...new Set(
+      (scopeHeader ?? "")
+        .split(",")
+        .map((scope) => scope.trim())
+        .filter(Boolean),
+    ),
+  ].sort()
+}
+
+export function missingSlackBotScopes(grantedScopes: Iterable<string>) {
+  const granted = new Set(grantedScopes)
+  return SLACK_BOT_SCOPES.filter((scope) => !granted.has(scope))
 }

--- a/apps/docs/content/docs/(guide)/connections/source-connectors/slack.mdx
+++ b/apps/docs/content/docs/(guide)/connections/source-connectors/slack.mdx
@@ -119,7 +119,9 @@ invited to the channel, and you used Slack autocomplete to **@mention** the bot.
 Bare mention or “capture this” snapshots the thread. Self-hosted operators
 should confirm Event Subscriptions include **`app_mention`** and that
 `MODEL_PROVIDER*` is set so the mention agent can interpret extra text — see
-[Self-host Slack](/docs/self-hosting/slack).
+[Self-host Slack](/docs/self-hosting/slack). If the Slack app's bot scopes were
+changed after installation, re-authorise the workspace; existing bot tokens do
+not gain new permissions automatically.
 
 ### Private channel
 

--- a/apps/docs/content/docs/self-hosting/slack.mdx
+++ b/apps/docs/content/docs/self-hosting/slack.mdx
@@ -48,12 +48,16 @@ multi-workspace distribution.
 
 Add bot token scopes at least:
 
+- `app_mentions:read` (receive capture requests from bot mentions)
 - `channels:history`, `channels:read`
 - `groups:history`, `groups:read` (private channels; bot must be invited)
 - `chat:write` (in-thread capturing → captured status replies)
 - `files:read`
 - `users:read`
-- `team:read`
+
+When adding a scope after a workspace has already installed the app, that
+workspace must complete OAuth again. Updating Slack app settings does not
+upgrade an existing bot token.
 
 Register this OAuth redirect URL:
 


### PR DESCRIPTION
## Summary
- explicitly request and validate `app_mentions:read`, while removing the unused `team:read` grant
- add authenticated Slack installation verification using `auth.test` identity data and `x-oauth-scopes`, without exposing bot tokens
- relay OAuth permission failures cleanly, log safe webhook ingress metadata, and document re-authorisation requirements

## Test plan
- [x] Run focused Slack client, connector route, webhook, model, and signature tests (43 passing)
- [x] Run Biome lint on all modified backend files
- [ ] Deploy, verify ctxpipe and Tru Rec installations before re-authorising either workspace
- [ ] Re-authorise Tru Rec only if its live token lacks `app_mentions:read`
- [ ] Confirm webhook → workflow → Slack reply → git commit in a normal channel thread