### PR TITLE
Add a Simplicity axis to every adversarial review

### DIFF
--- a/.ai/memory/research/index.md
+++ b/.ai/memory/research/index.md
@@ -7,3 +7,4 @@ Prior-art notes. Open the folder that matches the topic; do not load every note.
 | Local agent memory | [local-memory/index.md](./local-memory/index.md) | Market and architecture survey of memory systems |
 | UI / design skills | [ui-design-skills/index.md](./ui-design-skills/index.md) | Agent design skills, Refactoring UI test matrix, product-ui decision |
 | MCP testing | [mcp-testing/mcpjam.md](./mcp-testing/mcpjam.md) | MCPJam diagnostic capabilities, constraints, and adoption decision |
+| Simplicity audit | [simplicity-audit/index.md](./simplicity-audit/index.md) | Sol review miss vs Linear brief; why we vendor a job/thinnest-machine pass |

--- a/.ai/memory/research/simplicity-audit/index.md
+++ b/.ai/memory/research/simplicity-audit/index.md
@@ -2,7 +2,7 @@
 
 Research date: 2026-08-22
 
-Scope: why this repo vendors a simplicity pass instead of installing [petekp/simplicity-audit](https://www.skills.sh/petekp/agent-skills/simplicity-audit) as-is. Implementation lives in [`.agents/skills/simplicity-audit/`](../../../.agents/skills/simplicity-audit/SKILL.md). This note is prior art, not the skill.
+Scope: why this repo vendors a simplicity pass instead of installing [petekp/simplicity-audit](https://www.skills.sh/petekp/agent-skills/simplicity-audit) as-is. Implementation lives in [`.agents/skills/simplicity-audit/`](../../../../.agents/skills/simplicity-audit/SKILL.md). This note is prior art, not the skill.
 
 ## Question
 

--- a/.ai/memory/research/simplicity-audit/index.md
+++ b/.ai/memory/research/simplicity-audit/index.md
@@ -1,0 +1,51 @@
+# Simplicity audit (adversarial review)
+
+Research date: 2026-08-22
+
+Scope: why this repo vendors a simplicity pass instead of installing [petekp/simplicity-audit](https://www.skills.sh/petekp/agent-skills/simplicity-audit) as-is. Implementation lives in [`.agents/skills/simplicity-audit/`](../../../.agents/skills/simplicity-audit/SKILL.md). This note is prior art, not the skill.
+
+## Question
+
+How do we stop implementation agents from shipping leftover analogue machinery, and stop Sol reviews from blessing that machinery because the spec or ADR still names it?
+
+## Evidence (Sol threads on this repo)
+
+### Linear fold — brief supplied, leftover caught
+
+[PR design review](https://cursor.com/agents/bc-194f5e2f-623e-4a82-9ee1-8cbf66915cd0). The user wrote the brief by hand:
+
+> every step should receive adversary review by Sol. the reviewer should be well aware of the goal to simplify this implementation and not consider it correct
+
+Sol then flagged leftover dual-writes, dead tables, and wizard-only DB persistence. The job collapsed to: tokens/binding on `connections.config`, draft/live scope as `linear/config.yaml` (PR branch vs target branch), webhook work via OpenWorkflow. Dropped: `linear_scopes`, `linear_sync_targets`, `linear_dirty_entities`.
+
+### Notion fold — Confluence-shaped control plane
+
+[System design simplification](https://cursor.com/agents/bc-68ed8145-ee4d-46f7-b809-b81d031171e0). Implementation worked; it had copied Confluence tables, scope dual-write, and full remirror. OpenWorkflow was already correct. The debt was extra Postgres control plane. Folded to the Linear thin model ([ADR-023](../../decisions/ADR-023-notion-connector-git-native-mirror.md)).
+
+### Slack PR 267 — brief missing, leftover blessed
+
+[PR 267 adversarial audit](https://cursor.com/agents/bc-8d06a0fa-f30b-4b99-80f2-383b60df1f58). Sol ran Standards, Spec, product grill, and security. Merge bar was tenancy/auth. Runtime leftover “mostly gone.” `slack_sync_targets` was never challenged: [ADR-025](../../decisions/ADR-025-slack-connector-git-native-mirror.md) still named it, so Spec treated the table as given ([Sol spec and product grill](https://cursor.com/agents/bc-1bad2fb9-05b0-56fc-b718-94a3fe1c03fb)).
+
+A human later asked why Slack had a Confluence-shaped table. Linear and Notion already store that binding on `connections.config`. Five CREATE-then-DROP migrations were the feature’s autobiography, not a requirement.
+
+### Source-connectors skill grill — next agent cargo-cults
+
+[Sol round-2 skill grill](https://cursor.com/agents/bc-f7ba6b31-b6bf-5375-979e-e61d41f291fc). Same split applied to skill text: a vague or too-absolute rule makes the next connector invent tables, SaaS relays, or `config.yaml` theatre. Sol’s job was to break the skill before it shipped.
+
+## What Standards + Spec cannot absorb
+
+- **Spec** asks whether the diff matches the issue or ADR. That is how `slack_sync_targets` survived.
+- **Standards** asks house style and Fowler smells. Speculative Generality does not ask “you copied Confluence; Linear is the sibling.”
+- **Simplicity** asks whether the machinery should exist for this job. It may say the spec or ADR is overbuilt.
+
+## Decision
+
+Vendor the method (job → thinnest machine → essential vs accidental, justification search, confidence). Do not raw-install the upstream file (full-repo inventory, `docs/adr` paths, stack-rewrite posture).
+
+Make the Linear brief unskippable: every `code-review` spawns a Sol Simplicity axis. ADRs are evidence, not a veto. Spec-match is not a defense.
+
+## Sources
+
+- [petekp simplicity-audit](https://github.com/petekp/agent-skills/blob/main/skills/simplicity-audit/SKILL.md) (MIT) — essential/accidental, justification search, confidence
+- Linear / Notion / Slack Sol threads above
+- [ADR-022](../../decisions/ADR-022-linear-connector-git-native-mirror.md), [ADR-023](../../decisions/ADR-023-notion-connector-git-native-mirror.md), [ADR-025](../../decisions/ADR-025-slack-connector-git-native-mirror.md)

--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: code-review
-description: Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes — Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/spec asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to "review since X".
+description: Review the changes since a fixed point (commit, branch, tag, or merge-base) along three axes — Standards, Spec, and Simplicity. Runs the three reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to "review since X".
 ---
 
-Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
+Three-axis review of the diff between `HEAD` and a fixed point the user supplies:
 
 - **Standards** — does the code conform to this repo's documented coding standards?
 - **Spec** — does the code faithfully implement the originating issue / spec?
+- **Simplicity** — is the machinery essential for the job, or accidental leftover?
 
-Both axes run as **parallel sub-agents** so they don't pollute each other's context, then this skill aggregates their findings.
+All three axes run as **parallel sub-agents** (`gpt-5.6-sol-high`) so they don't pollute each other's context, then this skill aggregates their findings. Do **not** run Sol as spec-only.
 
 The issue tracker should have been provided to you — run `/setup-matt-pocock-skills` if `.ai/agents/issue-tracker.md` is missing.
 
@@ -20,7 +21,7 @@ Whatever the user said is the fixed point — a commit SHA, branch name, tag, `m
 
 Capture the diff command once: `git diff <fixed-point>...HEAD` (three-dot, so the comparison is against the merge-base). Also note the list of commits via `git log <fixed-point>..HEAD --oneline`.
 
-Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here — not inside two parallel sub-agents.
+Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here — not inside parallel sub-agents.
 
 ### 2. Identify the spec source
 
@@ -28,7 +29,7 @@ Look for the originating spec, in this order:
 
 1. Issue references in the commit messages (`#123`, `Closes #45`, GitLab `!67`, etc.) — fetch via the workflow in `.ai/agents/issue-tracker.md`.
 2. A path the user passed as an argument.
-3. A spec file under `docs/`, `specs/`, or `.scratch/` matching the branch name or feature.
+3. A spec file under `docs/`, `specs/`, `.ai/scratchpad/`, or `.scratch/` matching the branch name or feature.
 4. If nothing is found, ask the user where the spec is. If they say there isn't one, the **Spec** sub-agent will skip and report "no spec available".
 
 ### 3. Identify the standards sources
@@ -55,9 +56,11 @@ Each smell reads *what it is* → *how to fix*; match it against the diff:
 - **Middle Man** — a class or function that mostly just delegates onward. → cut it, call the real target direct.
 - **Refused Bequest** — a subclass or implementer that ignores or overrides most of what it inherits. → drop the inheritance, use composition.
 
-### 4. Spawn both sub-agents in parallel
+A single switch that replaced a one-adapter seam is not Repeated Switches. A type that matches `.ai/memory/glossary.md` is not Primitive Obsession. Speculative Generality is a local hint; leftover analogue / “should this table exist?” belongs on **Simplicity**.
 
-Spawn both with `model: gpt-5.6-sol-high`.
+### 4. Spawn three sub-agents in parallel
+
+Spawn all three with `model: gpt-5.6-sol-high`. Always spawn **Simplicity**. Skip Spec only when step 2 found no spec.
 
 **Standards sub-agent prompt** — include:
 
@@ -71,19 +74,25 @@ Spawn both with `model: gpt-5.6-sol-high`.
 - The path or fetched contents of the spec.
 - The brief: "Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words."
 
-If the spec is missing, skip the Spec sub-agent and note this in the final report.
+**Simplicity sub-agent prompt** — include:
+
+- The full diff command and commit list.
+- The spec path or a note that none was found.
+- The **entire** contents of [`.agents/skills/simplicity-audit/REVIEW-BRIEF.md`](../simplicity-audit/REVIEW-BRIEF.md), pasted in full — the sub-agent has no other access to it.
+- The brief: "You are the Simplicity axis. Apply every rule in the pasted brief to this diff. Report in the brief's shape. Spec-match is not a defense."
 
 ### 5. Aggregate
 
-Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings — the two axes are deliberately separate (see _Why two axes_).
+Present the reports under `## Standards`, `## Spec`, and `## Simplicity`, verbatim or lightly cleaned. Do **not** merge or rerank findings — the axes are deliberately separate (see _Why three axes_). If Spec was skipped, say so under `## Spec`.
 
 End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes — that's the reranking the separation exists to prevent.
 
-## Why two axes
+## Why three axes
 
-A change can pass one axis and fail the other:
+A change can pass one axis and fail another:
 
-- Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
-- Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+- House style and the wrong behaviour → **Standards pass, Spec fail.**
+- Exactly what the issue asked, against house conventions → **Spec pass, Standards fail.**
+- Matches the spec and looks clean, but the spec kept leftover analogue machinery → **Spec pass, Simplicity fail.**
 
-Reporting them separately stops one axis from masking the other.
+Reporting them separately stops Spec-match from hiding accidental complexity.

--- a/.cursor/skills/code-review/agents/openai.yaml
+++ b/.cursor/skills/code-review/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
   display_name: "Code Review"
-  short_description: "Review a diff on standards and spec"
+  short_description: "Review a diff on standards, spec, and simplicity"

--- a/.cursor/skills/codebase-design/SKILL.md
+++ b/.cursor/skills/codebase-design/SKILL.md
@@ -101,6 +101,7 @@ Good interfaces make testing natural:
 - A **Seam** is where a **Module**'s **Interface** lives.
 - An **Adapter** sits at a **Seam** and satisfies the **Interface**.
 - **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+- A **hypothetical seam** (one adapter, no ADR) is often **accidental**; a deep module that does the job is **essential**. Leftover-machinery review is [`simplicity-audit`](../simplicity-audit/SKILL.md), not this vocabulary.
 
 ## Rejected framings
 

--- a/.cursor/skills/grilling/SKILL.md
+++ b/.cursor/skills/grilling/SKILL.md
@@ -17,6 +17,8 @@ Each question should be formatted like so:
 
 Each round the user answers reshapes the tree — settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a _later_ round, not this one.
 
+When the tree is a design or implementation plan, the frontier includes: **what is the job, what is the thinnest machine, what here is analogue leftover?** Give a recommended answer, then wait. Reach for [`simplicity-audit`](../simplicity-audit/SKILL.md) when that judgment needs the review or audit brief.
+
 Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, etc.), dispatch a sub-agent to find it — don't ask the user for anything you could look up yourself. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for the sub-agent to report — ask the rest of the frontier now. The _decisions_ are the user's — put each to them and wait.
 
 The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed. Do not act on it until the user confirms you have reached a shared understanding.

--- a/.cursor/skills/implement/SKILL.md
+++ b/.cursor/skills/implement/SKILL.md
@@ -12,6 +12,6 @@ Use /tdd where possible, at pre-agreed seams.
 
 Run typechecking regularly, single test files regularly, and the full test suite once at the end.
 
-Once done, use /code-review (`gpt-5.6-sol-high`) to review the work.
+Once done, use /code-review (`gpt-5.6-sol-high`) to review the work. That review is three axes — Standards, Spec, and Simplicity.
 
 Commit your work to the current branch.

--- a/.cursor/skills/improve-codebase-architecture/SKILL.md
+++ b/.cursor/skills/improve-codebase-architecture/SKILL.md
@@ -11,7 +11,8 @@ Surface architectural friction and propose **deepening opportunities** — refac
 This command is _informed_ by the project's domain model and built on a shared design vocabulary:
 
 - Run the `/codebase-design` skill for the architecture vocabulary (**module**, **interface**, **depth**, **seam**, **adapter**, **leverage**, **locality**) and its principles (the deletion test, "the interface is the test surface", "one adapter = hypothetical seam, two = real"). Use these terms exactly in every suggestion — don't drift into "component," "service," "API," or "boundary."
-- The domain language in `CONTEXT.md` gives names to good seams; ADRs in `docs/adr/` record decisions this command should not re-litigate.
+- Domain language and ADRs live in `.ai/memory/` — follow [`.ai/agents/domain.md`](../../../.ai/agents/domain.md). Do not re-litigate stack ADRs.
+- Leftover analogue or unused generality is the [`simplicity-audit`](../simplicity-audit/SKILL.md) **audit** branch, not a deepening card.
 
 ## Process
 
@@ -22,7 +23,7 @@ This command is _informed_ by the project's domain model and built on a shared d
 - If the user named a direction — a module, a subsystem, a pain point — take it, and skip the inference below.
 - Otherwise, walk back a good stretch of the commit history (`git log --oneline`) to find the codebase's hot spots — the files and areas that keep coming up — and let those paths pull your attention first. If the changes are scattered with no clear hot spot, widen the net.
 
-Read the project's domain glossary (`CONTEXT.md`) and any ADRs in the area you're touching first.
+Read `.ai/memory/glossary.md` and the matching ADR from `.ai/memory/decisions/` first.
 
 Then spawn a sub-agent to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
 
@@ -51,7 +52,7 @@ For each candidate, render a card with:
 
 End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
 
-**Use CONTEXT.md vocabulary for the domain, and the `/codebase-design` vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+**Use `.ai/memory/glossary.md` vocabulary for the domain, and the `/codebase-design` vocabulary for the architecture.** If the glossary defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
 
 **ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
 
@@ -65,7 +66,7 @@ Once the user picks a candidate, run the `/grilling` skill to walk the decision 
 
 Side effects happen inline as decisions crystallize — run the `/domain-modeling` skill to keep the domain model current as you go:
 
-- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md`. Create the file lazily if it doesn't exist.
-- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **Naming a deepened module after a concept not in `.ai/memory/glossary.md`?** Run `/domain-modeling` / `capture-glossary` into `.ai/memory/`.
+- **Sharpening a fuzzy term during the conversation?** Update `.ai/memory/glossary.md` right there.
 - **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones.
 - **Want to explore alternative interfaces for the deepened module?** Run the `/codebase-design` skill and use its design-it-twice parallel sub-agent pattern.

--- a/.cursor/skills/simplicity-audit/AUDIT.md
+++ b/.cursor/skills/simplicity-audit/AUDIT.md
@@ -1,0 +1,26 @@
+# Area audit
+
+Load only when the user asked to simplify an area (not on a diff review).
+
+## Stance
+
+Same classifications and justification search as [REVIEW-BRIEF.md](REVIEW-BRIEF.md). Same rule: the current shape and the ADR are evidence, not a veto. Load [REPO.md](REPO.md) when in this repo.
+
+## Scope
+
+A named app or area. Full monorepo only if the user said so. Explore with `cursor-grok-4.6-high-fast` sub-agents.
+
+## Steps
+
+1. **Memory first.** [`memory-search`](../memory-search/SKILL.md) + [`.ai/agents/domain.md`](../../../.ai/agents/domain.md) — product-context, glossary, `decisions/index.md`, lessons. Use glossary terms in the report.
+2. **Name the job** the area actually does for a user. Then the **thinnest machine** (first principles + the aligned sibling).
+3. **Inventory** feature areas against that machine — behaviors, files, tables, queues, phase machines, dual-writes. Rough LOC/file counts are enough.
+4. **Classify** every control-plane piece (Essential / Earned / Accidental / Legacy / Uncertain) after the justification search. Stack ADRs stay out of scope unless the user reopened them.
+5. **Propose** a collapse only for Accidental or Legacy. Each proposal: what exists, what it could be, gain, loss, what you verified, confidence.
+6. **Write** `.ai/scratchpad/<area>/simplicity-audit.md`.
+
+**Done when:** every control-plane piece in scope is classified, Accidental/Legacy proposals have a verification list, and the scratchpad file exists.
+
+## After the report
+
+Do not implement. Offer, in order: `/grilling` for Uncertain or high-impact proposals; `/to-tickets` for High+Accidental/Legacy; `/wayfinder` if the destination is multi-session; `/capture-adr` when the user rejects a finding for a load-bearing reason.

--- a/.cursor/skills/simplicity-audit/REPO.md
+++ b/.cursor/skills/simplicity-audit/REPO.md
@@ -1,0 +1,20 @@
+# This repo
+
+Load when running simplicity-audit inside ctxpipe.
+
+## Memory
+
+Constraints live under `.ai/memory/`. Follow [`.ai/agents/domain.md`](../../../.ai/agents/domain.md). Recall via [`memory-search`](../memory-search/SKILL.md) — indexes first, then `rg`, skip `events/`. Do not look in `CONTEXT.md` or `docs/adr/`.
+
+## Stack ADRs (out of scope unless the user reopens them)
+
+Hono + OpenAPI + MCP, Drizzle, TanStack + React Aria, Better Auth, Zoekt, git-native source connectors. The review names leftover *inside* those decisions; it does not reopen the stack.
+
+## Connector siblings
+
+- **Aligned (thin):** Linear and Notion — binding on `connections.config`, scope in git yaml, work via OpenWorkflow. [ADR-022](../../../.ai/memory/decisions/ADR-022-linear-connector-git-native-mirror.md), [ADR-023](../../../.ai/memory/decisions/ADR-023-notion-connector-git-native-mirror.md).
+- **Leftover analogue:** Confluence control-plane tables, custom dirty queues, scope dual-write, ceremony yaml with nothing to review.
+
+## Models
+
+Simplicity review runs as `gpt-5.6-sol-high`. Implementation and explore stay `cursor-grok-4.6-high-fast`.

--- a/.cursor/skills/simplicity-audit/REVIEW-BRIEF.md
+++ b/.cursor/skills/simplicity-audit/REVIEW-BRIEF.md
@@ -1,0 +1,69 @@
+# Simplicity review brief
+
+Paste this file in full into the Sol Simplicity sub-agent. Apply every rule to the pinned diff.
+
+## Stance
+
+Do not treat the current implementation, the spec, or the ADR as correct or as something to preserve for consistency with itself. Spec-match is not a defense. The goal is to find accidental complexity.
+
+## Job, then thinnest machine
+
+1. **Name the job** in one concrete sentence from what the change actually does for a user (mention → commit; webhook → files in git). Not the ADR title. Not “handles Slack integration.”
+2. **Name the thinnest machine** for that job — first principles plus the *aligned* sibling, not the leftover analogue. One paragraph.
+
+## Classify every control-plane piece in the diff
+
+A control-plane piece is a table, queue, phase machine, dual-write, extra file, facade, unused seam, or ceremony path. Classify each as:
+
+- **Essential** — the job requires it. Name why so nobody deletes it.
+- **Earned** — pays for reliability or testability and the tradeoff is reasonable. State the purpose.
+- **Accidental** — leftover analogue, dual-write, ceremony (a PR with nothing to review), unused flexibility, facade after the table is gone, migration autobiography, “harmless preview residue.”
+- **Legacy** — served a past job that no longer applies. Cite the evidence.
+- **Uncertain** — checked what you could; the team must weigh a specific question.
+
+Leftover from a pivot, copied analogue, and “ugly, not a security issue” are findings, not nits — even if tests pass.
+
+## Justification search (before Accidental)
+
+For each piece you would call Accidental, check:
+
+1. Consumers across the repo, not only the module.
+2. Git history of the touched files (bugfix / incident / “fixes” → usually Essential).
+3. External constraints via [`.ai/agents/domain.md`](../../../.ai/agents/domain.md) and [`memory-search`](../memory-search/SKILL.md) — product-context, glossary, `decisions/index.md`, lessons. **ADRs are evidence, not a veto.** If the ADR still names leftover machinery after the job changed, classify Accidental and say “update the ADR.”
+4. Tests that exist only to exercise unused flexibility.
+5. Runtime conditions you cannot see (HMAC, retry, connection pools) — assume Essential until evidence says otherwise.
+
+Downgrade confidence when the search is incomplete. A false-positive delete is worse than a miss.
+
+## Confidence
+
+- **High** — consumers, history, and constraints checked; likely counterarguments do not apply.
+- **Medium** — obvious checks done; a plausible reason remains. State it.
+- **Low** — looks off; frame as a question, not a recommendation.
+
+## Out of scope on this pass
+
+Stack ADRs (Hono, Drizzle, TanStack, Better Auth, Zoekt, git-native connector shape) unless the user reopened them. No full-repo inventory. No rewrite-the-framework notes.
+
+## Report
+
+```markdown
+## Job
+<one sentence>
+
+## Thinnest machine
+<one paragraph>
+
+## Essential
+- <piece> — <why the job requires it>
+
+## Accidental
+- <piece> — <what you checked> — confidence High|Medium|Low
+
+## Uncertain
+- <piece> — <what you checked> — <question for the team>
+```
+
+Omit empty sections. Under 400 words.
+
+**Done when:** every new or retained control-plane piece in the diff is classified, or marked Uncertain with what was checked.

--- a/.cursor/skills/simplicity-audit/SKILL.md
+++ b/.cursor/skills/simplicity-audit/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: simplicity-audit
+description: >
+  Essential vs accidental. Use when an adversarial review of a diff must name leftover
+  machinery; when asked to simplify an area; or when code-review or grilling needs a
+  thinnest-machine judgment.
+license: MIT
+metadata:
+  author: petekp (method); ctxpipe (review-first adaptation)
+---
+
+# Simplicity Audit
+
+Name the **job**, name the **thinnest machine** that does it, then split the rest into **essential** vs **accidental**.
+
+This is not a bug hunt and not a deepening pass. Spec-match is not a defense. Method adapted from [petekp/simplicity-audit](https://github.com/petekp/agent-skills/blob/main/skills/simplicity-audit/SKILL.md) (MIT).
+
+In this repo, read [REPO.md](REPO.md) first.
+
+## Pick a branch
+
+- **Review** (default) — a pinned diff, or `code-review` asked for the Simplicity axis. Apply [REVIEW-BRIEF.md](REVIEW-BRIEF.md) to that diff.
+- **Audit** — the user asked to simplify an area. Load [AUDIT.md](AUDIT.md).
+
+## Review
+
+1. Pin the diff (`git diff <fixed-point>...HEAD`) if `code-review` has not already.
+2. Apply every rule in [REVIEW-BRIEF.md](REVIEW-BRIEF.md).
+3. Report under `## Simplicity` when this run is part of `code-review`; otherwise use the brief’s report shape as the whole answer.
+
+**Done when:** the brief’s completion criterion holds.
+
+## Shared terms
+
+**Essential** — the job requires it (HMAC on the raw body, OpenWorkflow instead of a custom queue, git as content SoT). Name it so nobody deletes it.
+
+**Accidental** — leftover analogue, dual-write, ceremony, unused flexibility, facade after delete, migration autobiography.
+
+A **hypothetical seam** (one adapter, no ADR) is often accidental. A deep module that does the job is essential — flattening it is the wrong fix. Vocabulary when needed: [`codebase-design`](../codebase-design/SKILL.md).

--- a/.cursor/skills/simplicity-audit/agents/openai.yaml
+++ b/.cursor/skills/simplicity-audit/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Simplicity Audit"
+  short_description: "Name leftover machinery vs the thinnest machine for the job"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,10 @@ Default role labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for
 
 Single-context via `.ai/memory/` (product context, glossary, ADRs). See [`.ai/agents/domain.md`](.ai/agents/domain.md).
 
+### Adversarial review
+
+Every adversarial review of a diff is three Sol axes — **Standards**, **Spec**, and **Simplicity** — via [`code-review`](.agents/skills/code-review/SKILL.md). Do not run Sol as spec-only. Simplicity names the job, the thinnest machine, and leftover machinery; spec-match is not a defense. See [`simplicity-audit`](.agents/skills/simplicity-audit/SKILL.md).
+
 ## Architecture decisions & ADRs
 
 - **Where ADRs live**: All ADRs are in `.ai/memory/decisions/`. Files are named `ADR-NNN-title-slug.md` (e.g. `ADR-001-frontend-ui-app-stack.md`). Start from [`decisions/index.md`](.ai/memory/decisions/index.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Vendors a review-first `simplicity-audit` skill and makes every `code-review` spawn a third Sol axis: **Standards**, **Spec**, and **Simplicity**.

Simplicity names the job, the thinnest machine that does it, and leftover analogue machinery. Spec-match is not a defense. ADRs are evidence, not a veto.

## Why

Standards + Spec blessed leftover Confluence control plane on Slack PR 267 because ADR-025 still named `slack_sync_targets`. The same Sol brief, when the user wrote it by hand on Linear, caught leftover tables. This makes that brief unskippable.

Prior art: [`.ai/memory/research/simplicity-audit/index.md`](.ai/memory/research/simplicity-audit/index.md). Method adapted from [petekp/simplicity-audit](https://github.com/petekp/agent-skills/blob/main/skills/simplicity-audit/SKILL.md) (MIT); not a raw install.

## Harness

- [`code-review`](.agents/skills/code-review/SKILL.md) always pastes [`REVIEW-BRIEF.md`](.agents/skills/simplicity-audit/REVIEW-BRIEF.md) into a parallel `gpt-5.6-sol-high` sub-agent
- [`implement`](.agents/skills/implement/SKILL.md) inherits the three-axis review
- [`grilling`](.agents/skills/grilling/SKILL.md) asks job / thinnest machine / analogue leftover on plans
- Root `AGENTS.md` records the Sol pattern
- Deepening skills keep their job; leftover analogue routes to the audit branch

## Verification

Harness check: required files present, `code-review` always spawns Simplicity, `implement` / `grilling` / `AGENTS.md` wired, skill is model-invoked, all relative links resolve.

[simplicity_audit_harness_check.log](https://cursor.com/artifacts/c/art-e7e198bd-c3e2-4bdf-9d51-c9e1ce6606ec)

## Not in this PR

No product code. No stack-ADR reopen. No `seam-ripper` / `architectural-refactor` / `dead-code-sweep`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d057414e-dae5-4502-b8b6-1d7a8d061049?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d057414e-dae5-4502-b8b6-1d7a8d061049&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

