### PR TITLE
Use step.runWorkflow for in-workflow repository ingestion

### DIFF
--- a/.changeset/ingestion-child-workflows.md
+++ b/.changeset/ingestion-child-workflows.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Fan out in-workflow repository ingestion with `step.runWorkflow` so parent workflows sleep and free concurrency slots while children run.

--- a/.cursor/skills/source-connectors/SKILL.md
+++ b/.cursor/skills/source-connectors/SKILL.md
@@ -7,7 +7,7 @@ description: Source connectors. Use when designing, implementing, or reviewing a
 
 This skill is how to **build new** source connectors. Do not retrofit Linear, Notion, Slack, or Confluence to match it.
 
-A **git-native** source connector authorises the provider on **this** deployment, writes selected content as files into a **context repository**, then `runRepositoryIngestionWorkflow` indexes that repo. Same code for hosted and self-host. The provider app and webhook endpoint terminate on this deployment; credentials are deployment-shared or connection-specific according to the provider’s tenant-isolation model.
+A **git-native** source connector authorises the provider on **this** deployment, writes selected content as files into a **context repository**, then `claimAndRunRepositoryIngestionChild` (in-workflow) / `enqueueRepositoryIngestionWorkflow` (HTTP) indexes that repo. Same code for hosted and self-host. The provider app and webhook endpoint terminate on this deployment; credentials are deployment-shared or connection-specific according to the provider’s tenant-isolation model.
 
 The store is **git**. Rich operations (open a config PR, `commitFiles`) are implemented today only for **GitHub**. Design against git paths; call the GitHub App for those operations. Do not invent a second git host’s PR API unless you are implementing it.
 
