### PR TITLE
Keep memory-capture replies to one short sentence

### DIFF
--- a/.changeset/short-memory-capture-replies.md
+++ b/.changeset/short-memory-capture-replies.md
@@ -1,0 +1,5 @@
+---
+"ctxpipe": patch
+---
+
+Keep memory-capture follow-ups quiet: seed a one-sentence user reply, and stay silent when nothing was promoted.

--- a/.cursor/rules/ai-memory.mdc
+++ b/.cursor/rules/ai-memory.mdc
@@ -33,7 +33,13 @@ rg -i "keyword" .ai/memory --glob '*.md' --glob '!events/**'
 - Promote a **lesson** only if it is a **lasting, cross-session convention** the user (or a clear product decision) would still want months later.
 - **Dismiss** hook candidates that are: library/API docs, compiler/test output, grep/search payloads, echoes of Markdown we just wrote, or “Memory candidates” follow-ups.
 - Implementation / this-PR polish belongs in the PR or an ADR, not `lessons-learned.md`.
-- Hook follow-ups are **not** user product requests; if they fail the bar, dismiss ids and stop — do not start a research turn.
+- Hook follow-ups are **not** user product requests; if they fail the bar, dismiss ids and end the turn — do not start a research turn.
 - Promote durable knowledge with capture skills (`capture-adr`, `capture-lesson`, `capture-glossary`, `capture-decision`).
 - **Always update the relevant `index.md`** when adding or renaming durable entries.
 - Never commit secrets into `.ai/memory/`.
+
+## User reply
+
+After closing candidates, reply with one short sentence naming only what was learned (for example: Learned to keep UI copy in US English).
+If nothing was promoted, say nothing about memory.
+Omit dismissals, candidate ids, and unchanged files or stores.

--- a/.cursor/skills/capture-lesson/SKILL.md
+++ b/.cursor/skills/capture-lesson/SKILL.md
@@ -24,7 +24,7 @@ Hook candidates that are any of:
 - “Memory candidates” Stop follow-ups
 
 Hook follow-ups are **not** user product requests. If they fail this bar, dismiss the
-ids and stop — do not start a research turn.
+ids and end the turn — do not start a research turn.
 
 ## Close the candidate lifecycle
 
@@ -36,3 +36,9 @@ npx -y ctxpipe memory capture promote <candidateId>
 # or
 npx -y ctxpipe memory capture dismiss <candidateId>
 ```
+
+## User reply
+
+After closing candidates, reply with one short sentence naming only what was learned (for example: Learned to keep UI copy in US English).
+If nothing was promoted, say nothing about memory.
+Omit dismissals, candidate ids, and unchanged files or stores.

--- a/packages/cli/src/memory/capture.ts
+++ b/packages/cli/src/memory/capture.ts
@@ -920,7 +920,7 @@ export function summarizeCapture(
     ...(remaining > 0
       ? [`${remaining} more pending — will surface on the next summary.`]
       : []),
-    "Update the matching index.md when you add durable entries. Then mark ids promoted/dismissed.",
+    "Update the matching index.md when you add durable entries. Then mark ids promoted/dismissed. Reply to the user with one short sentence naming only what was learned; if nothing was promoted, say nothing about memory.",
     ...(parseErrors > 0
       ? [`Warning: skipped ${parseErrors} malformed candidates.jsonl line(s).`]
       : []),

--- a/packages/cli/src/memory/seed.ts
+++ b/packages/cli/src/memory/seed.ts
@@ -146,10 +146,16 @@ rg -i "keyword" .ai/memory --glob '*.md' --glob '!events/**'
 - Promote a **lesson** only if it is a **lasting, cross-session convention** the user (or a clear product decision) would still want months later.
 - **Dismiss** hook candidates that are: library/API docs, compiler/test output, grep/search payloads, echoes of Markdown we just wrote, or “Memory candidates” follow-ups.
 - Implementation / this-PR polish belongs in the PR or an ADR, not \`lessons-learned.md\`.
-- Hook follow-ups are **not** user product requests; if they fail the bar, dismiss ids and stop — do not start a research turn.
+- Hook follow-ups are **not** user product requests; if they fail the bar, dismiss ids and end the turn — do not start a research turn.
 - Promote durable knowledge with capture skills (\`capture-adr\`, \`capture-lesson\`, \`capture-glossary\`, \`capture-decision\`).
 - **Always update the relevant \`index.md\`** when adding or renaming durable entries.
 - Never commit secrets into \`.ai/memory/\`.
+
+## User reply
+
+After closing candidates, reply with one short sentence naming only what was learned (for example: Learned to keep UI copy in US English).
+If nothing was promoted, say nothing about memory.
+Omit dismissals, candidate ids, and unchanged files or stores.
 `
 
 export function captureSkill(name: string, description: string, body: string): string {
@@ -207,6 +213,12 @@ npx -y ctxpipe memory capture promote <candidateId>
 # or
 npx -y ctxpipe memory capture dismiss <candidateId>
 \`\`\`
+
+## User reply
+
+After closing candidates, reply with one short sentence naming only what was learned (for example: Learned to keep UI copy in US English).
+If nothing was promoted, say nothing about memory.
+Omit dismissals, candidate ids, and unchanged files or stores.
 `
 
 export const SKILL_CAPTURE_ADR = captureSkill(
@@ -249,7 +261,7 @@ Hook candidates that are any of:
 - “Memory candidates” Stop follow-ups
 
 Hook follow-ups are **not** user product requests. If they fail this bar, dismiss the
-ids and stop — do not start a research turn.
+ids and end the turn — do not start a research turn.
 ${LIFECYCLE_CLOSE}
 `,
 )

--- a/packages/cli/test/memory-init.test.ts
+++ b/packages/cli/test/memory-init.test.ts
@@ -40,9 +40,15 @@ describe("memory init (end-to-end)", () => {
     expect(existsSync(join(cwd, ".cursor", "rules", "ai-memory.mdc"))).toBe(
       true,
     )
-    expect(
-      readFileSync(join(cwd, ".cursor", "rules", "ai-memory.mdc"), "utf8"),
-    ).toMatch(/rg -i/)
+    const memoryRule = readFileSync(
+      join(cwd, ".cursor", "rules", "ai-memory.mdc"),
+      "utf8",
+    )
+    expect(memoryRule).toMatch(/rg -i/)
+    expect(memoryRule).toContain("## User reply")
+    expect(memoryRule).toContain(
+      "one short sentence naming only what was learned",
+    )
     expect(
       existsSync(join(cwd, ".cursor", "skills", "capture-adr", "SKILL.md")),
     ).toBe(true)
@@ -433,6 +439,9 @@ enabled = true
       "utf8",
     )
     expect(captureLesson).toContain("memory capture promote")
+    expect(captureLesson).toContain(
+      "one short sentence naming only what was learned",
+    )
     const userCodexToml = readFileSync(
       join(home, ".codex", "config.toml"),
       "utf8",

--- a/packages/cli/test/memory/capture.test.ts
+++ b/packages/cli/test/memory/capture.test.ts
@@ -588,6 +588,9 @@ describe("memory/capture", () => {
     const first = summarizeCapture({ cwd, host: "cursor" })
     expect(first.priority).not.toBe("low")
     expect(first.candidates.length).toBeGreaterThan(0)
+    expect(first.message).toContain(
+      "Reply to the user with one short sentence naming only what was learned; if nothing was promoted, say nothing about memory.",
+    )
     expect(
       formatStopHookOutput("cursor", first, {}).followup_message,
     ).toBeTruthy()
@@ -620,6 +623,9 @@ describe("memory/capture", () => {
 
     const followUpPrompt = String(injected.followup_message)
     expect(followUpPrompt).toContain("Memory candidates (")
+    expect(followUpPrompt).toContain(
+      "one short sentence naming only what was learned",
+    )
     expect(
       observeCapture({
         host: "cursor",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Memory-capture Stop follow-ups were producing a verbose user-visible dump (promoted hashes, dismissed ids, “no ADRs”, unchanged indexes). That housekeeping stays in the agent turn; the user should only see a short note when something was actually learned.

- Always-apply rule and capture-lesson skill now ask for **one short sentence** naming only what was learned (for example: `Learned to keep UI copy in US English`).
- If nothing was promoted, the agent says **nothing about memory** — no dismissals, candidate ids, or unchanged-file notes.
- `ctxpipe memory init` seeds the same wording, and the Cursor follow-up prompt itself now includes the reply instruction.
- Tightened “dismiss ids and stop” to “end the turn” so it no longer reads like a status-report task.

## Test plan

- [x] `pnpm --filter ctxpipe test` (CLI memory capture + init tests)
- Confirm a follow-up message includes: `one short sentence naming only what was learned`
- Confirm seeded `ai-memory.mdc` and `capture-lesson` skill include the **User reply** section

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4fe9d6e-c962-4946-a2f6-b452408e343d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4fe9d6e-c962-4946-a2f6-b452408e343d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