@@ -62,7 +62,7 @@ Write under a managed root `<slug>/` in the bound context repository (often `ctx
 - **Images and attachments are files.** New connectors download bytes through the authorised client (not anonymous CDN), commit them next to the Markdown, and rewrite links to relative paths. That includes images (`png`/`jpg`/`webp`/`svg`) and other attachments the client can read (PDF, etc.). Never persist private or expiring URLs as file sources. If a blob exceeds the git host’s file-size limit, omit that file and leave a permalink stub — do not fail the whole write.
 - **Provenance.** YAML frontmatter: source, stable ids, canonical URL, timestamps. Connector uninstall does not purge git.
 
-Writes go through `commitFiles` in `installation-write-client.ts` (`encoding: "base64"` for binaries). After a successful write, enqueue `runRepositoryIngestionWorkflow`.
+Writes go through `commitFiles` in `installation-write-client.ts` (`encoding: "base64"` for binaries). After a successful write, hand off via `claimAndRunRepositoryIngestionChild` (from a parent workflow) or `enqueueRepositoryIngestionWorkflow` (from HTTP/webhooks).
 
 **Done when:** a sample tree is specified (config yaml, content paths, attachment files); config is a PR; content commits to the target branch; the mirrored page is readable without a live provider API.
 

--- a/.cursor/skills/source-connectors/references/file-map.md
+++ b/.cursor/skills/source-connectors/references/file-map.md
@@ -41,7 +41,7 @@ Partial unique indexes (e.g. one Slack `teamId` per org) belong on `connections`
 | Capture content | event/mention workflow that writes git then ingests |
 | Provider webhook | `apps/backend/src/routes/webhooks/<slug>/<slug>.ts` — register in `routes/webhooks.ts` |
 | GitHub config-merge | `routes/webhooks/github/github-<slug>-push.ts` wired from `github.ts` |
-| Enqueue | `runWorkflowWithWorkerWake`; after git write `runRepositoryIngestionWorkflow` |
+| Enqueue | `runWorkflowWithWorkerWake` (external); after git write `claimAndRunRepositoryIngestionChild` (in-workflow) or `enqueueRepositoryIngestionWorkflow` |
 
 Webhook: verify signature on the **raw** body; enqueue; ACK. Non-live phases skip. Do not parse-and-reserialise JSON before HMAC.
 

--- a/apps/backend/docs/repository-ingestion-queue.md
+++ b/apps/backend/docs/repository-ingestion-queue.md
@@ -13,7 +13,7 @@ Internal behaviour notes for engineers. Not public product documentation.
 
 [`tryClaimRepositoryIndexingEnqueue`](../src/models/repositories.ts) marks a repo `queued` and returns `true` only when status is not already `queued` or `running` (unless stale).
 
-Callers: [`enqueueRepositoryIngestionWorkflow`](../src/openworkflow/enqueue-repository-ingestion.ts) / `runRepositoryIngestionWorkflow` (webhooks, UI retry, sync).
+Callers: [`enqueueRepositoryIngestionWorkflow`](../src/openworkflow/enqueue-repository-ingestion.ts) (webhooks, UI retry) and `claimAndRunRepositoryIngestionChild` (in-workflow fan-out via `step.runWorkflow`).
 
 If claim returns `false`, no new orchestrator is started for that event.
 

--- a/apps/backend/src/openworkflow/enqueue-repository-ingestion.test.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-ingestion.test.ts
@@ -25,9 +25,20 @@ vi.mock("./workflows/repository-ingestion-orchestrator.js", () => ({
 }))
 
 import {
+  claimAndRunRepositoryIngestionChild,
   enqueueRepositoryIngestionWorkflow,
-  runRepositoryIngestionWorkflow,
+  type RepositoryIngestionChildStep,
 } from "./enqueue-repository-ingestion.js"
+
+function mockChildStep(overrides?: {
+  runWorkflow?: ReturnType<typeof vi.fn>
+}): RepositoryIngestionChildStep {
+  return {
+    run: vi.fn(async (_opts: { name: string }, fn: () => unknown) => fn()),
+    runWorkflow: overrides?.runWorkflow ?? vi.fn().mockResolvedValue(undefined),
+    sleep: vi.fn(),
+  } as unknown as RepositoryIngestionChildStep
+}
 
 describe("enqueueRepositoryIngestionWorkflow", () => {
   beforeEach(() => {
@@ -73,7 +84,7 @@ describe("enqueueRepositoryIngestionWorkflow", () => {
   })
 })
 
-describe("runRepositoryIngestionWorkflow", () => {
+describe("claimAndRunRepositoryIngestionChild", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     tryClaimMock.mockResolvedValue(true)
@@ -82,35 +93,89 @@ describe("runRepositoryIngestionWorkflow", () => {
     )
   })
 
-  it("awaits workflow wake when claim succeeds", async () => {
-    runWorkflowWithWorkerWakeMock.mockResolvedValue({
-      result: vi.fn().mockRejectedValue(new Error("terminal failure")),
-    })
+  it("claims then runs the orchestrator as a child workflow", async () => {
+    const step = mockChildStep()
     const log = { error: vi.fn() }
 
-    await runRepositoryIngestionWorkflow(
-      { repositoryId: "repo_1", orgId: "org_1" },
+    await claimAndRunRepositoryIngestionChild(
+      step,
+      {
+        repositoryId: "repo_1",
+        orgId: "org_1",
+        targetBranch: "main",
+        indexingReason: "Syncing",
+      },
       log,
     )
 
+    expect(step.run).toHaveBeenCalledWith(
+      { name: "claim-ingest-repo_1" },
+      expect.any(Function),
+    )
     expect(tryClaimMock).toHaveBeenCalledWith({
       repositoryId: "repo_1",
-      reason: null,
+      reason: "Syncing",
     })
-    expect(runWorkflowWithWorkerWakeMock).toHaveBeenCalled()
+    expect(step.runWorkflow).toHaveBeenCalledWith(
+      { name: "repository-ingestion-orchestrator" },
+      {
+        repositoryId: "repo_1",
+        orgId: "org_1",
+        targetBranch: "main",
+        indexingReason: "Syncing",
+      },
+      { name: "ingest-repo_1" },
+    )
+    expect(runWorkflowWithWorkerWakeMock).not.toHaveBeenCalled()
     expect(log.error).not.toHaveBeenCalled()
   })
 
-  it("skips workflow when indexing is already queued or running", async () => {
+  it("skips child workflow when indexing is already queued or running", async () => {
     tryClaimMock.mockResolvedValue(false)
+    const step = mockChildStep()
     const log = { error: vi.fn() }
 
-    await runRepositoryIngestionWorkflow(
+    await claimAndRunRepositoryIngestionChild(
+      step,
       { repositoryId: "repo_1", orgId: "org_1" },
       log,
     )
 
-    expect(runWorkflowWithWorkerWakeMock).not.toHaveBeenCalled()
+    expect(step.runWorkflow).not.toHaveBeenCalled()
     expect(log.error).not.toHaveBeenCalled()
+  })
+
+  it("rethrows SleepSignal without logging", async () => {
+    const sleepSignal = new Error("sleep")
+    sleepSignal.name = "SleepSignal"
+    const step = mockChildStep({
+      runWorkflow: vi.fn().mockRejectedValue(sleepSignal),
+    })
+    const log = { error: vi.fn() }
+
+    await expect(
+      claimAndRunRepositoryIngestionChild(
+        step,
+        { repositoryId: "repo_1", orgId: "org_1" },
+        log,
+      ),
+    ).rejects.toMatchObject({ name: "SleepSignal" })
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  it("logs and rethrows child failures", async () => {
+    const step = mockChildStep({
+      runWorkflow: vi.fn().mockRejectedValue(new Error("child failed")),
+    })
+    const log = { error: vi.fn() }
+
+    await expect(
+      claimAndRunRepositoryIngestionChild(
+        step,
+        { repositoryId: "repo_1", orgId: "org_1" },
+        log,
+      ),
+    ).rejects.toThrow("child failed")
+    expect(log.error).toHaveBeenCalledWith(expect.any(Error))
   })
 })

--- a/apps/backend/src/openworkflow/enqueue-repository-ingestion.ts
+++ b/apps/backend/src/openworkflow/enqueue-repository-ingestion.ts
@@ -1,3 +1,4 @@
+import type { Workflow } from "openworkflow"
 import { withOrgDbContext } from "../db/client.js"
 import { tryClaimRepositoryIndexingEnqueue } from "../models/repositories.js"
 import { runWorkflowWithWorkerWake } from "./client.js"
@@ -12,12 +13,20 @@ export type RepositoryIngestionEnqueueInput = {
   indexingReason?: string | null
 }
 
+/** OpenWorkflow `step` from a workflow handler (`run` / `runWorkflow` / `sleep`). */
+export type RepositoryIngestionChildStep = Parameters<
+  Workflow<unknown, unknown, unknown>["fn"]
+>[0]["step"]
+
 /**
  * Marks the repo as mid-ingestion for the UI, then enqueues repository-ingestion-orchestrator.
  * Skips starting another orchestrator when indexing is already `queued` or `running`,
  * unless that status is stale (`queued` > 30min or `running` > 6h).
  * Awaits the DB claim so callers can return HTTP 200 after the UI can poll status.
  * Does not await workflow completion; failures are handled inside the workflow.
+ *
+ * External entry only (HTTP/webhooks). In-workflow callers use
+ * {@link claimAndRunRepositoryIngestionChild}.
  */
 export async function enqueueRepositoryIngestionWorkflow(
   input: RepositoryIngestionEnqueueInput,
@@ -37,16 +46,10 @@ export async function enqueueRepositoryIngestionWorkflow(
 
   void (async () => {
     try {
-      await runWorkflowWithWorkerWake(repositoryIngestionOrchestrator.spec, {
-        repositoryId: input.repositoryId,
-        orgId: input.orgId,
-        ...(input.targetBranch !== undefined
-          ? { targetBranch: input.targetBranch }
-          : {}),
-        ...(input.indexingReason !== undefined
-          ? { indexingReason: input.indexingReason }
-          : {}),
-      })
+      await runWorkflowWithWorkerWake(
+        repositoryIngestionOrchestrator.spec,
+        input,
+      )
     } catch (err: unknown) {
       const normalized = err instanceof Error ? err : new Error(String(err))
       log.error(normalized)
@@ -54,34 +57,42 @@ export async function enqueueRepositoryIngestionWorkflow(
   })()
 }
 
-/** Await ingestion workflow (e.g. parent sync workflow). */
-export async function runRepositoryIngestionWorkflow(
+/**
+ * Claim indexing, then start repository-ingestion-orchestrator as a durable
+ * child via `step.runWorkflow` so the parent sleeps and frees its concurrency
+ * slot while ingestion runs.
+ *
+ * In-workflow entry only. External callers use {@link enqueueRepositoryIngestionWorkflow}.
+ */
+export async function claimAndRunRepositoryIngestionChild(
+  step: RepositoryIngestionChildStep,
   input: RepositoryIngestionEnqueueInput,
   log: { error: (err: Error) => void },
 ): Promise<void> {
-  const shouldEnqueue = await withOrgDbContext(input.orgId, () =>
-    tryClaimRepositoryIndexingEnqueue({
-      repositoryId: input.repositoryId,
-      reason: input.indexingReason ?? null,
-    }),
+  const shouldEnqueue = await step.run(
+    { name: `claim-ingest-${input.repositoryId}` },
+    () =>
+      withOrgDbContext(input.orgId, () =>
+        tryClaimRepositoryIndexingEnqueue({
+          repositoryId: input.repositoryId,
+          reason: input.indexingReason ?? null,
+        }),
+      ),
   )
   if (!shouldEnqueue) {
     return
   }
 
   try {
-    await runWorkflowWithWorkerWake(repositoryIngestionOrchestrator.spec, {
-      repositoryId: input.repositoryId,
-      orgId: input.orgId,
-      ...(input.targetBranch !== undefined
-        ? { targetBranch: input.targetBranch }
-        : {}),
-      ...(input.indexingReason !== undefined
-        ? { indexingReason: input.indexingReason }
-        : {}),
+    await step.runWorkflow(repositoryIngestionOrchestrator.spec, input, {
+      name: `ingest-${input.repositoryId}`,
     })
   } catch (err: unknown) {
-    log.error(err instanceof Error ? err : new Error(String(err)))
-    throw err
+    if (err instanceof Error && err.name === "SleepSignal") {
+      throw err
+    }
+    const normalized = err instanceof Error ? err : new Error(String(err))
+    log.error(normalized)
+    throw normalized
   }
 }

--- a/apps/backend/src/openworkflow/workflows/linear-sync-content.test.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-content.test.ts
@@ -32,7 +32,7 @@ vi.mock("../../services/linear/sync.js", () => ({
   syncLinearContentToGit: mocks.syncContent,
 }))
 vi.mock("../enqueue-repository-ingestion.js", () => ({
-  runRepositoryIngestionWorkflow: vi.fn(),
+  claimAndRunRepositoryIngestionChild: vi.fn(),
 }))
 
 import { linearSyncContent } from "./linear-sync-content.js"

--- a/apps/backend/src/openworkflow/workflows/linear-sync-content.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-content.ts
@@ -15,7 +15,7 @@ import {
 } from "../../services/linear/client.js"
 import { loadLinearScopeFromRepo } from "../../services/linear/config-from-repo.js"
 import { syncLinearContentToGit } from "../../services/linear/sync.js"
-import { runRepositoryIngestionWorkflow } from "../enqueue-repository-ingestion.js"
+import { claimAndRunRepositoryIngestionChild } from "../enqueue-repository-ingestion.js"
 
 const LinearSyncContentInputSchema = z.object({
   orgId: z.string().min(1),
@@ -111,22 +111,21 @@ export const linearSyncContent = defineWorkflow(
       )
 
       if (result.status !== "failed") {
-        await step.run({ name: "ingest-linear-content" }, () =>
-          runRepositoryIngestionWorkflow(
-            {
-              repositoryId: context.target.repositoryId,
-              orgId: input.orgId,
-              targetBranch: context.target.branch,
-              indexingReason: "Syncing Linear content",
-            },
-            {
-              error: (error) =>
-                getLogger().error(error, {
-                  step: "linear-sync-content.ingestion",
-                  connectionId: input.connectionId,
-                }),
-            },
-          ),
+        await claimAndRunRepositoryIngestionChild(
+          step,
+          {
+            repositoryId: context.target.repositoryId,
+            orgId: input.orgId,
+            targetBranch: context.target.branch,
+            indexingReason: "Syncing Linear content",
+          },
+          {
+            error: (error) =>
+              getLogger().error(error, {
+                step: "linear-sync-content.ingestion",
+                connectionId: input.connectionId,
+              }),
+          },
         )
       }
 

--- a/apps/backend/src/openworkflow/workflows/linear-sync-entity.test.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-entity.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../services/linear/sync.js", () => ({
   syncLinearIncrementalContent: mocks.syncIncremental,
 }))
 vi.mock("../enqueue-repository-ingestion.js", () => ({
-  runRepositoryIngestionWorkflow: mocks.runIngestion,
+  claimAndRunRepositoryIngestionChild: mocks.runIngestion,
 }))
 
 import { linearSyncEntity } from "./linear-sync-entity.js"
@@ -41,6 +41,7 @@ const step = {
     async (_options: { name: string }, operation: () => Promise<unknown>) =>
       operation(),
   ),
+  runWorkflow: vi.fn(),
 }
 
 const input = {
@@ -124,9 +125,11 @@ describe("linearSyncEntity", () => {
       }),
     )
     expect(mocks.runIngestion).toHaveBeenCalledWith(
+      step,
       {
         repositoryId: "repo_1",
         orgId: "org_1",
+        targetBranch: "main",
         indexingReason: "Applying Linear updates",
       },
       expect.any(Object),

--- a/apps/backend/src/openworkflow/workflows/linear-sync-entity.ts
+++ b/apps/backend/src/openworkflow/workflows/linear-sync-entity.ts
@@ -14,7 +14,7 @@ import {
 } from "../../services/linear/client.js"
 import { loadLinearScopeFromRepo } from "../../services/linear/config-from-repo.js"
 import { syncLinearIncrementalContent } from "../../services/linear/sync.js"
-import { runRepositoryIngestionWorkflow } from "../enqueue-repository-ingestion.js"
+import { claimAndRunRepositoryIngestionChild } from "../enqueue-repository-ingestion.js"
 
 const LinearSyncEntityInputSchema = z.object({
   orgId: z.string().min(1),
@@ -149,22 +149,21 @@ export const linearSyncEntity = defineWorkflow(
     )
 
     if (result.written > 0 || result.deleted > 0) {
-      await step.run({ name: "ingest-linear-entity" }, () =>
-        runRepositoryIngestionWorkflow(
-          {
-            repositoryId: context.target.repositoryId,
-            orgId: input.orgId,
-            targetBranch: context.target.branch,
-            indexingReason: "Applying Linear updates",
-          },
-          {
-            error: (error) =>
-              getLogger().error(error, {
-                step: "linear-sync-entity.ingestion",
-                connectionId: input.connectionId,
-              }),
-          },
-        ),
+      await claimAndRunRepositoryIngestionChild(
+        step,
+        {
+          repositoryId: context.target.repositoryId,
+          orgId: input.orgId,
+          targetBranch: context.target.branch,
+          indexingReason: "Applying Linear updates",
+        },
+        {
+          error: (error) =>
+            getLogger().error(error, {
+              step: "linear-sync-entity.ingestion",
+              connectionId: input.connectionId,
+            }),
+        },
       )
     }
 

--- a/apps/backend/src/openworkflow/workflows/notion-sync-content.test.ts
+++ b/apps/backend/src/openworkflow/workflows/notion-sync-content.test.ts
@@ -27,7 +27,7 @@ vi.mock("../../services/notion/sync.js", () => ({
   syncNotionContent: mocks.syncContent,
 }))
 vi.mock("../enqueue-repository-ingestion.js", () => ({
-  runRepositoryIngestionWorkflow: vi.fn(),
+  claimAndRunRepositoryIngestionChild: vi.fn(),
 }))
 
 import { notionSyncContent } from "./notion-sync-content.js"

--- a/apps/backend/src/openworkflow/workflows/notion-sync-content.ts
+++ b/apps/backend/src/openworkflow/workflows/notion-sync-content.ts
@@ -9,7 +9,7 @@ import {
 } from "../../models/notion-connector.js"
 import { getLogger } from "../../observability/logger.js"
 import { syncNotionContent } from "../../services/notion/sync.js"
-import { runRepositoryIngestionWorkflow } from "../enqueue-repository-ingestion.js"
+import { claimAndRunRepositoryIngestionChild } from "../enqueue-repository-ingestion.js"
 import { parsedNotionRepoScopeSchema } from "../notion-scope-repo-schema.js"
 
 const notionSyncContentInputSchema = z.object({
@@ -78,22 +78,21 @@ export const notionSyncContent = defineWorkflow(
       // Git is the content SoT; hand off to repository ingestion so codesearch
       // indexes the mirrored notion/ files (Linear/PR-271 pattern).
       if (contentResult.status !== "failed") {
-        await step.run({ name: "ingest-notion-content" }, () =>
-          runRepositoryIngestionWorkflow(
-            {
-              repositoryId: binding.repositoryId,
-              orgId: input.orgId,
-              targetBranch: binding.branch,
-              indexingReason: "Syncing Notion content",
-            },
-            {
-              error: (error) =>
-                getLogger().error(error, {
-                  step: "notion-sync-content.ingestion",
-                  connectionId: input.connectionId,
-                }),
-            },
-          ),
+        await claimAndRunRepositoryIngestionChild(
+          step,
+          {
+            repositoryId: binding.repositoryId,
+            orgId: input.orgId,
+            targetBranch: binding.branch,
+            indexingReason: "Syncing Notion content",
+          },
+          {
+            error: (error) =>
+              getLogger().error(error, {
+                step: "notion-sync-content.ingestion",
+                connectionId: input.connectionId,
+              }),
+          },
         )
       }
 

--- a/apps/backend/src/openworkflow/workflows/notion-sync-entity.test.ts
+++ b/apps/backend/src/openworkflow/workflows/notion-sync-entity.test.ts
@@ -30,7 +30,7 @@ vi.mock("../../services/notion/sync.js", () => ({
   syncNotionIncrementalContent: mocks.syncIncremental,
 }))
 vi.mock("../enqueue-repository-ingestion.js", () => ({
-  runRepositoryIngestionWorkflow: mocks.runIngestion,
+  claimAndRunRepositoryIngestionChild: mocks.runIngestion,
 }))
 
 import { notionSyncEntity } from "./notion-sync-entity.js"
@@ -40,6 +40,7 @@ const step = {
     async (_options: { name: string }, operation: () => Promise<unknown>) =>
       operation(),
   ),
+  runWorkflow: vi.fn(),
 }
 
 const input = {
@@ -116,9 +117,11 @@ describe("notionSyncEntity", () => {
       }),
     )
     expect(mocks.runIngestion).toHaveBeenCalledWith(
+      step,
       {
         repositoryId: "repo_1",
         orgId: "org_1",
+        targetBranch: "main",
         indexingReason: "Applying Notion updates",
       },
       expect.any(Object),

--- a/apps/backend/src/openworkflow/workflows/notion-sync-entity.ts
+++ b/apps/backend/src/openworkflow/workflows/notion-sync-entity.ts
@@ -9,7 +9,7 @@ import {
 import { getLogger } from "../../observability/logger.js"
 import { loadNotionScopeFromRepo } from "../../services/notion/config-from-repo.js"
 import { syncNotionIncrementalContent } from "../../services/notion/sync.js"
-import { runRepositoryIngestionWorkflow } from "../enqueue-repository-ingestion.js"
+import { claimAndRunRepositoryIngestionChild } from "../enqueue-repository-ingestion.js"
 
 const notionSyncEntityInputSchema = z.object({
   orgId: z.string().min(1),
@@ -107,22 +107,21 @@ export const notionSyncEntity = defineWorkflow(
     )
 
     if (result.written > 0 || result.deleted > 0) {
-      await step.run({ name: "ingest-notion-entity" }, () =>
-        runRepositoryIngestionWorkflow(
-          {
-            repositoryId: context.binding.repositoryId,
-            orgId: input.orgId,
-            targetBranch: context.binding.branch,
-            indexingReason: "Applying Notion updates",
-          },
-          {
-            error: (error) =>
-              getLogger().error(error, {
-                step: "notion-sync-entity.ingestion",
-                connectionId: input.connectionId,
-              }),
-          },
-        ),
+      await claimAndRunRepositoryIngestionChild(
+        step,
+        {
+          repositoryId: context.binding.repositoryId,
+          orgId: input.orgId,
+          targetBranch: context.binding.branch,
+          indexingReason: "Applying Notion updates",
+        },
+        {
+          error: (error) =>
+            getLogger().error(error, {
+              step: "notion-sync-entity.ingestion",
+              connectionId: input.connectionId,
+            }),
+        },
       )
     }
 

--- a/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.ts
+++ b/apps/backend/src/openworkflow/workflows/repository-ingestion-orchestrator.ts
@@ -35,12 +35,8 @@ export const repositoryIngestionOrchestrator = defineWorkflow(
             {
               repositoryId: input.repositoryId,
               orgId: input.orgId,
-              ...(input.targetBranch !== undefined
-                ? { targetBranch: input.targetBranch }
-                : {}),
-              ...(input.indexingReason !== undefined
-                ? { indexingReason: input.indexingReason }
-                : {}),
+              targetBranch: input.targetBranch,
+              indexingReason: input.indexingReason,
             },
             { name: "repository-ingestion-child" },
           )

--- a/apps/backend/src/openworkflow/workflows/sync-github-repositories.test.ts
+++ b/apps/backend/src/openworkflow/workflows/sync-github-repositories.test.ts
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const getGithubInstallationByConnectionIdMock = vi.hoisted(() => vi.fn())
 const listAllReposForInstallationMock = vi.hoisted(() => vi.fn())
 const bulkCreateRepositoriesForOrgMock = vi.hoisted(() => vi.fn())
-const runRepositoryIngestionWorkflowMock = vi.hoisted(() => vi.fn())
+const claimAndRunRepositoryIngestionChildMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../config/env.js", () => ({
+  parseEnv: vi.fn(() => ({})),
+}))
 
 vi.mock("../../models/github-installation.js", () => ({
   getGithubInstallationByConnectionId: getGithubInstallationByConnectionIdMock,
@@ -15,7 +19,7 @@ vi.mock("../../models/repositories.js", () => ({
 }))
 
 vi.mock("../enqueue-repository-ingestion.js", () => ({
-  runRepositoryIngestionWorkflow: runRepositoryIngestionWorkflowMock,
+  claimAndRunRepositoryIngestionChild: claimAndRunRepositoryIngestionChildMock,
 }))
 
 vi.mock("../../observability/logger.js", () => ({
@@ -53,13 +57,14 @@ describe("syncGithubRepositories workflow", () => {
       },
     ])
     bulkCreateRepositoriesForOrgMock.mockResolvedValue([])
-    runRepositoryIngestionWorkflowMock.mockResolvedValue(undefined)
+    claimAndRunRepositoryIngestionChildMock.mockResolvedValue(undefined)
   })
 
   it("uses reposToSync when provided without listing all installation repos", async () => {
     const step = {
       run: async (_opts: { name: string }, fn: () => Promise<unknown>) =>
         fn(),
+      runWorkflow: vi.fn(),
     }
 
     await syncGithubRepositories.fn({
@@ -93,6 +98,7 @@ describe("syncGithubRepositories workflow", () => {
     const step = {
       run: async (_opts: { name: string }, fn: () => Promise<unknown>) =>
         fn(),
+      runWorkflow: vi.fn(),
     }
 
     await syncGithubRepositories.fn({

--- a/apps/backend/src/openworkflow/workflows/sync-github-repositories.ts
+++ b/apps/backend/src/openworkflow/workflows/sync-github-repositories.ts
@@ -7,7 +7,7 @@ import {
 } from "../../models/github-installation.js"
 import { bulkCreateRepositoriesForOrg } from "../../models/repositories.js"
 import { createLogger, getLogger, withLogger } from "../../observability/logger.js"
-import { runRepositoryIngestionWorkflow } from "../enqueue-repository-ingestion.js"
+import { claimAndRunRepositoryIngestionChild } from "../enqueue-repository-ingestion.js"
 
 const reposToSyncItemSchema = z.object({
   name: z.string(),
@@ -71,17 +71,16 @@ export const syncGithubRepositories = defineWorkflow(
 
         await Promise.all(
           created.map((repo) =>
-            step.run({ name: `ingest-${repo.id}` }, () =>
-              runRepositoryIngestionWorkflow(
-                { repositoryId: repo.id, orgId: repo.orgId },
-                {
-                  error: (err) =>
-                    getLogger().error(err, {
-                      step: "sync-github-repositories.ingestion",
-                      repositoryId: repo.id,
-                    }),
-                },
-              ),
+            claimAndRunRepositoryIngestionChild(
+              step,
+              { repositoryId: repo.id, orgId: repo.orgId },
+              {
+                error: (err) =>
+                  getLogger().error(err, {
+                    step: "sync-github-repositories.ingestion",
+                    repositoryId: repo.id,
+                  }),
+              },
             ),
           ),
         )


### PR DESCRIPTION
## Summary
- In-workflow callers (GitHub sync, Linear/Notion sync) now start repository ingestion as durable **child** workflows via `step.runWorkflow`, after a short `step.run` claim — instead of awaiting `ow.runWorkflow` inside a parent step.
- **Why:** OpenWorkflow concurrency is per in-flight workflow run. Awaiting children with `ow.runWorkflow` kept the parent “running” and holding a worker slot while doing nothing useful. `step.runWorkflow` parks the parent (frees the slot) until children finish, so a 1×20 worker can spend capacity on actual ingestions when fanning out many repos.
- External entry (HTTP/webhooks) still uses `enqueueRepositoryIngestionWorkflow` + `runWorkflowWithWorkerWake`; wake remains an out-of-worker concern only.
- Replaced `runRepositoryIngestionWorkflow` with `claimAndRunRepositoryIngestionChild`; simplified optional field passthrough on the orchestrator.

## Test plan
- [ ] Unit tests: `enqueue-repository-ingestion`, sync-github / linear / notion sync workflows
- [ ] Sync many GitHub repos (> worker concurrency) and confirm ingestions queue/drain without dropping claims
- [ ] Confirm PR-preview wake path still works for webhook-driven `enqueueRepositoryIngestionWorkflow`


Made with [Cursor](https://cursor.com)