### PR TITLE
Conversation file editability on the chat sandbox

### DIFF
--- a/.ai/memory/decisions/ADR-026-pierre-files-pane-chrome.md
+++ b/.ai/memory/decisions/ADR-026-pierre-files-pane-chrome.md
@@ -6,7 +6,7 @@
 
 The Workspace Files pane started as a homemade React Aria `Tree` plus a `<pre>` preview of hydrated knowledge `.md` files. That explorer needed search, flatten, git status, diffs, edit, and mutations. Growing it in-house would duplicate a path-first file tree and a syntax-highlighted editor.
 
-`@pierre/trees` and `@pierre/diffs` (Apache-2.0) already provide that chrome. Persist must still follow workspace write jobs: in-sandbox worktree, at most one commit on the default branch, then push and hydrate. The pane is a **workspace-repository** explorer (full git tree at the projection SHA), not hydrate units only. Graph stays on hydrate knowledge.
+`@pierre/trees` and `@pierre/diffs` (Apache-2.0) already provide that chrome. Compose Files (`/$org/ws/$slug`, no thread) stay a **workspace-repository** explorer at the projection SHA via codesearch. Conversation Files persist on the **chat sandbox** (`ctxpipe/chat/<conversationId>/1`) and reach GitHub only through brokered Commit+Push / Create PR — not `POST …/files/jobs` / `ui_file_edit`. Graph stays on hydrate knowledge.
 
 React Aria remains the house primitive for product chrome. Pierre paints the tree and file surfaces in Shadow DOM — the same class of exception as Cosmograph.
 
@@ -14,8 +14,9 @@ React Aria remains the house primitive for product chrome. Pierre paints the tre
 
 Use **`@pierre/trees`** (`FileTree`, search, flatten, git badges, DND, rename) and **`@pierre/diffs`** (`File`, `FileDiff`, `EditProvider`) as Files pane chrome only.
 
-- Read the git tree, blobs, and status through org-scoped routes: `GET /{workspaceSlug}/files/tree`, `GET /{workspaceSlug}/files/blob?path=`, and `GET /{workspaceSlug}/files/status`. SHA is `activeProjectionSha`, then `desiredSha`. Status is porcelain from the write sandbox when one is attached; otherwise all-clean vs that SHA. Non-GitHub remotes and missing App connections return 409 with existing write-status reasons. `GET /{workspaceSlug}/files` stays the hydrate knowledge listing for Graph.
-- Persist edits and structure mutations only via `POST /{workspaceSlug}/files/jobs`, which enqueues a `ui_file_edit` write job (`mergeFiles` / `mergeDeletePaths`, in-sandbox worktree). Do not GitHub-API-commit from the UI. Read-only Workspaces browse and may edit locally, but Save and mutating menu items are disabled.
+- Compose / prepare-fallback browse: `GET /{workspaceSlug}/files/tree`, `GET /{workspaceSlug}/files/blob?path=`, and `GET /{workspaceSlug}/files/status`. SHA is `activeProjectionSha`, then `desiredSha`. That surface is **not writable**.
+- Conversation Files (sandbox ready): `GET|PUT /conversations/{id}/files/…`, `GET …/files/diff`, `POST …/push`. Save / autosave / ⌘S and tree mutations write the sandbox FS. Commit+Push leftover-commits then force-with-lease the session branch. Create PR is that push plus `pulls.create`. `POST /{workspaceSlug}/files/jobs` (`ui_file_edit`) is unused by the conversation pane.
+- Protected default is not read-only: chat may still edit the session branch. Cannot-publish (non-GitHub / no App / no Contents write) is Read-only: no pane edits, no agent writes.
 - Context menus stay React Aria; do not restyle Pierre rows with Tailwind.
 - Map Pierre CSS variables to house zinc / card / quiet focus. Tabler icons stay on pane chrome, not inside the tree.
 
@@ -30,4 +31,4 @@ Use **`@pierre/trees`** (`FileTree`, search, flatten, git badges, DND, rename) a
 
 - Keep growing the RAC tree and `<pre>` preview: rejected; the feature set already exists in Pierre.
 - Knowledge-only explorer (hydrate `.md` units): rejected; the Files pane is the workspace repository.
-- Commit via GitHub Contents API from the UI: rejected; write jobs are the persist boundary.
+- Commit via GitHub Contents API from the UI: rejected for jobs (default-branch persist stays `ui_file_edit`). Conversation publish is brokered git push of the session branch, not Contents squash.

--- a/.ai/scratchpad/git-backed-projects/issues/14-worktree-and-agent-change-lifecycle.md
+++ b/.ai/scratchpad/git-backed-projects/issues/14-worktree-and-agent-change-lifecycle.md
@@ -57,7 +57,7 @@ Frontier: UI label; chat write disposition vs ticket 13 hard deny; idle/destroy/
 
 ## Answer
 
-Human lock, 2026-08-15. No host git worktree for chat isolation ([Backend, codesearch, and sandbox-runner topology](08-backend-codesearch-sandbox-topology.md)). File-edit panel remains out of scope.
+Human lock, 2026-08-15. No host git worktree for chat isolation ([Backend, codesearch, and sandbox-runner topology](08-backend-codesearch-sandbox-topology.md)). Conversation file-edit is in scope: Pierre + sandbox FS + explicit Commit+Push / Create PR (one branch `ctxpipe/chat/<conversationId>/1`).
 
 **Vocabulary:** **Job sandbox** (one per Workspace, jobs + in-sandbox worktrees) vs **chat sandbox** (`withSandbox` per `threadId`). Retired: “write sandbox.” Any sandbox may write; **who may push the default branch** is the restriction.
 
@@ -75,9 +75,9 @@ The human-facing name is the **conversation name** ([Workspace chat, conversatio
 
 This **narrows** [Workspace chat, conversation state, and sandbox security](13-project-chat-and-sandbox-security.md): the hard deny is **no push to the default branch** (and no Contents:write / App PEM in the sandbox). Branch+PR is allowed and **brokered** — `gh` in the sandbox stays read-only ([Backend, codesearch, and sandbox-runner topology](08-backend-codesearch-sandbox-topology.md)).
 
-Dirtiness alone **never** creates GitHub state. Only an **explicit** brokered request (agent/user: open or update a PR) creates a branch + PR.
+Dirtiness alone **never** creates GitHub state. Only an **explicit** brokered request creates GitHub state: **Commit+Push** (session branch) or **Create PR** (that push + `pulls.create`). The conversation file-edit panel is the other explicit publish path.
 
-A conversation may open **multiple** PRs (no one-PR cap, no “start a new conversation after merge”). Branch names are a code constant (`ctxpipe/chat/<conversationId>/<n>`). Runner pushes that **session** branch (force-with-lease on that branch only). **Never** force-push the default branch. Relink: do not push a PR to the old URL (generation recheck); the same conversation may publish to the new desired remote. Conversation delete destroys the sandbox and does **not** close or delete existing GitHub PRs/branches. Non-GitHub workspace remotes: chat stays dirty-tree only (v1 writes are GitHub-only).
+A conversation uses **one** working branch (`ctxpipe/chat/<conversationId>/1`). Merged/closed PRs return chrome to Create PR on that same branch. Runner pushes that **session** branch (force-with-lease on that branch only). **Never** force-push the default branch. Relink: do not push a PR to the old URL (generation recheck); the same conversation may publish to the new desired remote. Conversation delete destroys the sandbox and does **not** close or delete existing GitHub PRs/branches. Non-GitHub workspace remotes: chat stays dirty-tree only (v1 writes are GitHub-only).
 
 Uncommitted edits that never become a PR: **discard** when the chat sandbox is destroyed (idle/delete/crash-without-snapshot).
 

--- a/.ai/scratchpad/git-backed-projects/map.md
+++ b/.ai/scratchpad/git-backed-projects/map.md
@@ -17,7 +17,7 @@ A locked spec for ctxpipe as a **job engine over Context Workspaces**: an organi
 - **Vocabulary (2026-08-15):** [glossary](../../memory/glossary.md). **Workspace** (was Project / `proj_`). **Workspace repository** (was backing). **Linked repository** (was attached). **Job** = background write to the workspace repository. **Projection** = derived retrieval state. **Hydrate** refreshes the projection and does not edit git.
 - **Chat runtime (locked):** Client workspace chat is TanStack AI `chat()` + `withSandbox(defineSandbox(…))` + `opencodeText`. Isolation is a TanStack sandbox provider. Do **not** spawn `opencode serve`, `docker run` OpenCode, or host git worktrees as the chat isolation mechanism. See [Chat uses TanStack sandbox, not DIY OpenCode](issues/17-tanstack-sandbox-not-diy-opencode.md) and [Backend, codesearch, and sandbox-runner topology](issues/08-backend-codesearch-sandbox-topology.md). **Ops** is a **job** on the Workspace **job sandbox** — [Ingest-to-git write and concurrency protocol](issues/10-ingest-to-git-write-protocol.md). Chat may open a brokered branch+PR; only jobs push the default branch — [Worktree and agent-change lifecycle](issues/14-worktree-and-agent-change-lifecycle.md).
 - **Sandbox topology (locked):** backend ≠ codesearch (ADR-008). `SANDBOX_PROVIDER` locks a provider (fail closed); unset auto-detects `sbx` → Docker/DinD → unsandboxed `localProcessSandbox`. Compose template: DinD sidecar + `docker`. Railway: custom SandboxProvider + lock `railway`. CDK Fargate v1: unsandboxed. Chat workspace = shallow clone of the **workspace repository**; workspace-level snapshot/fork is application-owned; `gh` is read-only on that Workspace’s GitHub remotes for one installation.
-- **Writes vs editor UI:** a file-edit / diff *panel* is later. Agent writes live in the **TanStack sandbox working tree** (container clone), not a host git worktree. Disposition is locked on [Worktree and agent-change lifecycle](issues/14-worktree-and-agent-change-lifecycle.md): jobs push default; chat may only broker a branch+PR.
+- **Writes vs editor UI:** conversation Files persist on the chat sandbox; Commit+Push / Create PR are the explicit GitHub publish. Compose Files stay codesearch browse. Agent writes live in the **TanStack sandbox working tree** (container clone), not a host git worktree. Disposition is locked on [Worktree and agent-change lifecycle](issues/14-worktree-and-agent-change-lifecycle.md): jobs push default; chat may only broker a session branch + PR.
 - **Default branch** (never silent `main`) and the rest of the write protocol are locked on [Ingest-to-git write and concurrency protocol](issues/10-ingest-to-git-write-protocol.md).
 - **Existing ADRs to reopen explicitly if contradicted:** [ADR-008](../../memory/decisions/ADR-008-codesearch-zoekt-orchestration.md) (separate codesearch), [ADR-018](../../memory/decisions/ADR-018-unified-connections-table.md), [ADR-022](../../memory/decisions/ADR-022-linear-connector-git-native-mirror.md) / [ADR-023](../../memory/decisions/ADR-023-notion-connector-git-native-mirror.md) (git-native connector mirrors already exist; this effort extends git-canonical knowledge to *extracted* content).
 - **Language collisions to kill on sight:** product **Workspace** vs FalkorDB verb `project()` vs Linear **Project** vs prompt field `currentWorkspaceName`. Product **projection** (retrieval index) vs that `project()` verb. **Linked** repository (codesearch) vs “sub project” (not an aggregate). Retired: Project, backing, attached. Resolved terms go in `.ai/memory/glossary.md`.
@@ -48,12 +48,12 @@ A locked spec for ctxpipe as a **job engine over Context Workspaces**: an organi
 ## Not yet specified
 
 - Fine-grained MCP tools that replace deprecated `ctx_advisor` (shim is locked on [Workspace chat, conversation state, and sandbox security](issues/13-project-chat-and-sandbox-security.md)).
-- Production file-editor and diff-panel interaction (the *UI* for editing files — not whether agent writes must have a disposition).
+- Multi-PR `/n` session branches (conversation file-edit uses `/1`).
 
 ## Out of scope
 
 - Implementing the destination in this wayfinder effort — the map stops at a locked spec.
-- Building the production file-edit and diff-of-current-changes panels.
+- Host worktrees and auto-push of conversation sandboxes.
 - Manual per-tenant migrations — upgrade work is an OpenWorkflow job queued at version start, as with the SCIP migration.
 - Keeping top-level Chat and Knowledge graph as primary nav destinations — they move onto the workspace page.
 - The current UI/MCP conversation-source selector — it goes away.

--- a/apps/backend/src/domain/workspaces/chat-lifecycle.test.ts
+++ b/apps/backend/src/domain/workspaces/chat-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   chatHeartbeatKeepsSandbox,
   chatMayPublishPullRequest,
   chatSessionBranchName,
+  conversationSessionBranch,
   JOB_SANDBOX_IDLE_MS,
   lastBranchExistsOnRemote,
   mayForcePushBranch,
@@ -23,6 +24,7 @@ import {
 describe("chat lifecycle", () => {
   it("names session branches and never force-pushes default", () => {
     expect(chatSessionBranchName("conv_1", 2)).toBe("ctxpipe/chat/conv_1/2")
+    expect(conversationSessionBranch("conv_1")).toBe("ctxpipe/chat/conv_1/1")
     expect(nextChatPrNumber(null)).toBe(1)
     expect(mayForcePushBranch("ctxpipe/chat/conv_1/1", "main")).toBe(true)
     expect(mayForcePushBranch("main", "main")).toBe(false)

--- a/apps/backend/src/domain/workspaces/chat-lifecycle.ts
+++ b/apps/backend/src/domain/workspaces/chat-lifecycle.ts
@@ -12,6 +12,11 @@ export function chatSessionBranchName(
   return `${CHAT_SESSION_BRANCH_PREFIX}/${conversationId}/${prNumber}`
 }
 
+/** One working branch per conversation. */
+export function conversationSessionBranch(conversationId: string): string {
+  return chatSessionBranchName(conversationId, 1)
+}
+
 export function nextChatPrNumber(lastChatPrNumber: number | null): number {
   return (lastChatPrNumber ?? 0) + 1
 }

--- a/apps/backend/src/domain/workspaces/chat-runtime.ts
+++ b/apps/backend/src/domain/workspaces/chat-runtime.ts
@@ -173,6 +173,8 @@ export function workspaceChatRuntimeConfig(input?: {
   hasDocker?: boolean
   env?: Record<string, string | undefined>
   writeStatus?: string
+  currentBranch?: string | null
+  defaultBranch?: string | null
   judge?: (
     toolName: string,
     argsExcerpt: string,
@@ -188,6 +190,8 @@ export function workspaceChatRuntimeConfig(input?: {
     provider,
     onPermissionRequest: createWorkspaceChatPermissionHandler({
       writeStatus: input?.writeStatus ?? "read_only",
+      currentBranch: input?.currentBranch,
+      defaultBranch: input?.defaultBranch,
       judge: input?.judge ?? judgeChatToolWithFastModel,
     }),
   }

--- a/apps/backend/src/domain/workspaces/chat-sandbox-policy.test.ts
+++ b/apps/backend/src/domain/workspaces/chat-sandbox-policy.test.ts
@@ -118,6 +118,20 @@ describe("createWorkspaceChatPermissionHandler", () => {
         title: "git commit -am leaked",
       }),
     ).resolves.toBe("reject")
+    const onSession = createWorkspaceChatPermissionHandler({
+      writeStatus: "writable",
+      currentBranch: "ctxpipe/chat/conv_1/1",
+      defaultBranch: "main",
+      judge,
+    })
+    await expect(
+      onSession({
+        id: "perm_commit_ok",
+        sessionID: "sess_1",
+        type: "bash",
+        title: "git commit -am save",
+      }),
+    ).resolves.toBe("once")
     await expect(
       handler({
         id: "perm_4",
@@ -165,11 +179,13 @@ describe("read-only sandbox tools skip the judge", () => {
 })
 
 describe("decideChatToolPermission", () => {
-  it("hard-denies commit/push even when the judge would allow", () => {
+  it("hard-denies push and read-only writes; allows commit on the session branch", () => {
     expect(
       decideChatToolPermission({
         toolName: "git_push",
         writeStatus: "writable",
+        currentBranch: "ctxpipe/chat/conv_1/1",
+        defaultBranch: "main",
         judge: "allow",
       }),
     ).toBe("deny")
@@ -185,7 +201,25 @@ describe("decideChatToolPermission", () => {
         toolName: "apply_patch",
         writeStatus: "read_only",
       }),
+    ).toBe("deny")
+    expect(
+      decideChatToolPermission({
+        toolName: "bash",
+        argsExcerpt: "git commit -am save",
+        writeStatus: "writable",
+        currentBranch: "ctxpipe/chat/conv_1/1",
+        defaultBranch: "main",
+      }),
     ).toBe("allow")
+    expect(
+      decideChatToolPermission({
+        toolName: "bash",
+        argsExcerpt: "git commit -am save",
+        writeStatus: "writable",
+        currentBranch: "main",
+        defaultBranch: "main",
+      }),
+    ).toBe("deny")
   })
 })
 

--- a/apps/backend/src/domain/workspaces/chat-sandbox-policy.ts
+++ b/apps/backend/src/domain/workspaces/chat-sandbox-policy.ts
@@ -9,6 +9,8 @@ export const CHAT_HARD_DENY_REASONS = [
   "auth_secret",
   "contents_write",
   "commit_push",
+  "read_only_write",
+  "default_branch_commit",
   "cloud_metadata",
   "host_not_allowlisted",
   "printenv",
@@ -57,17 +59,35 @@ export function isMcpOriginConversation(
   return origin === "mcp"
 }
 
+export function workspaceAllowsConversationEdits(writeStatus: string): boolean {
+  return writeStatus === "writable"
+}
+
+function excerptLooksLikePush(name: string, excerpt: string): boolean {
+  return (
+    name.includes("git_push") ||
+    name === "push" ||
+    excerpt.includes("git push")
+  )
+}
+
+function excerptLooksLikeCommit(name: string, excerpt: string): boolean {
+  return name.includes("commit") || excerpt.includes("git commit")
+}
+
 export function classifyChatToolRequest(input: {
   toolName: string
   argsExcerpt?: string
   writeStatus: string
+  currentBranch?: string | null
+  defaultBranch?: string | null
 }): {
   hardDeny: ChatHardDenyReason | null
   acceptEditsWouldAllow: boolean
 } {
-  void input.writeStatus
   const name = input.toolName.toLowerCase()
   const excerpt = (input.argsExcerpt ?? "").toLowerCase()
+  const canEdit = workspaceAllowsConversationEdits(input.writeStatus)
   if (
     name.includes("app_pem") ||
     excerpt.includes("app.pem") ||
@@ -101,14 +121,22 @@ export function classifyChatToolRequest(input: {
   ) {
     return { hardDeny: "cloud_metadata", acceptEditsWouldAllow: false }
   }
-  if (
-    name.includes("commit") ||
-    name.includes("git_push") ||
-    name === "push" ||
-    excerpt.includes("git push") ||
-    excerpt.includes("git commit")
-  ) {
+  if (excerptLooksLikePush(name, excerpt)) {
     return { hardDeny: "commit_push", acceptEditsWouldAllow: false }
+  }
+  if (excerptLooksLikeCommit(name, excerpt)) {
+    if (!canEdit) {
+      return { hardDeny: "read_only_write", acceptEditsWouldAllow: false }
+    }
+    const branch = input.currentBranch?.trim() ?? ""
+    const defaultBranch = input.defaultBranch?.trim() ?? ""
+    if (
+      !branch.startsWith("ctxpipe/chat/") ||
+      (defaultBranch && branch === defaultBranch)
+    ) {
+      return { hardDeny: "default_branch_commit", acceptEditsWouldAllow: false }
+    }
+    return { hardDeny: null, acceptEditsWouldAllow: true }
   }
   if (name.includes("contents_write") || excerpt.includes("contents:write")) {
     return { hardDeny: "contents_write", acceptEditsWouldAllow: false }
@@ -124,6 +152,9 @@ export function classifyChatToolRequest(input: {
     name.includes("write") ||
     name.includes("apply_patch")
   ) {
+    if (!canEdit) {
+      return { hardDeny: "read_only_write", acceptEditsWouldAllow: false }
+    }
     return { hardDeny: null, acceptEditsWouldAllow: true }
   }
   if (isReadOnlySandboxTool(name, excerpt)) {
@@ -183,6 +214,8 @@ function isReadOnlySandboxTool(name: string, excerpt: string): boolean {
 
 export function createWorkspaceChatPermissionHandler(input: {
   writeStatus: string
+  currentBranch?: string | null
+  defaultBranch?: string | null
   judge?: (
     toolName: string,
     argsExcerpt: string,
@@ -197,6 +230,8 @@ export function createWorkspaceChatPermissionHandler(input: {
       toolName,
       argsExcerpt,
       writeStatus: input.writeStatus,
+      currentBranch: input.currentBranch,
+      defaultBranch: input.defaultBranch,
     })
     if (classified.hardDeny) return "reject"
     if (classified.acceptEditsWouldAllow) return "once"
@@ -213,6 +248,8 @@ export function decideChatToolPermission(input: {
   toolName: string
   argsExcerpt?: string
   writeStatus: string
+  currentBranch?: string | null
+  defaultBranch?: string | null
   judge?: "allow" | "deny" | "timeout" | "garbage"
 }): "allow" | "deny" {
   const classified = classifyChatToolRequest(input)

--- a/apps/backend/src/domain/workspaces/conversation-files.test.ts
+++ b/apps/backend/src/domain/workspaces/conversation-files.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+import {
+  conversationSandboxStatus,
+  ensureConversationSessionBranch,
+  listConversationSandboxPaths,
+  renameConversationSandboxPath,
+  sanitizeGitRemoteError,
+  writeConversationSandboxFile,
+} from "./conversation-files.js"
+
+function fakeHandle(commands: string[], answers: Record<string, string>) {
+  return {
+    exec: async (command: string) => {
+      commands.push(command)
+      for (const [needle, stdout] of Object.entries(answers)) {
+        if (command.includes(needle)) {
+          return { stdout, stderr: "", exitCode: 0 }
+        }
+      }
+      return { stdout: "", stderr: "", exitCode: 0 }
+    },
+    fs: {
+      write: async () => undefined,
+      read: async () => "",
+      remove: async () => undefined,
+      mkdir: async () => undefined,
+    },
+  }
+}
+
+describe("conversation sandbox files", () => {
+  it("checks out the one session branch", async () => {
+    const commands: string[] = []
+    const branch = await ensureConversationSessionBranch({
+      conversationId: "conv_1",
+      defaultBranch: "main",
+      handle: fakeHandle(commands, {}),
+    })
+    expect(branch).toBe("ctxpipe/chat/conv_1/1")
+    expect(commands[0]).toBe("git checkout -B ctxpipe/chat/conv_1/1")
+  })
+
+  it("lists tracked and untracked paths", async () => {
+    const paths = await listConversationSandboxPaths(
+      fakeHandle([], {
+        "git ls-files -z": "AGENTS.md\0knowledge/a.md\0",
+        "git ls-files --others": "new.md\0",
+      }),
+    )
+    expect(paths).toEqual(["AGENTS.md", "knowledge/a.md", "new.md"])
+  })
+
+  it("marks dirty or ahead-of-default as differing", async () => {
+    const status = await conversationSandboxStatus({
+      defaultBranch: "main",
+      sessionBranch: "ctxpipe/chat/conv_1/1",
+      handle: fakeHandle([], {
+        "git status --porcelain": " M knowledge/a.md\n",
+        "git diff --numstat": "1\t0\tknowledge/a.md\n",
+        "git rev-list --left-right": "0\t1",
+        "origin/ctxpipe/chat/conv_1/1..HEAD": "1",
+      }),
+    })
+    expect(status.dirty).toBe(true)
+    expect(status.differsFromDefault).toBe(true)
+    expect(status.unpushed).toBe(true)
+    expect(status.published).toBe(true)
+    expect(status.items[0]?.path).toBe("knowledge/a.md")
+  })
+
+  it("writes and renames sandbox files", async () => {
+    const writes: Array<{ path: string; body: string }> = []
+    const removed: string[] = []
+    const handle = {
+      exec: async (command: string) => {
+        if (command.includes("git ls-files")) {
+          return { stdout: "knowledge/a.md\0", stderr: "", exitCode: 0 }
+        }
+        return { stdout: "", stderr: "", exitCode: 0 }
+      },
+      fs: {
+        write: async (path: string, body: string) => {
+          writes.push({ path, body })
+        },
+        read: async () => "hello",
+        remove: async (path: string) => {
+          removed.push(path)
+        },
+        mkdir: async () => undefined,
+      },
+    }
+    await writeConversationSandboxFile({
+      handle,
+      path: "knowledge/b.md",
+      body: "next",
+    })
+    await renameConversationSandboxPath({
+      handle,
+      from: "knowledge/a.md",
+      to: "knowledge/c.md",
+    })
+    expect(writes).toEqual([
+      { path: "knowledge/b.md", body: "next" },
+      { path: "knowledge/c.md", body: "hello" },
+    ])
+    expect(removed).toEqual(["knowledge/a.md"])
+  })
+
+  it("strips tokens from git remote errors", () => {
+    expect(
+      sanitizeGitRemoteError("fatal: token ghp_secret denied", "ghp_secret"),
+    ).toBe("fatal: token *** denied")
+  })
+})

--- a/apps/backend/src/domain/workspaces/conversation-files.ts
+++ b/apps/backend/src/domain/workspaces/conversation-files.ts
@@ -1,0 +1,254 @@
+import { adaptTanstackHandle } from "./job-sandbox.js"
+import { getRegisteredChatSandbox } from "./sandbox-registry.js"
+import { memoizedConversationSandboxHandle } from "./workspace-chat-sandbox-memo.js"
+import { conversationSessionBranch, mayForcePushBranch } from "./chat-lifecycle.js"
+import {
+  chatPullRequestPathIsSafe,
+  isChatSessionBranch,
+  splitGitNulPaths,
+} from "./chat-pull-request.js"
+import {
+  explorerBlobFromContent,
+  explorerGitStatusFromPorcelain,
+  withExplorerGitLineCounts,
+  explorerGitNumstatFromStdout,
+  type ExplorerGitStatusEntry,
+} from "./git-explorer.js"
+import type { JobSandboxHandle } from "./job-worktree.js"
+
+export { conversationSessionBranch }
+
+export function resolveConversationSandboxHandle(
+  conversationId: string,
+): JobSandboxHandle | null {
+  const registered = getRegisteredChatSandbox(conversationId)?.handle
+  if (registered) return registered
+  const raw = memoizedConversationSandboxHandle(conversationId)
+  return raw ? adaptTanstackHandle(raw) : null
+}
+
+async function execGit(
+  exec: JobSandboxHandle["exec"],
+  command: string,
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return exec(command, { env: env ?? {} })
+}
+
+async function execGitOk(
+  exec: JobSandboxHandle["exec"],
+  command: string,
+  env?: Record<string, string>,
+): Promise<string> {
+  const result = await execGit(exec, command, env)
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || `Command failed: ${command}`)
+  }
+  return result.stdout
+}
+
+export async function ensureConversationSessionBranch(input: {
+  handle: JobSandboxHandle
+  conversationId: string
+  defaultBranch: string
+}): Promise<string> {
+  const branch = conversationSessionBranch(input.conversationId)
+  if (!mayForcePushBranch(branch, input.defaultBranch)) {
+    throw new Error(`Refusing to check out ${branch}`)
+  }
+  if (!isChatSessionBranch(branch)) {
+    throw new Error(`Refusing to check out ${branch}`)
+  }
+  await execGitOk(input.handle.exec, `git checkout -B ${branch}`)
+  return branch
+}
+
+export async function listConversationSandboxPaths(
+  handle: JobSandboxHandle,
+): Promise<string[]> {
+  const [tracked, untracked] = await Promise.all([
+    execGitOk(handle.exec, "git ls-files -z"),
+    execGitOk(handle.exec, "git ls-files --others --exclude-standard -z"),
+  ])
+  const paths = new Set<string>()
+  for (const path of [
+    ...splitGitNulPaths(tracked),
+    ...splitGitNulPaths(untracked),
+  ]) {
+    if (chatPullRequestPathIsSafe(path)) paths.add(path)
+  }
+  return [...paths].sort()
+}
+
+export async function readConversationSandboxFile(
+  handle: JobSandboxHandle,
+  path: string,
+): Promise<{ path: string; body: string | null; binary: boolean } | null> {
+  if (!chatPullRequestPathIsSafe(path)) return null
+  try {
+    const content = await handle.fs.read(path)
+    const blob = explorerBlobFromContent(content)
+    if (!blob) return null
+    return { path, ...blob }
+  } catch {
+    return null
+  }
+}
+
+export async function writeConversationSandboxFile(input: {
+  handle: JobSandboxHandle
+  path: string
+  body: string
+}): Promise<void> {
+  if (!chatPullRequestPathIsSafe(input.path)) {
+    throw new Error(`Unsafe path: ${input.path}`)
+  }
+  const parent = input.path.split("/").slice(0, -1).join("/")
+  if (parent) await input.handle.fs.mkdir(parent)
+  await input.handle.fs.write(input.path, input.body)
+}
+
+export async function removeConversationSandboxPath(input: {
+  handle: JobSandboxHandle
+  path: string
+}): Promise<void> {
+  if (!chatPullRequestPathIsSafe(input.path)) {
+    throw new Error(`Unsafe path: ${input.path}`)
+  }
+  await input.handle.fs.remove(input.path)
+}
+
+export async function renameConversationSandboxPath(input: {
+  handle: JobSandboxHandle
+  from: string
+  to: string
+}): Promise<void> {
+  if (
+    !chatPullRequestPathIsSafe(input.from) ||
+    !chatPullRequestPathIsSafe(input.to)
+  ) {
+    throw new Error(`Unsafe path: ${input.from} → ${input.to}`)
+  }
+  if (input.from === input.to) return
+  const paths = await listConversationSandboxPaths(input.handle)
+  const matches = paths.filter(
+    (path) => path === input.from || path.startsWith(`${input.from}/`),
+  )
+  if (matches.length === 0) return
+  for (const oldPath of matches) {
+    const next =
+      oldPath === input.from
+        ? input.to
+        : `${input.to}/${oldPath.slice(input.from.length + 1)}`
+    const current = await readConversationSandboxFile(input.handle, oldPath)
+    if (current?.body != null) {
+      await writeConversationSandboxFile({
+        handle: input.handle,
+        path: next,
+        body: current.body,
+      })
+    }
+    await removeConversationSandboxPath({
+      handle: input.handle,
+      path: oldPath,
+    })
+  }
+}
+
+export type ConversationSandboxStatus = {
+  dirty: boolean
+  differsFromDefault: boolean
+  unpushed: boolean
+  published: boolean
+  ahead: number
+  behind: number
+  items: ExplorerGitStatusEntry[]
+}
+
+export async function conversationSandboxStatus(input: {
+  handle: JobSandboxHandle
+  defaultBranch: string
+  sessionBranch: string
+}): Promise<ConversationSandboxStatus> {
+  const [porcelain, numstat, revList, remoteAhead] = await Promise.all([
+    execGitOk(input.handle.exec, "git status --porcelain"),
+    execGitOk(input.handle.exec, "git diff --numstat HEAD"),
+    execGit(
+      input.handle.exec,
+      `git rev-list --left-right --count ${input.defaultBranch}...HEAD`,
+    ),
+    execGit(
+      input.handle.exec,
+      `git rev-list --count origin/${input.sessionBranch}..HEAD`,
+    ),
+  ])
+  const counts = explorerGitNumstatFromStdout(numstat)
+  const items = explorerGitStatusFromPorcelain(porcelain).map((item) =>
+    withExplorerGitLineCounts(item, counts),
+  )
+  const dirty = porcelain.trim().length > 0
+  const [behindRaw, aheadRaw] = (revList.stdout.trim() || "0\t0").split(/\s+/)
+  const ahead = Number.parseInt(aheadRaw || "0", 10) || 0
+  const behind = Number.parseInt(behindRaw || "0", 10) || 0
+  const published = remoteAhead.exitCode === 0
+  const remoteUnpushed = published
+    ? (Number.parseInt(remoteAhead.stdout.trim() || "0", 10) || 0) > 0
+    : ahead > 0
+  return {
+    dirty,
+    differsFromDefault: dirty || ahead > 0,
+    unpushed: dirty || remoteUnpushed,
+    published,
+    ahead,
+    behind,
+    items,
+  }
+}
+
+export type ConversationFileDiff = {
+  path: string
+  oldBody: string | null
+  body: string | null
+}
+
+export async function conversationSandboxDiff(input: {
+  handle: JobSandboxHandle
+  defaultBranch: string
+}): Promise<ConversationFileDiff[]> {
+  const [committed, unstaged, untracked] = await Promise.all([
+    execGitOk(
+      input.handle.exec,
+      `git diff --name-only -z ${input.defaultBranch}...HEAD`,
+    ),
+    execGitOk(input.handle.exec, "git diff --name-only -z HEAD"),
+    execGitOk(input.handle.exec, "git ls-files --others --exclude-standard -z"),
+  ])
+  const paths = new Set<string>()
+  for (const path of [
+    ...splitGitNulPaths(committed),
+    ...splitGitNulPaths(unstaged),
+    ...splitGitNulPaths(untracked),
+  ]) {
+    if (chatPullRequestPathIsSafe(path)) paths.add(path)
+  }
+  const diffs: ConversationFileDiff[] = []
+  for (const path of [...paths].sort()) {
+    const oldResult = await execGit(
+      input.handle.exec,
+      `git show ${input.defaultBranch}:${path}`,
+    )
+    const oldBody =
+      oldResult.exitCode === 0 ? oldResult.stdout : null
+    const current = await readConversationSandboxFile(input.handle, path)
+    diffs.push({
+      path,
+      oldBody,
+      body: current?.binary ? null : (current?.body ?? null),
+    })
+  }
+  return diffs
+}
+
+export function sanitizeGitRemoteError(text: string, token: string): string {
+  return token ? text.split(token).join("***") : text
+}

--- a/apps/backend/src/domain/workspaces/conversation-publish.test.ts
+++ b/apps/backend/src/domain/workspaces/conversation-publish.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+import {
+  chromePullRequestAction,
+  conversationGithubPullUrl,
+  conversationPushRemoteUrl,
+  pushConversationSessionBranch,
+  shellSingleQuote,
+} from "./conversation-publish.js"
+
+describe("conversation publish", () => {
+  it("quotes commit messages for the leftover commit", () => {
+    expect(shellSingleQuote("Repo layout")).toBe("'Repo layout'")
+    expect(shellSingleQuote("it's fine")).toBe("'it'\\''s fine'")
+  })
+
+  it("builds a tokenized push remote without leaving the token in chrome URLs", () => {
+    expect(
+      conversationPushRemoteUrl({
+        repositoryName: "acme/docs",
+        token: "tok",
+      }),
+    ).toBe("https://x-access-token:tok@github.com/acme/docs.git")
+    expect(
+      conversationGithubPullUrl({ repositoryName: "acme/docs", prNumber: 41 }),
+    ).toBe("https://github.com/acme/docs/pull/41")
+  })
+
+  it("returns Create PR after a merged or closed PR", () => {
+    expect(chromePullRequestAction("open")).toBe("show")
+    expect(chromePullRequestAction("merged")).toBe("create")
+    expect(chromePullRequestAction(null)).toBe("create")
+  })
+
+  it("pushes leftover commits on the session branch only", async () => {
+    const commands: string[] = []
+    const result = await pushConversationSessionBranch({
+      conversationId: "conv_1",
+      defaultBranch: "main",
+      repositoryName: "acme/docs",
+      token: "tok",
+      commitMessage: "Repo layout",
+      handle: {
+        exec: async (command) => {
+          commands.push(command)
+          if (command.includes("git status --porcelain")) {
+            return { stdout: "", stderr: "", exitCode: 0 }
+          }
+          if (command.includes("git rev-list --left-right")) {
+            return { stdout: "0\t1", stderr: "", exitCode: 0 }
+          }
+          if (command.includes("origin/ctxpipe/chat/conv_1/1..HEAD")) {
+            return { stdout: "1", stderr: "", exitCode: 0 }
+          }
+          if (command.includes("nothing to commit")) {
+            return { stdout: "nothing to commit", stderr: "", exitCode: 1 }
+          }
+          return { stdout: "", stderr: "", exitCode: 0 }
+        },
+        fs: {
+          write: async () => undefined,
+          read: async () => "",
+          remove: async () => undefined,
+          mkdir: async () => undefined,
+        },
+      },
+    })
+    expect(result).toEqual({
+      ok: true,
+      branch: "ctxpipe/chat/conv_1/1",
+      pushed: true,
+    })
+    expect(
+      commands.some((command) =>
+        command.includes(
+          "git push --force-with-lease https://x-access-token:tok@github.com/acme/docs.git HEAD:refs/heads/ctxpipe/chat/conv_1/1",
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      commands.some((command) => command.includes("git checkout -B ctxpipe/chat/conv_1/1")),
+    ).toBe(true)
+  })
+
+  it("refuses to push when there is nothing vs default and nothing unpushed", async () => {
+    const result = await pushConversationSessionBranch({
+      conversationId: "conv_1",
+      defaultBranch: "main",
+      repositoryName: "acme/docs",
+      token: "tok",
+      commitMessage: "Repo layout",
+      handle: {
+        exec: async (command) => {
+          if (command.includes("git commit")) {
+            return {
+              stdout: "nothing to commit, working tree clean",
+              stderr: "",
+              exitCode: 1,
+            }
+          }
+          if (command.includes("git rev-list --left-right")) {
+            return { stdout: "0\t0", stderr: "", exitCode: 0 }
+          }
+          if (command.includes("origin/ctxpipe/chat/conv_1/1..HEAD")) {
+            return { stdout: "0", stderr: "", exitCode: 0 }
+          }
+          return { stdout: "", stderr: "", exitCode: 0 }
+        },
+        fs: {
+          write: async () => undefined,
+          read: async () => "",
+          remove: async () => undefined,
+          mkdir: async () => undefined,
+        },
+      },
+    })
+    expect(result).toEqual({ ok: false, error: "no_changes" })
+  })
+})

--- a/apps/backend/src/domain/workspaces/conversation-publish.ts
+++ b/apps/backend/src/domain/workspaces/conversation-publish.ts
@@ -1,0 +1,118 @@
+import {
+  conversationSessionBranch,
+  mayForcePushBranch,
+  planChatPullRequest,
+} from "./chat-lifecycle.js"
+import { isChatSessionBranch } from "./chat-pull-request.js"
+import {
+  conversationSandboxStatus,
+  ensureConversationSessionBranch,
+  sanitizeGitRemoteError,
+} from "./conversation-files.js"
+import type { JobSandboxHandle } from "./job-worktree.js"
+
+export type ConversationPublishPlan = ReturnType<typeof planChatPullRequest>
+
+export async function commitLeftoverConversationFiles(input: {
+  handle: JobSandboxHandle
+  conversationId: string
+  defaultBranch: string
+  message: string
+}): Promise<{ committed: boolean; branch: string }> {
+  const branch = await ensureConversationSessionBranch({
+    handle: input.handle,
+    conversationId: input.conversationId,
+    defaultBranch: input.defaultBranch,
+  })
+  await input.handle.exec("git add -A", { env: {} })
+  const committed = await input.handle.exec(
+    `git -c user.email=workspace-chat@ctxpipe.local -c user.name=ctxpipe commit -m ${shellSingleQuote(input.message)}`,
+    { env: {} },
+  )
+  const output = `${committed.stdout}\n${committed.stderr}`
+  if (committed.exitCode !== 0 && !/nothing to commit/i.test(output)) {
+    throw new Error(committed.stderr || "Failed to commit leftover conversation files")
+  }
+  return { committed: committed.exitCode === 0, branch }
+}
+
+export function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+export function conversationPushRemoteUrl(input: {
+  repositoryName: string
+  token: string
+}): string {
+  return `https://x-access-token:${input.token}@github.com/${input.repositoryName}.git`
+}
+
+export async function pushConversationSessionBranch(input: {
+  handle: JobSandboxHandle
+  conversationId: string
+  defaultBranch: string
+  repositoryName: string
+  token: string
+  commitMessage: string
+}): Promise<
+  | { ok: true; branch: string; pushed: boolean }
+  | { ok: false; error: "no_changes" | "default_branch" | string }
+> {
+  const branch = conversationSessionBranch(input.conversationId)
+  if (!mayForcePushBranch(branch, input.defaultBranch)) {
+    return { ok: false, error: "default_branch" }
+  }
+  if (!isChatSessionBranch(branch)) {
+    return { ok: false, error: "default_branch" }
+  }
+  await commitLeftoverConversationFiles({
+    handle: input.handle,
+    conversationId: input.conversationId,
+    defaultBranch: input.defaultBranch,
+    message: input.commitMessage,
+  })
+  const status = await conversationSandboxStatus({
+    handle: input.handle,
+    defaultBranch: input.defaultBranch,
+    sessionBranch: branch,
+  })
+  if (!status.differsFromDefault && !status.unpushed) {
+    return { ok: false, error: "no_changes" }
+  }
+  const remote = conversationPushRemoteUrl({
+    repositoryName: input.repositoryName,
+    token: input.token,
+  })
+  const pushed = await input.handle.exec(
+    `git push --force-with-lease ${remote} HEAD:refs/heads/${branch}`,
+    { env: {} },
+  )
+  if (pushed.exitCode !== 0) {
+    return {
+      ok: false,
+      error: sanitizeGitRemoteError(
+        pushed.stderr || "Failed to push the conversation branch",
+        input.token,
+      ),
+    }
+  }
+  return { ok: true, branch, pushed: true }
+}
+
+export function conversationGithubTreeUrl(input: {
+  repositoryName: string
+  branch: string
+}): string {
+  return `https://github.com/${input.repositoryName}/tree/${input.branch}`
+}
+
+export function conversationGithubPullUrl(input: {
+  repositoryName: string
+  prNumber: number
+}): string {
+  return `https://github.com/${input.repositoryName}/pull/${input.prNumber}`
+}
+
+export function chromePullRequestAction(prState: string | null): "create" | "show" {
+  return prState === "open" ? "show" : "create"
+}

--- a/apps/backend/src/domain/workspaces/tanstack-workspace-chat.ts
+++ b/apps/backend/src/domain/workspaces/tanstack-workspace-chat.ts
@@ -248,7 +248,11 @@ async function* streamTanstackWorkspaceChatBody(
   }, CHAT_HEARTBEAT_INTERVAL_MS)
 
   const startedAt = Date.now()
-  const runtime = workspaceChatRuntimeConfig({ writeStatus: turn.writeStatus })
+  const runtime = workspaceChatRuntimeConfig({
+    writeStatus: turn.writeStatus,
+    currentBranch: turn.ref,
+    defaultBranch: turn.defaultBranch,
+  })
   const recordChatAttempt = (error?: unknown) => {
     const fields = opencodeChatStreamEvent({
       conversationId: turn.conversationId,
@@ -440,7 +444,11 @@ async function startWorkspaceChat(input: TanstackWorkspaceChatInput): Promise<
 > {
   const built = await buildWorkspaceChatSandbox(input)
   if (!built.ok) return built
-  const runtime = workspaceChatRuntimeConfig({ writeStatus: input.writeStatus })
+  const runtime = workspaceChatRuntimeConfig({
+    writeStatus: input.writeStatus,
+    currentBranch: input.ref,
+    defaultBranch: input.defaultBranch,
+  })
   const session = await resolveWorkspaceChatSession(input, built.spec.isolation)
   if (!session.ok) return session
   const portLease =
@@ -593,7 +601,11 @@ async function buildWorkspaceChatSandbox(input: TanstackWorkspaceChatInput) {
       error: "workspace_required",
     }
   }
-  const runtime = workspaceChatRuntimeConfig({ writeStatus: input.writeStatus })
+  const runtime = workspaceChatRuntimeConfig({
+    writeStatus: input.writeStatus,
+    currentBranch: input.ref,
+    defaultBranch: input.defaultBranch,
+  })
   const contract = workspaceChatOpenCodeContract(process.env)
   if (!contract.ok) {
     return {

--- a/apps/backend/src/domain/workspaces/workspace-chat-sandbox-memo.ts
+++ b/apps/backend/src/domain/workspaces/workspace-chat-sandbox-memo.ts
@@ -58,6 +58,12 @@ export function memoizedConversationSandbox<T>(input: {
   return { definition, handle }
 }
 
+export function memoizedConversationSandboxHandle(
+  conversationId: string,
+): TanstackLikeHandle | null {
+  return definitions.get(conversationId)?.handle.current ?? null
+}
+
 export function forgetConversationSandboxDefinition(
   conversationId: string,
 ): void {

--- a/apps/backend/src/domain/workspaces/workspace-chat-send-runtime.ts
+++ b/apps/backend/src/domain/workspaces/workspace-chat-send-runtime.ts
@@ -44,7 +44,7 @@ export async function resolveWorkspaceChatSendRuntime(input: {
     desiredGeneration: runtime.desiredGeneration,
     writeStatus: runtime.writeStatus,
     defaultBranch: runtime.defaultBranch,
-    ref: runtime.lastBranch || runtime.desiredSha || "HEAD",
+    ref: runtime.cloneRef || runtime.desiredSha || "HEAD",
     cloneToken: runtime.cloneToken ?? null,
   }
 }

--- a/apps/backend/src/domain/workspaces/workspace-chat-turn-runtime.ts
+++ b/apps/backend/src/domain/workspaces/workspace-chat-turn-runtime.ts
@@ -5,9 +5,11 @@ import { log } from "../../observability/logger.js"
 import { resolveGithubDefaultBranch } from "../../routes/webhooks/github/github-workspace-tip.js"
 import { githubRefExists } from "../../services/github/installation-write-client.js"
 import {
+  conversationSessionBranch,
   lastBranchExistsOnRemote,
   restoreBranchAfterIdle,
 } from "./chat-lifecycle.js"
+import { workspaceAllowsConversationEdits } from "./chat-sandbox-policy.js"
 import { githubRepoFullNameFromWorkspaceUrl } from "./write-status.js"
 
 export type WorkspaceChatTurnConversation = {
@@ -33,6 +35,7 @@ export async function resolveWorkspaceChatTurnRuntime(input: {
   env: Env
 }): Promise<{
   lastBranch: string
+  cloneRef: string
   defaultBranch: string
   cloneToken: string | null
   writeStatus: string
@@ -79,7 +82,7 @@ export async function resolveWorkspaceChatTurnRuntime(input: {
     ms: Date.now() - githubStarted,
     conversationId: conversation.id,
   })
-  const lastBranch = restoreBranchAfterIdle({
+  const restored = restoreBranchAfterIdle({
     lastBranch: conversation.lastBranch,
     lastBranchExistsOnRemote: lastBranchExistsOnRemote({
       lastBranch: conversation.lastBranch,
@@ -90,6 +93,25 @@ export async function resolveWorkspaceChatTurnRuntime(input: {
     }),
     defaultBranch,
   })
+  const canEdit = workspaceAllowsConversationEdits(
+    workspace?.writeStatus ?? "read_only",
+  )
+  const sessionBranch = conversationSessionBranch(conversation.id)
+  const lastBranch = canEdit ? sessionBranch : restored
+  const cloneRef =
+    canEdit &&
+    conversation.lastBranch === sessionBranch &&
+    lastBranchExistsOnRemote({
+      lastBranch: conversation.lastBranch,
+      remoteBranches:
+        remoteHasLastBranch && conversation.lastBranch
+          ? [conversation.lastBranch]
+          : [],
+    })
+      ? sessionBranch
+      : restored === defaultBranch
+        ? (workspace?.desiredSha ?? defaultBranch)
+        : restored
   if (lastBranch.startsWith("ctxpipe/chat/")) {
     await persistConversationLastBranch({
       conversationId: conversation.id,
@@ -98,6 +120,7 @@ export async function resolveWorkspaceChatTurnRuntime(input: {
   }
   return {
     lastBranch,
+    cloneRef: cloneRef || workspace?.desiredSha || defaultBranch,
     defaultBranch,
     cloneToken,
     writeStatus: workspace?.writeStatus ?? "read_only",

--- a/apps/backend/src/domain/workspaces/write-status.test.ts
+++ b/apps/backend/src/domain/workspaces/write-status.test.ts
@@ -9,6 +9,7 @@ import {
   WRITE_STATUS_REASONS,
   writeStatusFromClassification,
   writeStatusFromGithubProbeError,
+  isProtectedDefaultBranchGithubError,
 } from "./write-status.js"
 
 describe("githubRepoFullNameFromWorkspaceUrl", () => {
@@ -76,22 +77,28 @@ describe("writeStatusFromGithubProbeError", () => {
     })
   })
 
-  it("maps protected-branch 403 separately from Contents:write", () => {
+  it("does not freeze the Workspace when only the default branch is protected", () => {
+    expect(
+      isProtectedDefaultBranchGithubError({
+        status: 403,
+        message: "Required status checks on protected branch",
+      }),
+    ).toBe(true)
     expect(
       writeStatusFromGithubProbeError({
         status: 403,
         message: "Required status checks on protected branch",
-      }).readOnlyReason,
-    ).toBe(WRITE_STATUS_REASONS.protectedBranch)
-    expect(
-      writeStatusFromGithubProbeError({ status: 403 }).readOnlyReason,
-    ).toBe(WRITE_STATUS_REASONS.contentsWriteDenied)
+      }),
+    ).toEqual({ writeStatus: "writable", readOnlyReason: null })
     expect(
       writeStatusFromGithubProbeError({
         status: 403,
         message: "Repository ruleset prevents this push",
-      }).readOnlyReason,
-    ).toBe(WRITE_STATUS_REASONS.protectedBranch)
+      }),
+    ).toEqual({ writeStatus: "writable", readOnlyReason: null })
+    expect(
+      writeStatusFromGithubProbeError({ status: 403 }).readOnlyReason,
+    ).toBe(WRITE_STATUS_REASONS.contentsWriteDenied)
   })
 })
 

--- a/apps/backend/src/domain/workspaces/write-status.ts
+++ b/apps/backend/src/domain/workspaces/write-status.ts
@@ -17,9 +17,9 @@ export const WRITE_STATUS_REASONS = {
   notInInstallation:
     "This repository is not in the GitHub App installation. An installation owner or admin must add it, then refresh.",
   contentsWriteDenied:
-    "The GitHub App cannot write to this repository. Grant Contents: write, or check branch protection — ctxpipe does not open a pull request.",
+    "The GitHub App cannot write to this repository. Grant Contents: write so ctxpipe can push a conversation branch.",
   protectedBranch:
-    "The default branch is protected. ctxpipe commits directly and will not open a pull request. Relax protection for the App or relink.",
+    "The default branch is protected. Jobs cannot push it; conversation chat can still push a session branch and open a pull request.",
 } as const
 
 export type WorkspaceWriteProbe = {
@@ -70,27 +70,35 @@ export function writeStatusFromClassification(input: {
   }
 }
 
+export function isProtectedDefaultBranchGithubError(error: {
+  status?: number
+  message?: string
+}): boolean {
+  if (error.status !== 403) return false
+  const message = (error.message ?? "").toLowerCase()
+  return (
+    message.includes("protected") ||
+    message.includes("ruleset") ||
+    message.includes("required status")
+  )
+}
+
+/**
+ * Maps a live GitHub error to Workspace writeStatus.
+ * Protected default is not read-only: the App can still push a session branch.
+ */
 export function writeStatusFromGithubProbeError(error: {
   status?: number
   message?: string
 }): WorkspaceWriteProbe {
-  const message = (error.message ?? "").toLowerCase()
   if (error.status === 404) {
     return {
       writeStatus: WORKSPACE_WRITE_STATUSES.read_only,
       readOnlyReason: WRITE_STATUS_REASONS.notInInstallation,
     }
   }
-  if (
-    error.status === 403 &&
-    (message.includes("protected") ||
-      message.includes("ruleset") ||
-      message.includes("required status"))
-  ) {
-    return {
-      writeStatus: WORKSPACE_WRITE_STATUSES.read_only,
-      readOnlyReason: WRITE_STATUS_REASONS.protectedBranch,
-    }
+  if (isProtectedDefaultBranchGithubError(error)) {
+    return writableWorkspaceWriteProbe()
   }
   if (error.status === 403) {
     return {

--- a/apps/backend/src/openworkflow/workflows/workspace-write-commit.ts
+++ b/apps/backend/src/openworkflow/workflows/workspace-write-commit.ts
@@ -47,6 +47,7 @@ import {
 } from "../../domain/workspaces/write-runner.js"
 import {
   githubRepoFullNameFromWorkspaceUrl,
+  isProtectedDefaultBranchGithubError,
   writeStatusFromGithubProbeError,
 } from "../../domain/workspaces/write-status.js"
 import { generateObjectId } from "../../lib/id.js"
@@ -580,6 +581,12 @@ export const workspaceWriteCommit = defineWorkflow(
                 error && typeof error === "object"
                   ? (error as { status?: number; message?: string })
                   : {}
+              if (isProtectedDefaultBranchGithubError(probe)) {
+                await orgSql(() =>
+                  persistWriteJobStatus(jobId, WRITE_JOB_STATUSES.paused),
+                )
+                return { committed: false, reason: "paused" as const }
+              }
               const mapped = writeStatusFromGithubProbeError(probe)
               if (mapped.writeStatus === "read_only") {
                 await orgSql(async () => {

--- a/apps/backend/src/routes/v1/conversation-files-routes.ts
+++ b/apps/backend/src/routes/v1/conversation-files-routes.ts
@@ -1,0 +1,509 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { AppEnv } from "../../app/env.js"
+import { parseEnv } from "../../config/env.js"
+import {
+  conversationSandboxDiff,
+  conversationSandboxStatus,
+  ensureConversationSessionBranch,
+  listConversationSandboxPaths,
+  readConversationSandboxFile,
+  removeConversationSandboxPath,
+  resolveConversationSandboxHandle,
+  renameConversationSandboxPath,
+  writeConversationSandboxFile,
+} from "../../domain/workspaces/conversation-files.js"
+import {
+  conversationGithubPullUrl,
+  conversationGithubTreeUrl,
+  pushConversationSessionBranch,
+} from "../../domain/workspaces/conversation-publish.js"
+import { workspaceAllowsConversationEdits } from "../../domain/workspaces/chat-sandbox-policy.js"
+import { conversationSessionBranch as sessionBranchName } from "../../domain/workspaces/chat-lifecycle.js"
+import { attachChatSandboxHandle } from "../../domain/workspaces/sandbox-registry.js"
+import { getConversation, persistConversationLastBranch } from "../../models/conversations.js"
+import { getInstallationToken } from "../../models/github-installation.js"
+import { getWorkspaceById } from "../../models/workspaces.js"
+import { githubRepoFullNameFromWorkspaceUrl } from "../../domain/workspaces/write-status.js"
+import { resolveGithubDefaultBranch } from "../webhooks/github/github-workspace-tip.js"
+
+const ErrorResponseSchema = z
+  .object({ error: z.string() })
+  .openapi("ConversationFileErrorResponse")
+
+const ConversationParamsSchema = z
+  .object({
+    conversationId: z.string().min(1),
+  })
+  .openapi("ConversationFileParams")
+
+const ConversationGitTreeResponseSchema = z
+  .object({
+    sha: z.string(),
+    paths: z.array(z.string()),
+    branch: z.string(),
+  })
+  .openapi("ConversationGitTreeResponse")
+
+const ConversationGitBlobQuerySchema = z
+  .object({
+    path: z.string().min(1),
+  })
+  .openapi("ConversationGitBlobQuery")
+
+const ConversationGitBlobResponseSchema = z
+  .object({
+    path: z.string(),
+    body: z.string().nullable(),
+    binary: z.boolean(),
+  })
+  .openapi("ConversationGitBlobResponse")
+
+const ConversationGitStatusResponseSchema = z
+  .object({
+    source: z.literal("sandbox"),
+    dirty: z.boolean(),
+    differsFromDefault: z.boolean(),
+    unpushed: z.boolean(),
+    published: z.boolean(),
+    ahead: z.number().int(),
+    behind: z.number().int(),
+    items: z.array(
+      z.object({
+        path: z.string(),
+        status: z.string(),
+        additions: z.number().int().optional(),
+        deletions: z.number().int().optional(),
+      }),
+    ),
+  })
+  .openapi("ConversationGitStatusResponse")
+
+const ConversationGitDiffResponseSchema = z
+  .object({
+    items: z.array(
+      z.object({
+        path: z.string(),
+        oldBody: z.string().nullable(),
+        body: z.string().nullable(),
+      }),
+    ),
+  })
+  .openapi("ConversationGitDiffResponse")
+
+const PutConversationFileBodySchema = z
+  .object({
+    path: z.string().min(1),
+    body: z.string().optional(),
+    deletePath: z.boolean().optional(),
+    from: z.string().min(1).optional(),
+  })
+  .openapi("PutConversationFileBody")
+
+const ConversationPushResponseSchema = z
+  .object({
+    branch: z.string(),
+    treeUrl: z.string(),
+  })
+  .openapi("ConversationPushResponse")
+
+const listTreeRoute = createRoute({
+  method: "get",
+  path: "/{conversationId}/files/tree",
+  request: { params: ConversationParamsSchema },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ConversationGitTreeResponseSchema },
+      },
+      description: "Sandbox git tree",
+    },
+    401: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unauthorized",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Not found",
+    },
+    409: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Chat sandbox missing",
+    },
+  },
+})
+
+const getBlobRoute = createRoute({
+  method: "get",
+  path: "/{conversationId}/files/blob",
+  request: {
+    params: ConversationParamsSchema,
+    query: ConversationGitBlobQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ConversationGitBlobResponseSchema },
+      },
+      description: "Sandbox file",
+    },
+    401: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unauthorized",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Not found",
+    },
+    409: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Chat sandbox missing",
+    },
+  },
+})
+
+const getStatusRoute = createRoute({
+  method: "get",
+  path: "/{conversationId}/files/status",
+  request: { params: ConversationParamsSchema },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ConversationGitStatusResponseSchema },
+      },
+      description: "Sandbox git status vs default",
+    },
+    401: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unauthorized",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Not found",
+    },
+    409: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Chat sandbox missing",
+    },
+  },
+})
+
+const getDiffRoute = createRoute({
+  method: "get",
+  path: "/{conversationId}/files/diff",
+  request: { params: ConversationParamsSchema },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ConversationGitDiffResponseSchema },
+      },
+      description: "Per-file diffs vs default",
+    },
+    401: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unauthorized",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Not found",
+    },
+    409: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Chat sandbox missing",
+    },
+  },
+})
+
+const putFileRoute = createRoute({
+  method: "put",
+  path: "/{conversationId}/files/blob",
+  request: {
+    params: ConversationParamsSchema,
+    body: {
+      content: { "application/json": { schema: PutConversationFileBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ConversationGitBlobResponseSchema },
+      },
+      description: "Wrote sandbox file",
+    },
+    401: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unauthorized",
+    },
+    403: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Read-only",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Not found",
+    },
+    409: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Chat sandbox missing",
+    },
+  },
+})
+
+const postPushRoute = createRoute({
+  method: "post",
+  path: "/{conversationId}/push",
+  request: { params: ConversationParamsSchema },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ConversationPushResponseSchema },
+      },
+      description: "Pushed the session branch",
+    },
+    400: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Refused",
+    },
+    401: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unauthorized",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Not found",
+    },
+    409: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Chat sandbox missing",
+    },
+  },
+})
+
+async function loadConversationWorkspace(conversationId: string) {
+  const conversation = await getConversation(conversationId)
+  if (!conversation?.workspaceId) return null
+  const workspace = await getWorkspaceById(conversation.workspaceId)
+  if (!workspace) return null
+  return { conversation, workspace }
+}
+
+function requireUser(c: { get: (key: "user" | "session") => unknown }) {
+  return Boolean(c.get("user") && c.get("session"))
+}
+
+export const conversationFileRoutes = new OpenAPIHono<AppEnv>()
+  .openapi(listTreeRoute, async (c) => {
+    if (!requireUser(c)) return c.json({ error: "Unauthorized" }, 401)
+    const conversationId = c.req.param("conversationId")
+    const loaded = await loadConversationWorkspace(conversationId)
+    if (!loaded) return c.json({ error: "Not found" }, 404)
+    const handle = resolveConversationSandboxHandle(conversationId)
+    if (!handle) return c.json({ error: "missing_sandbox" }, 409)
+    const paths = await listConversationSandboxPaths(handle)
+    const branch = sessionBranchName(conversationId)
+    return c.json({ sha: loaded.workspace.desiredSha ?? "HEAD", paths, branch })
+  })
+  .openapi(getBlobRoute, async (c) => {
+    if (!requireUser(c)) return c.json({ error: "Unauthorized" }, 401)
+    const conversationId = c.req.param("conversationId")
+    const path = c.req.query("path") ?? ""
+    const loaded = await loadConversationWorkspace(conversationId)
+    if (!loaded) return c.json({ error: "Not found" }, 404)
+    const handle = resolveConversationSandboxHandle(conversationId)
+    if (!handle) return c.json({ error: "missing_sandbox" }, 409)
+    const blob = await readConversationSandboxFile(handle, path)
+    if (!blob) return c.json({ error: "Not found" }, 404)
+    return c.json(blob)
+  })
+  .openapi(getStatusRoute, async (c) => {
+    if (!requireUser(c)) return c.json({ error: "Unauthorized" }, 401)
+    const conversationId = c.req.param("conversationId")
+    const loaded = await loadConversationWorkspace(conversationId)
+    if (!loaded) return c.json({ error: "Not found" }, 404)
+    const handle = resolveConversationSandboxHandle(conversationId)
+    if (!handle) return c.json({ error: "missing_sandbox" }, 409)
+    const env = parseEnv(process.env as Record<string, string | undefined>)
+    const repoName = githubRepoFullNameFromWorkspaceUrl(
+      loaded.workspace.workspaceRepositoryUrl,
+    )
+    const defaultBranch = repoName
+      ? ((await resolveGithubDefaultBranch({
+          orgId: loaded.workspace.orgId,
+          githubConnectionId: loaded.workspace.githubConnectionId,
+          repoFullName: repoName,
+          env,
+        })) ?? "main")
+      : "main"
+    const status = await conversationSandboxStatus({
+      handle,
+      defaultBranch,
+      sessionBranch: sessionBranchName(conversationId),
+    })
+    return c.json({ source: "sandbox" as const, ...status })
+  })
+  .openapi(getDiffRoute, async (c) => {
+    if (!requireUser(c)) return c.json({ error: "Unauthorized" }, 401)
+    const conversationId = c.req.param("conversationId")
+    const loaded = await loadConversationWorkspace(conversationId)
+    if (!loaded) return c.json({ error: "Not found" }, 404)
+    const handle = resolveConversationSandboxHandle(conversationId)
+    if (!handle) return c.json({ error: "missing_sandbox" }, 409)
+    const env = parseEnv(process.env as Record<string, string | undefined>)
+    const repoName = githubRepoFullNameFromWorkspaceUrl(
+      loaded.workspace.workspaceRepositoryUrl,
+    )
+    const defaultBranch = repoName
+      ? ((await resolveGithubDefaultBranch({
+          orgId: loaded.workspace.orgId,
+          githubConnectionId: loaded.workspace.githubConnectionId,
+          repoFullName: repoName,
+          env,
+        })) ?? "main")
+      : "main"
+    const items = await conversationSandboxDiff({ handle, defaultBranch })
+    return c.json({ items })
+  })
+  .openapi(putFileRoute, async (c) => {
+    if (!requireUser(c)) return c.json({ error: "Unauthorized" }, 401)
+    const conversationId = c.req.param("conversationId")
+    const loaded = await loadConversationWorkspace(conversationId)
+    if (!loaded) return c.json({ error: "Not found" }, 404)
+    if (!workspaceAllowsConversationEdits(loaded.workspace.writeStatus)) {
+      return c.json({ error: "read_only" }, 403)
+    }
+    const handle = resolveConversationSandboxHandle(conversationId)
+    if (!handle) return c.json({ error: "missing_sandbox" }, 409)
+    const body = PutConversationFileBodySchema.parse(await c.req.json())
+    if (body.deletePath) {
+      await removeConversationSandboxPath({ handle, path: body.path })
+      return c.json({ path: body.path, body: null, binary: false })
+    }
+    if (body.from && body.from !== body.path) {
+      await renameConversationSandboxPath({
+        handle,
+        from: body.from,
+        to: body.path,
+      })
+    }
+    if (body.body != null) {
+      await writeConversationSandboxFile({
+        handle,
+        path: body.path,
+        body: body.body,
+      })
+    }
+    return c.json({
+      path: body.path,
+      body: body.body ?? null,
+      binary: false,
+    })
+  })
+  .openapi(postPushRoute, async (c) => {
+    if (!requireUser(c)) return c.json({ error: "Unauthorized" }, 401)
+    const conversationId = c.req.param("conversationId")
+    const loaded = await loadConversationWorkspace(conversationId)
+    if (!loaded) return c.json({ error: "Not found" }, 404)
+    if (!workspaceAllowsConversationEdits(loaded.workspace.writeStatus)) {
+      return c.json({ error: "read_only" }, 400)
+    }
+    const handle = resolveConversationSandboxHandle(conversationId)
+    if (!handle) return c.json({ error: "missing_sandbox" }, 409)
+    const env = parseEnv(process.env as Record<string, string | undefined>)
+    const repoName = githubRepoFullNameFromWorkspaceUrl(
+      loaded.workspace.workspaceRepositoryUrl,
+    )
+    if (!repoName) return c.json({ error: "not_github" }, 400)
+    const token = await getInstallationToken(
+      loaded.workspace.orgId,
+      env,
+      loaded.workspace.githubConnectionId ?? undefined,
+    )
+    if (!token) return c.json({ error: "not_allowed" }, 400)
+    const defaultBranch =
+      (await resolveGithubDefaultBranch({
+        orgId: loaded.workspace.orgId,
+        githubConnectionId: loaded.workspace.githubConnectionId,
+        repoFullName: repoName,
+        env,
+      })) ?? "main"
+    const pushed = await pushConversationSessionBranch({
+      handle,
+      conversationId,
+      defaultBranch,
+      repositoryName: repoName,
+      token,
+      commitMessage: loaded.conversation.name,
+    })
+    if (!pushed.ok) return c.json({ error: pushed.error }, 400)
+    await persistConversationLastBranch({
+      conversationId,
+      lastBranch: pushed.branch,
+    })
+    return c.json({
+      branch: pushed.branch,
+      treeUrl: conversationGithubTreeUrl({
+        repositoryName: repoName,
+        branch: pushed.branch,
+      }),
+    })
+  })
+
+export async function checkoutPreparedConversationBranch(input: {
+  conversationId: string
+  workspaceId: string
+  orgId: string
+  defaultBranch: string
+  writeStatus: string
+  desiredUrl?: string
+  desiredGeneration?: number
+  desiredSha?: string | null
+}): Promise<void> {
+  if (!workspaceAllowsConversationEdits(input.writeStatus)) return
+  const handle = resolveConversationSandboxHandle(input.conversationId)
+  if (!handle) return
+  const branch = await ensureConversationSessionBranch({
+    handle,
+    conversationId: input.conversationId,
+    defaultBranch: input.defaultBranch,
+  })
+  await persistConversationLastBranch({
+    conversationId: input.conversationId,
+    lastBranch: branch,
+  })
+  await attachChatSandboxHandle({
+    kind: "chat",
+    conversationId: input.conversationId,
+    workspaceId: input.workspaceId,
+    orgId: input.orgId,
+    handle,
+    desiredUrl: input.desiredUrl,
+    desiredGeneration: input.desiredGeneration,
+    desiredSha: input.desiredSha,
+    defaultBranch: input.defaultBranch,
+  })
+}
+
+export function conversationPublicPrUrl(input: {
+  workspaceRepositoryUrl: string
+  lastChatPrNumber: number | null
+}): string | null {
+  if (input.lastChatPrNumber == null) return null
+  const repo = githubRepoFullNameFromWorkspaceUrl(input.workspaceRepositoryUrl)
+  if (!repo) return null
+  return conversationGithubPullUrl({
+    repositoryName: repo,
+    prNumber: input.lastChatPrNumber,
+  })
+}
+
+export function conversationPublicTreeUrl(input: {
+  workspaceRepositoryUrl: string
+  lastBranch: string | null
+}): string | null {
+  if (!input.lastBranch?.startsWith("ctxpipe/chat/")) return null
+  const repo = githubRepoFullNameFromWorkspaceUrl(input.workspaceRepositoryUrl)
+  if (!repo) return null
+  return conversationGithubTreeUrl({
+    repositoryName: repo,
+    branch: input.lastBranch,
+  })
+}

--- a/apps/backend/src/routes/v1/conversations.test.ts
+++ b/apps/backend/src/routes/v1/conversations.test.ts
@@ -19,10 +19,12 @@ const loadConversationTurnsMock = vi.hoisted(() =>
 
 const getWorkspaceByIdMock = vi.hoisted(() => vi.fn())
 const getRegisteredChatSandboxMock = vi.hoisted(() => vi.fn())
-const collectChatPullRequestTreeMock = vi.hoisted(() => vi.fn())
+const resolveConversationSandboxHandleMock = vi.hoisted(() => vi.fn())
+const pushConversationSessionBranchMock = vi.hoisted(() => vi.fn())
+const createPullRequestFromBranchMock = vi.hoisted(() => vi.fn())
+const getPullRequestStateMock = vi.hoisted(() => vi.fn())
 const reserveConversationChatPrNumberMock = vi.hoisted(() => vi.fn())
 const persistConversationLastChatPrNumberMock = vi.hoisted(() => vi.fn())
-const createPullRequestWithFilesMock = vi.hoisted(() => vi.fn())
 
 vi.mock("../../models/workspaces.js", () => ({
   getWorkspaceById: getWorkspaceByIdMock,
@@ -38,12 +40,31 @@ vi.mock("../webhooks/github/github-workspace-tip.js", () => ({
 
 vi.mock("../../services/github/installation-write-client.js", () => ({
   githubRefExists: vi.fn().mockResolvedValue(false),
-  createPullRequestWithFiles: createPullRequestWithFilesMock,
+  createPullRequestFromBranch: createPullRequestFromBranchMock,
+  getPullRequestState: getPullRequestStateMock,
 }))
 
 vi.mock("../../models/github-installation.js", () => ({
   getRepoReadCloneToken: vi.fn().mockResolvedValue("tok"),
+  getInstallationToken: vi.fn().mockResolvedValue("install-tok"),
 }))
+
+vi.mock("../../domain/workspaces/conversation-files.js", () => ({
+  resolveConversationSandboxHandle: resolveConversationSandboxHandleMock,
+}))
+
+vi.mock("../../domain/workspaces/conversation-publish.js", () => ({
+  pushConversationSessionBranch: pushConversationSessionBranchMock,
+}))
+
+vi.mock("./conversation-files-routes.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./conversation-files-routes.js")>()
+  return {
+    ...actual,
+    checkoutPreparedConversationBranch: vi.fn(async () => {}),
+  }
+})
 
 vi.mock("../../models/conversations.js", () => ({
   getConversation: getConversationMock,
@@ -66,11 +87,7 @@ vi.mock("../../domain/workspaces/sandbox-registry.js", () => ({
   ),
   getChatSandbox: vi.fn(() => null),
   getRegisteredChatSandbox: getRegisteredChatSandboxMock,
-}))
-
-vi.mock("../../domain/workspaces/chat-pull-request.js", () => ({
-  collectChatPullRequestTree: collectChatPullRequestTreeMock,
-  checkoutPublishedChatBranch: vi.fn(async () => {}),
+  attachChatSandboxHandle: vi.fn(),
 }))
 
 vi.mock("../../models/conversation-messages.js", () => ({
@@ -87,6 +104,7 @@ vi.mock("../../domain/conversations/transport.js", () => ({
 vi.mock("../../domain/workspaces/workspace-chat-turn-runtime.js", () => ({
   resolveWorkspaceChatTurnRuntime: vi.fn(async () => ({
     lastBranch: "main",
+    cloneRef: "abc",
     defaultBranch: "main",
     cloneToken: "tok",
     writeStatus: "writable",
@@ -193,16 +211,23 @@ describe("conversations API", () => {
       desiredGeneration: 1,
     })
     getRegisteredChatSandboxMock.mockReturnValue(null)
-    collectChatPullRequestTreeMock.mockResolvedValue({
-      files: [],
-      deletePaths: [],
+    resolveConversationSandboxHandleMock.mockReturnValue({
+      exec: vi.fn(),
+      fs: {},
+    })
+    pushConversationSessionBranchMock.mockResolvedValue({
+      ok: true,
+      branch: "ctxpipe/chat/conv_1/1",
+      pushed: true,
     })
     reserveConversationChatPrNumberMock.mockResolvedValue(3)
-    createPullRequestWithFilesMock.mockResolvedValue({
+    createPullRequestFromBranchMock.mockResolvedValue({
       pullNumber: 41,
       pullUrl: "https://github.com/acme/docs/pull/41",
-      branch: "ctxpipe/chat/conv_1/3",
+      branch: "ctxpipe/chat/conv_1/1",
+      prState: "open",
     })
+    getPullRequestStateMock.mockResolvedValue(null)
   })
 
   it("lists UI conversations for a Workspace and ignores source=all", async () => {
@@ -444,7 +469,7 @@ describe("conversations API", () => {
     expect(discardUnstartedConversationMock).not.toHaveBeenCalled()
   })
 
-  it("brokers a PR from the live sandbox tree and returns GitHub's pull number", async () => {
+  it("brokers a PR from the session branch and returns GitHub's pull number", async () => {
     getConversationMock.mockResolvedValue(conversationRow)
     getRegisteredChatSandboxMock.mockReturnValue({
       handle: { exec: vi.fn(), fs: {} },
@@ -453,44 +478,33 @@ describe("conversations API", () => {
       desiredSha: "abc",
       defaultBranch: "main",
     })
-    collectChatPullRequestTreeMock.mockResolvedValue({
-      files: [{ path: "knowledge/a.md", content: "hello" }],
-      deletePaths: ["knowledge/gone.md"],
-    })
 
     const res = await app().request("/conversations/conv_1/pull-request", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         title: "Chat changes",
-        files: [{ path: "client.md", content: "ignored" }],
       }),
     })
 
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
-      branch: "ctxpipe/chat/conv_1/3",
+      branch: "ctxpipe/chat/conv_1/1",
       prNumber: 41,
       pullUrl: "https://github.com/acme/docs/pull/41",
+      prState: "open",
     })
-    expect(createPullRequestWithFilesMock).toHaveBeenCalledWith(
+    expect(createPullRequestFromBranchMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        branch: "ctxpipe/chat/conv_1/3",
-        files: [{ path: "knowledge/a.md", content: "hello" }],
-        deletePaths: ["knowledge/gone.md"],
-        requireNewBranch: true,
+        branch: "ctxpipe/chat/conv_1/1",
+        title: "Chat changes",
       }),
     )
-    expect(createPullRequestWithFilesMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        files: [{ path: "client.md", content: "ignored" }],
-      }),
-    )
-    expect(persistConversationLastBranchMock).toHaveBeenCalledWith({
+    expect(persistConversationLastChatPrNumberMock).toHaveBeenCalledWith({
       conversationId: "conv_1",
-      lastBranch: "ctxpipe/chat/conv_1/3",
+      lastChatPrNumber: 41,
+      lastBranch: "ctxpipe/chat/conv_1/1",
     })
-    expect(persistConversationLastChatPrNumberMock).not.toHaveBeenCalled()
   })
 
   it("streams a second turn without a custom claim lock", async () => {
@@ -520,7 +534,7 @@ describe("conversations API", () => {
 
   it("refuses a PR when the chat sandbox is gone", async () => {
     getConversationMock.mockResolvedValue(conversationRow)
-    getRegisteredChatSandboxMock.mockReturnValue(null)
+    resolveConversationSandboxHandleMock.mockReturnValue(null)
     const res = await app().request("/conversations/conv_1/pull-request", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -528,7 +542,7 @@ describe("conversations API", () => {
     })
     expect(res.status).toBe(409)
     expect(await res.json()).toEqual({ error: "missing_sandbox" })
-    expect(createPullRequestWithFilesMock).not.toHaveBeenCalled()
+    expect(createPullRequestFromBranchMock).not.toHaveBeenCalled()
   })
 
   it("refuses a PR when captured sandbox metadata is stale", async () => {
@@ -547,6 +561,6 @@ describe("conversations API", () => {
     })
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ error: "stale_url" })
-    expect(collectChatPullRequestTreeMock).not.toHaveBeenCalled()
+    expect(createPullRequestFromBranchMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/routes/v1/conversations.ts
+++ b/apps/backend/src/routes/v1/conversations.ts
@@ -8,20 +8,23 @@ import {
   workspaceChatStreamResponse,
 } from "../../domain/conversations/transport.js"
 import {
-  chatSessionBranchName,
-  mayForcePushBranch,
   planChatPullRequest,
   shouldDestroyChatSandbox,
 } from "../../domain/workspaces/chat-lifecycle.js"
-import {
-  checkoutPublishedChatBranch,
-  collectChatPullRequestTree,
-} from "../../domain/workspaces/chat-pull-request.js"
+import { workspaceAllowsConversationEdits } from "../../domain/workspaces/chat-sandbox-policy.js"
+import { resolveConversationSandboxHandle } from "../../domain/workspaces/conversation-files.js"
+import { pushConversationSessionBranch } from "../../domain/workspaces/conversation-publish.js"
 import {
   destroySandboxesForConversation,
   getRegisteredChatSandbox,
   withDestroyedConversationSandboxes,
 } from "../../domain/workspaces/sandbox-registry.js"
+import {
+  checkoutPreparedConversationBranch,
+  conversationFileRoutes,
+  conversationPublicPrUrl,
+  conversationPublicTreeUrl,
+} from "./conversation-files-routes.js"
 import { reconstructChat } from "@tanstack/ai-persistence"
 import {
   conversationHasStoredTurns,
@@ -42,12 +45,16 @@ import {
   getConversation,
   listConversationsPaginated,
   persistConversationLastBranch,
-  reserveConversationChatPrNumber,
+  persistConversationLastChatPrNumber,
   updateConversation,
 } from "../../models/conversations.js"
+import { getInstallationToken } from "../../models/github-installation.js"
 import { getWorkspaceById } from "../../models/workspaces.js"
 import { getLogger } from "../../observability/logger.js"
-import { createPullRequestWithFiles } from "../../services/github/installation-write-client.js"
+import {
+  createPullRequestFromBranch,
+  getPullRequestState,
+} from "../../services/github/installation-write-client.js"
 import { resolveGithubDefaultBranch } from "../webhooks/github/github-workspace-tip.js"
 
 const ErrorResponseSchema = z
@@ -64,6 +71,9 @@ const ConversationSchema = z
     source: z.string().nullable(),
     lastBranch: z.string().nullable().optional(),
     lastChatPrNumber: z.number().int().nullable().optional(),
+    lastChatPrUrl: z.string().nullable().optional(),
+    prState: z.enum(["open", "closed", "merged"]).nullable().optional(),
+    branchTreeUrl: z.string().nullable().optional(),
     lastMessageAt: z.string().datetime().nullable(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
@@ -357,8 +367,31 @@ const ConversationPullRequestResponseSchema = z
     branch: z.string(),
     prNumber: z.number().int(),
     pullUrl: z.string(),
+    prState: z.enum(["open", "closed", "merged"]),
   })
   .openapi("ConversationPullRequestResponse")
+
+const getConversationPullRequestRoute = createRoute({
+  method: "get",
+  path: "/{conversationId}/pull-request",
+  request: { params: ConversationParamsSchema },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ConversationPullRequestResponseSchema },
+      },
+      description: "Current conversation pull request",
+    },
+    401: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Unauthorized",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Not found",
+    },
+  },
+})
 
 const postConversationPullRequestRoute = createRoute({
   method: "post",
@@ -398,6 +431,7 @@ const postConversationPullRequestRoute = createRoute({
 })
 
 export const conversationRoutes = new OpenAPIHono<AppEnv>()
+  .route("/", conversationFileRoutes)
   .openapi(listConversationsRoute, async (c) => {
     const user = c.get("user")
     const session = c.get("session")
@@ -417,6 +451,7 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
       first: query.first,
       after: query.after,
     })
+    const listedWorkspace = await getWorkspaceById(query.workspaceId.trim())
 
     const items = rows.map((row) => ({
       ...row,
@@ -424,6 +459,16 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
       workspaceId: row.workspaceId ?? null,
       lastBranch: row.lastBranch ?? null,
       lastChatPrNumber: row.lastChatPrNumber ?? null,
+      lastChatPrUrl: conversationPublicPrUrl({
+        workspaceRepositoryUrl:
+          listedWorkspace?.workspaceRepositoryUrl ?? "",
+        lastChatPrNumber: row.lastChatPrNumber ?? null,
+      }),
+      branchTreeUrl: conversationPublicTreeUrl({
+        workspaceRepositoryUrl:
+          listedWorkspace?.workspaceRepositoryUrl ?? "",
+        lastBranch: row.lastBranch ?? null,
+      }),
       createdAt: row.createdAt.toISOString(),
       updatedAt: row.updatedAt.toISOString(),
       lastMessageAt: row.lastMessageAt?.toISOString() ?? null,
@@ -447,6 +492,9 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
       checkpointNamespace: "",
       workspaceId: conversation.workspaceId,
     })
+    const detailWorkspace = conversation.workspaceId
+      ? await getWorkspaceById(conversation.workspaceId)
+      : null
 
     return c.json(
       {
@@ -456,6 +504,16 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
           workspaceId: conversation.workspaceId ?? null,
           lastBranch: conversation.lastBranch ?? null,
           lastChatPrNumber: conversation.lastChatPrNumber ?? null,
+          lastChatPrUrl: conversationPublicPrUrl({
+            workspaceRepositoryUrl:
+              detailWorkspace?.workspaceRepositoryUrl ?? "",
+            lastChatPrNumber: conversation.lastChatPrNumber ?? null,
+          }),
+          branchTreeUrl: conversationPublicTreeUrl({
+            workspaceRepositoryUrl:
+              detailWorkspace?.workspaceRepositoryUrl ?? "",
+            lastBranch: conversation.lastBranch ?? null,
+          }),
           createdAt: conversation.createdAt.toISOString(),
           updatedAt: conversation.updatedAt.toISOString(),
           lastMessageAt: conversation.lastMessageAt?.toISOString() ?? null,
@@ -641,12 +699,56 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
       desiredSha: runtime.desiredSha,
       desiredGeneration: runtime.desiredGeneration,
       defaultBranch: runtime.defaultBranch,
-      ref: runtime.lastBranch || runtime.desiredSha || "HEAD",
+      ref: runtime.cloneRef || runtime.desiredSha || "HEAD",
       writeStatus: runtime.writeStatus,
       cloneToken: runtime.cloneToken,
     })
     if (!warmed.ok) return c.json({ error: warmed.error }, 503)
+    await checkoutPreparedConversationBranch({
+      conversationId,
+      workspaceId: runtime.workspaceId ?? workspace.id,
+      orgId: runtime.orgId,
+      defaultBranch: runtime.defaultBranch,
+      writeStatus: runtime.writeStatus,
+      desiredUrl: runtime.desiredUrl,
+      desiredGeneration: runtime.desiredGeneration,
+      desiredSha: runtime.desiredSha,
+    })
     return c.body(null, 204)
+  })
+  .openapi(getConversationPullRequestRoute, async (c) => {
+    const user = c.get("user")
+    const session = c.get("session")
+    if (!user || !session) return c.json({ error: "Unauthorized" }, 401)
+    const conversationId = c.req.param("conversationId")
+    const conversation = await getConversation(conversationId)
+    if (!conversation?.workspaceId) {
+      return c.json({ error: "Not found" }, 404)
+    }
+    const workspace = await getWorkspaceById(conversation.workspaceId)
+    if (!workspace) return c.json({ error: "Not found" }, 404)
+    if (conversation.lastChatPrNumber == null) {
+      return c.json({ error: "Not found" }, 404)
+    }
+    const env = parseEnv(process.env as Record<string, string | undefined>)
+    const repoName = githubRepoFullNameFromWorkspaceUrl(
+      workspace.workspaceRepositoryUrl,
+    )
+    if (!repoName) return c.json({ error: "Not found" }, 404)
+    const state = await getPullRequestState({
+      orgId: workspace.orgId,
+      repositoryName: repoName,
+      env,
+      githubConnectionId: workspace.githubConnectionId ?? undefined,
+      pullNumber: conversation.lastChatPrNumber,
+    })
+    if (!state) return c.json({ error: "Not found" }, 404)
+    return c.json({
+      branch: state.branch,
+      prNumber: state.prNumber,
+      pullUrl: state.pullUrl,
+      prState: state.prState,
+    })
   })
   .openapi(postConversationPullRequestRoute, async (c) => {
     const user = c.get("user")
@@ -661,103 +763,104 @@ export const conversationRoutes = new OpenAPIHono<AppEnv>()
     }
     const workspace = await getWorkspaceById(conversation.workspaceId)
     if (!workspace) return c.json({ error: "Not found" }, 404)
-    const sandbox = getRegisteredChatSandbox(conversationId)
-    if (!sandbox?.handle) {
+    if (!workspaceAllowsConversationEdits(workspace.writeStatus)) {
+      return c.json({ error: "read_only" }, 400)
+    }
+    const handle = resolveConversationSandboxHandle(conversationId)
+    if (!handle) {
       return c.json({ error: "missing_sandbox" }, 409)
     }
     const env = parseEnv(process.env as Record<string, string | undefined>)
     const repoName = githubRepoFullNameFromWorkspaceUrl(
       workspace.workspaceRepositoryUrl,
     )
-    const defaultBranch = repoName
-      ? ((await resolveGithubDefaultBranch({
-          orgId: workspace.orgId,
-          githubConnectionId: workspace.githubConnectionId,
-          repoFullName: repoName,
-          env,
-        })) ?? "main")
-      : "main"
+    if (!repoName) {
+      return c.json({ error: "not_github" }, 400)
+    }
+    const defaultBranch =
+      (await resolveGithubDefaultBranch({
+        orgId: workspace.orgId,
+        githubConnectionId: workspace.githubConnectionId,
+        repoFullName: repoName,
+        env,
+      })) ?? "main"
+    const sandbox = getRegisteredChatSandbox(conversationId)
     const planned = planChatPullRequest({
       writeStatus: workspace.writeStatus,
       explicitRequest: true,
-      host: repoName ? "github" : "other",
+      host: "github",
       defaultBranch,
-      capturedDefaultBranch: sandbox.defaultBranch ?? null,
-      capturedGeneration: sandbox.desiredGeneration ?? null,
+      capturedDefaultBranch: sandbox?.defaultBranch ?? defaultBranch,
+      capturedGeneration:
+        sandbox?.desiredGeneration ?? workspace.desiredGeneration,
       desiredGeneration: workspace.desiredGeneration,
-      capturedUrl: sandbox.desiredUrl ?? null,
+      capturedUrl: sandbox?.desiredUrl ?? workspace.workspaceRepositoryUrl,
       desiredUrl: workspace.workspaceRepositoryUrl,
-      capturedSha: sandbox.desiredSha ?? null,
+      capturedSha: sandbox?.desiredSha ?? workspace.desiredSha,
       desiredSha: workspace.desiredSha,
     })
     if (!planned.publish) {
       return c.json({ error: planned.reason }, 400)
     }
-    if (!repoName) {
-      return c.json({ error: "not_github" }, 400)
-    }
-    const tree = await collectChatPullRequestTree(sandbox.handle)
-    if (tree.files.length === 0 && tree.deletePaths.length === 0) {
-      return c.json({ error: "no_changes" }, 400)
-    }
-    const latest = await getWorkspaceById(conversation.workspaceId)
-    if (!latest) return c.json({ error: "Not found" }, 404)
-    const stillFresh = planChatPullRequest({
-      writeStatus: latest.writeStatus,
-      explicitRequest: true,
-      host: repoName ? "github" : "other",
+    const token = await getInstallationToken(
+      workspace.orgId,
+      env,
+      workspace.githubConnectionId ?? undefined,
+    )
+    if (!token) return c.json({ error: "not_allowed" }, 400)
+    const title = body.title ?? conversation.name
+    const pushed = await pushConversationSessionBranch({
+      handle,
+      conversationId,
       defaultBranch,
-      capturedDefaultBranch: sandbox.defaultBranch ?? null,
-      capturedGeneration: sandbox.desiredGeneration ?? null,
-      desiredGeneration: latest.desiredGeneration,
-      capturedUrl: sandbox.desiredUrl ?? null,
-      desiredUrl: latest.workspaceRepositoryUrl,
-      capturedSha: sandbox.desiredSha ?? null,
-      desiredSha: latest.desiredSha,
+      repositoryName: repoName,
+      token,
+      commitMessage: title,
     })
-    if (!stillFresh.publish) {
-      return c.json({ error: stillFresh.reason }, 400)
+    if (!pushed.ok) return c.json({ error: pushed.error }, 400)
+    if (
+      conversation.lastChatPrNumber != null
+    ) {
+      const existing = await getPullRequestState({
+        orgId: workspace.orgId,
+        repositoryName: repoName,
+        env,
+        githubConnectionId: workspace.githubConnectionId ?? undefined,
+        pullNumber: conversation.lastChatPrNumber,
+      })
+      if (existing?.prState === "open") {
+        await persistConversationLastChatPrNumber({
+          conversationId,
+          lastChatPrNumber: existing.prNumber,
+          lastBranch: pushed.branch,
+        })
+        return c.json({
+          branch: pushed.branch,
+          prNumber: existing.prNumber,
+          pullUrl: existing.pullUrl,
+          prState: existing.prState,
+        })
+      }
     }
-    const prNumber = await reserveConversationChatPrNumber(conversationId)
-    const branch = chatSessionBranchName(conversationId, prNumber)
-    if (!mayForcePushBranch(branch, defaultBranch)) {
-      return c.json({ error: "default_branch" }, 400)
-    }
-    const created = await createPullRequestWithFiles({
-      orgId: latest.orgId,
+    const created = await createPullRequestFromBranch({
+      orgId: workspace.orgId,
       repositoryName: repoName,
       env,
-      githubConnectionId: latest.githubConnectionId ?? undefined,
+      githubConnectionId: workspace.githubConnectionId ?? undefined,
       baseBranch: defaultBranch,
-      branch,
-      title: body.title ?? `Workspace chat ${conversationId}`,
+      branch: pushed.branch,
+      title,
       body: body.body ?? "",
-      commitMessage: body.title ?? `Workspace chat ${conversationId}`,
-      files: tree.files,
-      deletePaths: tree.deletePaths,
-      requireNewBranch: true,
     })
-    await persistConversationLastBranch({
+    await persistConversationLastChatPrNumber({
       conversationId,
+      lastChatPrNumber: created.pullNumber,
       lastBranch: created.branch,
     })
-    try {
-      await checkoutPublishedChatBranch({
-        handle: sandbox.handle,
-        branch: created.branch,
-      })
-    } catch (error) {
-      getLogger().error(
-        error instanceof Error ? error : new Error(String(error)),
-        { step: "checkout-published-chat-branch", conversationId },
-      )
-    }
-    return c.json(
-      {
-        branch: created.branch,
-        prNumber: created.pullNumber,
-        pullUrl: created.pullUrl,
-      },
-      200,
-    )
+    return c.json({
+      branch: created.branch,
+      prNumber: created.pullNumber,
+      pullUrl: created.pullUrl,
+      prState: created.prState,
+    })
   })

--- a/apps/backend/src/services/github/installation-write-client.ts
+++ b/apps/backend/src/services/github/installation-write-client.ts
@@ -532,3 +532,90 @@ export async function closePullRequest(
     )
   }
 }
+
+export type GithubPullRequestState = "open" | "closed" | "merged"
+
+export async function getPullRequestState(
+  input: BaseInput & { pullNumber: number },
+): Promise<{
+  prNumber: number
+  pullUrl: string
+  prState: GithubPullRequestState
+  branch: string
+} | null> {
+  try {
+    const context = await getInstallationContext(input)
+    const { data } = await withTransientGitHubRetry(() =>
+      context.octokit.rest.pulls.get({
+        owner: context.owner,
+        repo: context.repo,
+        pull_number: input.pullNumber,
+      }),
+    )
+    const prState: GithubPullRequestState = data.merged_at
+      ? "merged"
+      : data.state === "open"
+        ? "open"
+        : "closed"
+    return {
+      prNumber: data.number,
+      pullUrl: data.html_url,
+      prState,
+      branch: data.head.ref,
+    }
+  } catch (error) {
+    if ((error as { status?: number }).status === 404) return null
+    throw error
+  }
+}
+
+export async function createPullRequestFromBranch(
+  input: BaseInput & {
+    baseBranch: string
+    branch: string
+    title: string
+    body: string
+  },
+): Promise<{
+  pullNumber: number
+  pullUrl: string
+  branch: string
+  prState: GithubPullRequestState
+}> {
+  const context = await getInstallationContext(input)
+  try {
+    const { data: pull } = await withTransientGitHubRetry(() =>
+      context.octokit.rest.pulls.create({
+        owner: context.owner,
+        repo: context.repo,
+        head: input.branch,
+        base: input.baseBranch,
+        title: input.title,
+        body: input.body,
+      }),
+    )
+    return {
+      pullNumber: pull.number,
+      pullUrl: pull.html_url,
+      branch: input.branch,
+      prState: "open",
+    }
+  } catch (error) {
+    const status = (error as { status?: number }).status
+    if (status !== 422) throw error
+    const { data: existing } = await context.octokit.rest.pulls.list({
+      owner: context.owner,
+      repo: context.repo,
+      head: `${context.owner}:${input.branch}`,
+      state: "open",
+    })
+    const open = existing[0]
+    if (!open) throw error
+    return {
+      pullNumber: open.number,
+      pullUrl: open.html_url,
+      branch: input.branch,
+      prState: "open",
+    }
+  }
+}

--- a/apps/ui/src/features/chat/types.ts
+++ b/apps/ui/src/features/chat/types.ts
@@ -30,11 +30,18 @@ export type PageInfo = {
   endCursor: string | null
 }
 
+export type ConversationPrState = "open" | "closed" | "merged"
+
 export type ConversationListItem = {
   id: string
   name: string
   source: string | null
   lastMessageAt: string | null
+  lastBranch?: string | null
+  lastChatPrNumber?: number | null
+  lastChatPrUrl?: string | null
+  prState?: ConversationPrState | null
+  branchTreeUrl?: string | null
 }
 
 export type ConversationDetail = {

--- a/apps/ui/src/features/workspaces/WorkspaceChat.tsx
+++ b/apps/ui/src/features/workspaces/WorkspaceChat.tsx
@@ -145,15 +145,16 @@ function WorkspaceChatResume(props: {
   }
 
   return (
-    <WorkspaceChatSession
-      key={conversationId}
-      orgSlug={orgSlug}
-      workspace={workspace}
-      conversationId={conversationId}
-      composing={false}
-      title={detail.conversation.name || "New conversation"}
-      initialMessages={detail.messages}
-      headerExtra={props.headerExtra}
-    />
+      <WorkspaceChatSession
+        key={conversationId}
+        orgSlug={orgSlug}
+        workspace={workspace}
+        conversationId={conversationId}
+        composing={false}
+        title={detail.conversation.name || "New conversation"}
+        initialMessages={detail.messages}
+        conversation={detail.conversation}
+        headerExtra={props.headerExtra}
+      />
   )
 }

--- a/apps/ui/src/features/workspaces/WorkspaceChatChrome.stories.tsx
+++ b/apps/ui/src/features/workspaces/WorkspaceChatChrome.stories.tsx
@@ -3,7 +3,11 @@ import { InlineAlert } from "@/components/ui/InlineAlert"
 import { entryPageInnerDecorators } from "../../../.storybook/decorators/entry-page-decorators"
 import type { StoryRouteParams } from "../../../.storybook/decorators/with-story-route"
 import { WorkspaceChatChrome } from "./WorkspaceChatChrome"
-import { docsWorkspace, readOnlyWorkspace } from "./workspace-fixtures"
+import {
+  docsWorkspace,
+  pendingWriteWorkspace,
+  readOnlyWorkspace,
+} from "./workspace-fixtures"
 
 const meta = {
   title: "Components/Workspaces/ChatChrome",
@@ -46,6 +50,106 @@ export const ReadOnly: Story = {
   args: {
     workspace: readOnlyWorkspace,
     title: "Handbook",
+  },
+}
+
+export const PendingProbe: Story = {
+  args: {
+    workspace: pendingWriteWorkspace,
+    title: "Repo layout",
+  },
+}
+
+export const DirtyCommitPush: Story = {
+  args: {
+    title: "Repo layout",
+    branch: {
+      shortName: "chat/1",
+      fullRef: "ctxpipe/chat/conv_1/1",
+    },
+    publish: {
+      commitPush: {
+        enabled: true,
+        pending: false,
+        onPress: () => {},
+      },
+      pullRequest: {
+        action: "create",
+        pending: false,
+        onPress: () => {},
+      },
+    },
+  },
+}
+
+export const Pushing: Story = {
+  args: {
+    ...DirtyCommitPush.args,
+    publish: {
+      commitPush: {
+        enabled: true,
+        pending: true,
+        onPress: () => {},
+      },
+      pullRequest: {
+        action: "create",
+        pending: false,
+        onPress: () => {},
+      },
+    },
+  },
+}
+
+export const CreatingPr: Story = {
+  args: {
+    ...DirtyCommitPush.args,
+    publish: {
+      commitPush: {
+        enabled: true,
+        pending: false,
+        onPress: () => {},
+      },
+      pullRequest: {
+        action: "create",
+        pending: true,
+        onPress: () => {},
+      },
+    },
+  },
+}
+
+export const ShowPr: Story = {
+  args: {
+    title: "Repo layout",
+    branch: {
+      shortName: "chat/1",
+      fullRef: "ctxpipe/chat/conv_1/1",
+      href: "https://github.com/acme/docs/tree/ctxpipe/chat/conv_1/1",
+    },
+    publish: {
+      commitPush: {
+        enabled: true,
+        pending: false,
+        onPress: () => {},
+      },
+      pullRequest: {
+        action: "show",
+        pending: false,
+        href: "https://github.com/acme/docs/pull/41",
+        onPress: () => {},
+      },
+    },
+  },
+}
+
+export const MergedCreatePrAgain: Story = {
+  args: {
+    ...DirtyCommitPush.args,
+    branch: {
+      shortName: "chat/1",
+      fullRef: "ctxpipe/chat/conv_1/1",
+      href: "https://github.com/acme/docs/tree/ctxpipe/chat/conv_1/1",
+    },
   },
 }
 

--- a/apps/ui/src/features/workspaces/WorkspaceChatChrome.test.tsx
+++ b/apps/ui/src/features/workspaces/WorkspaceChatChrome.test.tsx
@@ -1,0 +1,81 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import { WorkspaceChatChrome } from "./WorkspaceChatChrome"
+import { docsWorkspace, pendingWriteWorkspace, readOnlyWorkspace } from "./workspace-fixtures"
+
+vi.mock("@/components/OverlayNavButton", () => ({
+  OverlayNavMenuButton: () => null,
+}))
+
+describe("WorkspaceChatChrome", () => {
+  it("shows Read-only and pending chips, not publish actions", () => {
+    const readOnly = renderToStaticMarkup(
+      <WorkspaceChatChrome workspace={readOnlyWorkspace} title="Handbook">
+        <p>body</p>
+      </WorkspaceChatChrome>,
+    )
+    expect(readOnly).toContain("Read-only")
+    expect(readOnly).not.toContain("Commit+Push")
+
+    const pending = renderToStaticMarkup(
+      <WorkspaceChatChrome workspace={pendingWriteWorkspace} title="Repo layout">
+        <p>body</p>
+      </WorkspaceChatChrome>,
+    )
+    expect(pending).toContain("Checking write access")
+    expect(pending).not.toContain("Create PR")
+  })
+
+  it("shows Commit+Push, Creating PR, then Show PR", () => {
+    const dirty = renderToStaticMarkup(
+      <WorkspaceChatChrome
+        workspace={docsWorkspace}
+        title="Repo layout"
+        branch={{ shortName: "chat/1", fullRef: "ctxpipe/chat/conv_1/1" }}
+        publish={{
+          commitPush: { enabled: true, pending: false, onPress: () => {} },
+          pullRequest: { action: "create", pending: false, onPress: () => {} },
+        }}
+      >
+        <p>body</p>
+      </WorkspaceChatChrome>,
+    )
+    expect(dirty).toContain("Commit+Push")
+    expect(dirty).toContain("Create PR")
+    expect(dirty).toContain("chat/1")
+
+    const creating = renderToStaticMarkup(
+      <WorkspaceChatChrome
+        workspace={docsWorkspace}
+        title="Repo layout"
+        publish={{
+          commitPush: { enabled: true, pending: false, onPress: () => {} },
+          pullRequest: { action: "create", pending: true, onPress: () => {} },
+        }}
+      >
+        <p>body</p>
+      </WorkspaceChatChrome>,
+    )
+    expect(creating).toContain("Creating PR…")
+
+    const show = renderToStaticMarkup(
+      <WorkspaceChatChrome
+        workspace={docsWorkspace}
+        title="Repo layout"
+        publish={{
+          commitPush: { enabled: true, pending: false, onPress: () => {} },
+          pullRequest: {
+            action: "show",
+            pending: false,
+            href: "https://github.com/acme/docs/pull/41",
+            onPress: () => {},
+          },
+        }}
+      >
+        <p>body</p>
+      </WorkspaceChatChrome>,
+    )
+    expect(show).toContain("Show PR")
+    expect(show).not.toContain("Create PR")
+  })
+})

--- a/apps/ui/src/features/workspaces/WorkspaceChatChrome.tsx
+++ b/apps/ui/src/features/workspaces/WorkspaceChatChrome.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react"
+import { Link as AriaLink } from "react-aria-components"
 import { OverlayNavMenuButton } from "@/components/OverlayNavButton"
+import { Button } from "@/components/ui/Button"
 import { cn } from "@/lib/utils"
 import type { Workspace } from "./types"
 import {
@@ -11,6 +13,26 @@ import {
 } from "./workspaceChrome"
 import { writeStatusLabel } from "./writeStatusLabel"
 
+export type ConversationPublishChrome = {
+  commitPush: {
+    enabled: boolean
+    pending: boolean
+    onPress: () => void
+  }
+  pullRequest: {
+    action: "create" | "show"
+    pending: boolean
+    href?: string | null
+    onPress: () => void
+  }
+}
+
+export type ConversationBranchChrome = {
+  shortName: string
+  fullRef: string
+  href?: string | null
+}
+
 /**
  * Conversation column chrome: card surface with the conversation name as an
  * active tab (conversation is one pane; files/graph/settings are the other).
@@ -19,10 +41,14 @@ export function WorkspaceChatChrome(props: {
   workspace: Workspace
   title: ReactNode
   headerExtra?: ReactNode
+  branch?: ConversationBranchChrome | null
+  publish?: ConversationPublishChrome | null
   children: ReactNode
 }) {
   const write = writeStatusLabel(props.workspace.writeStatus)
-  const showWriteBadge = write.tone === "read_only" || write.tone === "pending"
+  const showWriteBadge =
+    !props.publish &&
+    (write.tone === "read_only" || write.tone === "pending")
   return (
     <div
       className={cn(
@@ -48,8 +74,28 @@ export function WorkspaceChatChrome(props: {
             ) : (
               props.title
             )}
+            {props.branch ? (
+              props.branch.href ? (
+                <AriaLink
+                  href={props.branch.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-2 truncate font-mono text-xs text-muted-foreground hover:text-teal-400"
+                  aria-label={props.branch.fullRef}
+                >
+                  {props.branch.shortName}
+                </AriaLink>
+              ) : (
+                <span
+                  title={props.branch.fullRef}
+                  className="ml-2 truncate font-mono text-xs text-muted-foreground"
+                >
+                  {props.branch.shortName}
+                </span>
+              )
+            ) : null}
           </div>
-          {props.headerExtra || showWriteBadge ? (
+          {props.headerExtra || showWriteBadge || props.publish ? (
             <div className="ml-auto flex min-w-0 items-end gap-0.5">
               {showWriteBadge ? (
                 <span className="inline-flex h-[37px] shrink-0 items-center">
@@ -65,6 +111,9 @@ export function WorkspaceChatChrome(props: {
                   </span>
                 </span>
               ) : null}
+              {props.publish ? (
+                <ConversationPublishActions publish={props.publish} />
+              ) : null}
               {props.headerExtra}
             </div>
           ) : null}
@@ -72,6 +121,47 @@ export function WorkspaceChatChrome(props: {
 
         <div className={workspaceChromeCardClassName}>{props.children}</div>
       </div>
+    </div>
+  )
+}
+
+function ConversationPublishActions(props: {
+  publish: ConversationPublishChrome
+}) {
+  const { commitPush, pullRequest } = props.publish
+  return (
+    <div className="mb-px flex h-[37px] shrink-0 items-center gap-1">
+      <Button
+        variant="ghost"
+        size="default"
+        isDisabled={!commitPush.enabled || commitPush.pending}
+        isPending={commitPush.pending}
+        onPress={commitPush.onPress}
+        className="h-8 px-2 text-xs"
+      >
+        {commitPush.pending ? "Pushing…" : "Commit+Push"}
+      </Button>
+      {pullRequest.action === "show" && pullRequest.href ? (
+        <AriaLink
+          href={pullRequest.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex h-8 items-center rounded-lg px-2 text-xs text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground"
+        >
+          Show PR
+        </AriaLink>
+      ) : (
+        <Button
+          variant="ghost"
+          size="default"
+          isDisabled={pullRequest.pending}
+          isPending={pullRequest.pending}
+          onPress={pullRequest.onPress}
+          className="h-8 px-2 text-xs"
+        >
+          {pullRequest.pending ? "Creating PR…" : "Create PR"}
+        </Button>
+      )}
     </div>
   )
 }

--- a/apps/ui/src/features/workspaces/WorkspaceChatSession.tsx
+++ b/apps/ui/src/features/workspaces/WorkspaceChatSession.tsx
@@ -1,6 +1,6 @@
 import type { StreamChunk, UIMessage } from "@tanstack/ai"
 import { useChat } from "@tanstack/ai-react"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import { InlineAlert } from "@/components/ui/InlineAlert"
@@ -12,7 +12,23 @@ import type {
   ConversationDetail,
   ConversationListInfiniteData,
 } from "@/features/chat/types"
-import { prepareWorkspaceChat, workspaceKeys } from "./queries"
+import type { ConversationListItem } from "@/features/chat/types"
+import {
+  conversationGitStatusOptions,
+  conversationPullRequestOptions,
+  createConversationPullRequest,
+  pushConversationBranch,
+  workspaceChatPrepareOptions,
+  workspaceKeys,
+} from "./queries"
+import {
+  conversationBranchShortName,
+  conversationCommitPushEnabled,
+  conversationGithubTreeHref,
+  conversationPullRequestAction,
+  conversationSessionBranch,
+} from "./conversationPublish"
+import { conversationWriteToolSignature } from "./conversationFileLive"
 import type { Workspace } from "./types"
 import { WorkspaceChatChrome } from "./WorkspaceChatChrome"
 import { workspaceChatWebSocket } from "./workspaceChatWebSocket"
@@ -70,6 +86,7 @@ export function WorkspaceChatSession(props: {
   composing: boolean
   title: string
   initialMessages: ConversationDetail["messages"]
+  conversation?: ConversationListItem
   headerExtra?: ReactNode
 }) {
   const {
@@ -130,11 +147,71 @@ export function WorkspaceChatSession(props: {
     )
   }
 
-  useQuery({
-    queryKey: workspaceKeys.chatPrepare(orgSlug, conversationId, workspace.id),
-    queryFn: () => prepareWorkspaceChat(orgSlug, conversationId, workspace.id),
-    staleTime: Number.POSITIVE_INFINITY,
-    retry: false,
+  const prepareQuery = useQuery(
+    workspaceChatPrepareOptions(orgSlug, conversationId, workspace.id),
+  )
+  const statusQuery = useQuery({
+    ...conversationGitStatusOptions(orgSlug, conversationId),
+    enabled: !composing && prepareQuery.isSuccess,
+  })
+  const pullQuery = useQuery(
+    conversationPullRequestOptions(
+      orgSlug,
+      conversationId,
+      !composing && (props.conversation?.lastChatPrNumber ?? null) != null,
+    ),
+  )
+  const pushMutation = useMutation({
+    mutationFn: () => pushConversationBranch(orgSlug, conversationId),
+    onSuccess: (result) => {
+      queryClient.setQueryData<ConversationDetail>(
+        workspaceKeys.conversation(orgSlug, conversationId, workspace.id),
+        (old) =>
+          old
+            ? {
+                ...old,
+                conversation: {
+                  ...old.conversation,
+                  lastBranch: result.branch,
+                  branchTreeUrl: result.treeUrl,
+                },
+              }
+            : old,
+      )
+      void queryClient.invalidateQueries({
+        queryKey: workspaceKeys.conversationGitStatus(orgSlug, conversationId),
+      })
+    },
+  })
+  const createPrMutation = useMutation({
+    mutationFn: () =>
+      createConversationPullRequest(orgSlug, conversationId, {
+        title: headerTitle,
+      }),
+    onSuccess: (result) => {
+      queryClient.setQueryData<ConversationDetail>(
+        workspaceKeys.conversation(orgSlug, conversationId, workspace.id),
+        (old) =>
+          old
+            ? {
+                ...old,
+                conversation: {
+                  ...old.conversation,
+                  lastBranch: result.branch,
+                  lastChatPrNumber: result.prNumber,
+                  lastChatPrUrl: result.pullUrl,
+                  prState: result.prState,
+                },
+              }
+            : old,
+      )
+      void queryClient.invalidateQueries({
+        queryKey: workspaceKeys.conversationPullRequest(orgSlug, conversationId),
+      })
+      void queryClient.invalidateQueries({
+        queryKey: workspaceKeys.conversationGitStatus(orgSlug, conversationId),
+      })
+    },
   })
 
   const { messages, sendMessage, status, error, isLoading, stop } = useChat({
@@ -154,6 +231,14 @@ export function WorkspaceChatSession(props: {
       if (name) applyRename(name)
       const phase = sandboxPhaseFromChunk(chunk)
       if (phase) setSandboxPhase(phase)
+      if (chunk.type === "TOOL_CALL" || chunk.type === "TOOL_CALL_DELTA") {
+        void queryClient.invalidateQueries({
+          queryKey: workspaceKeys.conversationGitStatus(orgSlug, conversationId),
+        })
+        void queryClient.invalidateQueries({
+          queryKey: workspaceKeys.conversationGitTree(orgSlug, conversationId),
+        })
+      }
       if (chunk.type === "RUN_FINISHED" || chunk.type === "RUN_ERROR") {
         setSandboxPhase("idle")
         if (chunk.type === "RUN_FINISHED") {
@@ -170,8 +255,33 @@ export function WorkspaceChatSession(props: {
       void queryClient.invalidateQueries({
         queryKey: workspaceKeys.conversations(orgSlug, workspace.id),
       })
+      void queryClient.invalidateQueries({
+        queryKey: workspaceKeys.conversationGitStatus(orgSlug, conversationId),
+      })
     },
   })
+
+  const writeSignature = conversationWriteToolSignature(
+    messages as ChatMessage[],
+  )
+  useEffect(() => {
+    if (!writeSignature) return
+    void queryClient.invalidateQueries({
+      queryKey: workspaceKeys.conversationGitStatus(orgSlug, conversationId),
+    })
+    void queryClient.invalidateQueries({
+      queryKey: workspaceKeys.conversationGitTree(orgSlug, conversationId),
+    })
+    for (const path of writeSignature.split("\0").filter(Boolean)) {
+      void queryClient.invalidateQueries({
+        queryKey: workspaceKeys.conversationGitBlob(
+          orgSlug,
+          conversationId,
+          path,
+        ),
+      })
+    }
+  }, [conversationId, orgSlug, queryClient, writeSignature])
 
   const insertComposeRow = () => {
     queryClient.setQueriesData<ConversationListInfiniteData>(
@@ -222,6 +332,53 @@ export function WorkspaceChatSession(props: {
       workspace={workspace}
       title={headerTitle}
       headerExtra={props.headerExtra}
+      branch={
+        !composing && prepareQuery.isSuccess
+          ? {
+              shortName: conversationBranchShortName(
+                props.conversation?.lastBranch ??
+                  conversationSessionBranch(conversationId),
+              ),
+              fullRef:
+                props.conversation?.lastBranch ??
+                conversationSessionBranch(conversationId),
+              href: statusQuery.data?.published
+                ? (props.conversation?.branchTreeUrl ??
+                    conversationGithubTreeHref(
+                      workspace.workspaceRepositoryUrl,
+                      props.conversation?.lastBranch ??
+                        conversationSessionBranch(conversationId),
+                    ))
+                : null,
+            }
+          : null
+      }
+      publish={
+        !composing &&
+        prepareQuery.isSuccess &&
+        workspace.writeStatus === "writable"
+          ? {
+              commitPush: {
+                enabled: conversationCommitPushEnabled(
+                  statusQuery.data ?? null,
+                ),
+                pending: pushMutation.isPending,
+                onPress: () => pushMutation.mutate(),
+              },
+              pullRequest: {
+                action: conversationPullRequestAction(
+                  pullQuery.data?.prState ?? props.conversation?.prState,
+                ),
+                pending: createPrMutation.isPending,
+                href:
+                  pullQuery.data?.pullUrl ??
+                  props.conversation?.lastChatPrUrl ??
+                  null,
+                onPress: () => createPrMutation.mutate(),
+              },
+            }
+          : null
+      }
     >
       {composing && messages.length === 0 ? (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-6 py-10">

--- a/apps/ui/src/features/workspaces/WorkspacePane.stories.tsx
+++ b/apps/ui/src/features/workspaces/WorkspacePane.stories.tsx
@@ -3,6 +3,13 @@ import { useNavigate, useSearch } from "@tanstack/react-router"
 import { type ComponentProps, useState } from "react"
 import { fn } from "storybook/test"
 import {
+  conversationFilePutHandler,
+  conversationGitBlobHandler,
+  conversationGitDiffHandler,
+  conversationGitStatusHandler,
+  conversationGitTreeHandler,
+  conversationGitTreeMissingHandler,
+  conversationPrepareHandler,
   workspaceFileJobHandler,
   workspaceGitBlobHandler,
   workspaceGitBlobLoadingHandler,
@@ -416,6 +423,85 @@ export const Maximized: Story = {
     msw: {
       handlers: {
         page: gitFilesHandlers,
+      },
+    },
+  },
+}
+
+const conversationFileHandlers = [
+  conversationPrepareHandler(),
+  conversationGitTreeHandler(),
+  conversationGitBlobHandler(),
+  conversationGitStatusHandler(),
+  conversationGitDiffHandler(),
+  conversationFilePutHandler(),
+  ...gitFilesHandlers,
+]
+
+export const ConversationWritable: Story = {
+  args: {
+    conversationId: "conv_1",
+    pane: { kind: "file", path: ledgerPath },
+    fileTabs: [ledgerPath],
+    previewPath: ledgerPath,
+  },
+  parameters: {
+    storyRoute: {
+      pattern: "orgWorkspace",
+      orgSlug: "acme",
+      workspaceSlug: "docs",
+      conversationId: "conv_1",
+      pane: serializePane({ kind: "file", path: ledgerPath }),
+    } satisfies StoryRouteParams,
+    msw: {
+      handlers: {
+        page: conversationFileHandlers,
+      },
+    },
+  },
+}
+
+export const DiffTab: Story = {
+  args: {
+    conversationId: "conv_1",
+    pane: { kind: "diff" },
+  },
+  parameters: {
+    storyRoute: {
+      pattern: "orgWorkspace",
+      orgSlug: "acme",
+      workspaceSlug: "docs",
+      conversationId: "conv_1",
+      pane: "diff",
+    } satisfies StoryRouteParams,
+    msw: {
+      handlers: {
+        page: conversationFileHandlers,
+      },
+    },
+  },
+}
+
+export const SandboxLoadingFallback: Story = {
+  args: {
+    conversationId: "conv_1",
+    pane: { kind: "files" },
+  },
+  parameters: {
+    storyRoute: {
+      pattern: "orgWorkspace",
+      orgSlug: "acme",
+      workspaceSlug: "docs",
+      conversationId: "conv_1",
+      pane: "files",
+    } satisfies StoryRouteParams,
+    msw: {
+      handlers: {
+        page: [
+          conversationPrepareHandler(),
+          conversationGitTreeMissingHandler(),
+          ...gitFilesHandlers,
+        ],
       },
     },
   },

--- a/apps/ui/src/features/workspaces/WorkspacePane.tsx
+++ b/apps/ui/src/features/workspaces/WorkspacePane.tsx
@@ -5,7 +5,9 @@ import {
   IconArrowForwardUp,
   IconArrowsDiagonal2,
   IconArrowsDiagonalMinimize,
+  IconDeviceFloppy,
   IconFolder,
+  IconGitCompare,
   IconLayoutSidebarLeftExpand,
   IconLayoutSidebarRightCollapse,
   IconLayoutSidebarRightExpand,
@@ -44,10 +46,16 @@ import {
 import { focusVisibleClassName } from "@/lib/focus-styles"
 import { useUrgentValue } from "@/lib/useUrgentValue"
 import { cn } from "@/lib/utils"
+import { conversationAllowsEdits } from "./conversationPublish"
 import { joinFileName, optimisticPathsAfterJob } from "./fileTreeMutations"
 import { filePaneId, type ParsedPane, parsePane, serializePane } from "./pane"
 import {
-  enqueueWorkspaceFileJob,
+  conversationGitBlobOptions,
+  conversationGitDiffOptions,
+  conversationGitStatusOptions,
+  conversationGitTreeOptions,
+  persistConversationFileMutation,
+  workspaceChatPrepareOptions,
   workspaceGitBlobOptions,
   workspaceGitStatusOptions,
   workspaceGitTreeOptions,
@@ -55,6 +63,7 @@ import {
   workspaceKeys,
 } from "./queries"
 import type {
+  ConversationGitDiffItem,
   WorkspaceDetail,
   WorkspaceFileJobRequest,
   WorkspaceGitStatusItem,
@@ -88,6 +97,7 @@ import {
 export function WorkspacePane(props: {
   orgSlug: string
   workspace: WorkspaceDetail
+  conversationId?: string
   pane: ParsedPane
   fileTabs: string[]
   previewPath: string | null
@@ -110,12 +120,18 @@ export function WorkspacePane(props: {
   const urlPaneKey = serializePane(props.pane)
   const [pane, setPane] = useUrgentValue(props.pane, urlPaneKey)
   const activeFile = pane.kind === "file" ? pane.path : null
-  const filesTabActive = pane.kind === "files"
+  const filesTabActive = pane.kind === "files" || pane.kind === "diff"
   const selectedKey = serializePane(pane)
   const paneWidthLocked = props.width != null
 
   const prefetchPane = (next: ParsedPane) => {
-    prefetchWorkspacePane(queryClient, props.orgSlug, props.workspace, next)
+    prefetchWorkspacePane(
+      queryClient,
+      props.orgSlug,
+      props.workspace,
+      next,
+      props.conversationId,
+    )
   }
 
   const selectPane = (next: ParsedPane) => {
@@ -243,6 +259,14 @@ export function WorkspacePane(props: {
                 icon={<IconFolder stroke={1.6} aria-hidden />}
                 onIntent={() => prefetchPane({ kind: "files" })}
               />
+              {props.conversationId ? (
+                <ConversationDiffTab
+                  orgSlug={props.orgSlug}
+                  conversationId={props.conversationId}
+                  workspaceId={props.workspace.id}
+                  onIntent={() => prefetchPane({ kind: "diff" })}
+                />
+              ) : null}
               <PaneIconTab
                 id="graph"
                 label="Graph"
@@ -338,6 +362,8 @@ export function WorkspacePane(props: {
                 <WorkspaceFilesPaneBody
                   orgSlug={props.orgSlug}
                   workspaceSlug={props.workspace.slug}
+                  workspaceId={props.workspace.id}
+                  conversationId={props.conversationId}
                   sha={
                     props.workspace.activeProjectionSha?.trim() ||
                     props.workspace.desiredSha?.trim() ||
@@ -356,6 +382,18 @@ export function WorkspacePane(props: {
                   }}
                   onToggleTree={props.onToggleTree}
                   onCloseActiveFile={props.onCloseActiveFile}
+                />
+              </Suspense>
+            ) : null}
+            {pane.kind === "diff" && props.conversationId ? (
+              <Suspense fallback={<WorkspaceFilesPaneSkeleton />}>
+                <WorkspaceConversationDiffPane
+                  orgSlug={props.orgSlug}
+                  conversationId={props.conversationId}
+                  onOpenFile={(path) => {
+                    setPane({ kind: "file", path })
+                    props.onPinFile(path)
+                  }}
                 />
               </Suspense>
             ) : null}
@@ -407,6 +445,8 @@ export function WorkspacePane(props: {
 function WorkspaceFilesPaneBody(props: {
   orgSlug: string
   workspaceSlug: string
+  workspaceId: string
+  conversationId?: string
   sha: string
   writeStatus: string
   activeFile: string | null
@@ -416,21 +456,48 @@ function WorkspaceFilesPaneBody(props: {
   onToggleTree: () => void
   onCloseActiveFile: () => void
 }) {
-  const { data } = useSuspenseQuery(
+  const prepareQuery = useQuery({
+    ...workspaceChatPrepareOptions(
+      props.orgSlug,
+      props.conversationId ?? "",
+      props.workspaceId,
+    ),
+    enabled: Boolean(props.conversationId),
+  })
+  const sandboxTreeQuery = useQuery({
+    ...conversationGitTreeOptions(props.orgSlug, props.conversationId ?? ""),
+    enabled: Boolean(props.conversationId) && prepareQuery.isSuccess,
+  })
+  const workspaceTree = useSuspenseQuery(
     workspaceGitTreeOptions(props.orgSlug, props.workspaceSlug, props.sha),
   )
-  const statusQuery = useQuery(
-    workspaceGitStatusOptions(props.orgSlug, props.workspaceSlug, props.sha),
-  )
+  const useSandbox = Boolean(props.conversationId) && sandboxTreeQuery.isSuccess
+  const sandboxStatusQuery = useQuery({
+    ...conversationGitStatusOptions(props.orgSlug, props.conversationId ?? ""),
+    enabled: useSandbox,
+  })
+  const workspaceStatusQuery = useQuery({
+    ...workspaceGitStatusOptions(props.orgSlug, props.workspaceSlug, props.sha),
+    enabled: !useSandbox,
+  })
+  const tree = useSandbox ? sandboxTreeQuery.data : workspaceTree.data
+  if (!tree) return null
   return (
     <div className="h-full min-h-0 min-w-0 flex-1">
       <WorkspaceFilesPaneContent
         orgSlug={props.orgSlug}
         workspaceSlug={props.workspaceSlug}
+        conversationId={useSandbox ? props.conversationId : undefined}
         sha={props.sha}
-        writeStatus={props.writeStatus}
-        tree={data}
-        gitStatus={statusQuery.data?.items ?? []}
+        tree={tree}
+        gitStatus={
+          (useSandbox
+            ? sandboxStatusQuery.data?.items
+            : workspaceStatusQuery.data?.items) ?? []
+        }
+        writable={
+          useSandbox && conversationAllowsEdits(props.writeStatus)
+        }
         activeFile={props.activeFile}
         treeCollapsed={props.treeCollapsed}
         onPreviewFile={props.onPreviewFile}
@@ -455,10 +522,11 @@ function clampTreeWidth(width: number): number {
 function WorkspaceFilesPaneContent(props: {
   orgSlug: string
   workspaceSlug: string
+  conversationId?: string
   sha: string
-  writeStatus: string
   tree: WorkspaceGitTreeResponse
   gitStatus: readonly WorkspaceGitStatusItem[]
+  writable: boolean
   activeFile: string | null
   treeCollapsed: boolean
   onPreviewFile: (path: string) => void
@@ -468,6 +536,16 @@ function WorkspaceFilesPaneContent(props: {
 }) {
   const queryClient = useQueryClient()
   const prefetchBlob = (path: string) => {
+    if (props.conversationId) {
+      void queryClient.prefetchQuery(
+        conversationGitBlobOptions(
+          props.orgSlug,
+          props.conversationId,
+          path,
+        ),
+      )
+      return
+    }
     void queryClient.prefetchQuery(
       workspaceGitBlobOptions(
         props.orgSlug,
@@ -477,7 +555,7 @@ function WorkspaceFilesPaneContent(props: {
       ),
     )
   }
-  const writable = false
+  const writable = props.writable
   const [treeWidth, setTreeWidth] = useState(TREE_WIDTH_DEFAULT)
   const [treeResizing, setTreeResizing] = useState(false)
   const [drafts, setDrafts] = useState<Record<string, string>>({})
@@ -530,6 +608,34 @@ function WorkspaceFilesPaneContent(props: {
   }, [drafts, props.gitStatus])
 
   const invalidateFiles = async () => {
+    if (props.conversationId) {
+      await queryClient.invalidateQueries({
+        queryKey: workspaceKeys.conversationGitTree(
+          props.orgSlug,
+          props.conversationId,
+        ),
+      })
+      await queryClient.invalidateQueries({
+        queryKey: workspaceKeys.conversationGitStatus(
+          props.orgSlug,
+          props.conversationId,
+        ),
+      })
+      await queryClient.invalidateQueries({
+        queryKey: workspaceKeys.conversationGitDiff(
+          props.orgSlug,
+          props.conversationId,
+        ),
+      })
+      await queryClient.invalidateQueries({
+        queryKey: [
+          "conversation-git-blob",
+          props.orgSlug,
+          props.conversationId,
+        ],
+      })
+      return
+    }
     await queryClient.invalidateQueries({
       queryKey: workspaceKeys.gitTree(
         props.orgSlug,
@@ -555,15 +661,28 @@ function WorkspaceFilesPaneContent(props: {
   }
 
   const jobMutation = useMutation({
-    mutationFn: (input: WorkspaceFileJobRequest) =>
-      enqueueWorkspaceFileJob(props.orgSlug, props.workspaceSlug, input),
+    mutationFn: (input: WorkspaceFileJobRequest) => {
+      if (!props.conversationId) {
+        throw new Error("Conversation sandbox is not ready")
+      }
+      return persistConversationFileMutation(
+        props.orgSlug,
+        props.conversationId,
+        input,
+      )
+    },
     onMutate: async (input) => {
       setJobError(null)
-      const key = workspaceKeys.gitTree(
-        props.orgSlug,
-        props.workspaceSlug,
-        props.sha,
-      )
+      const key = props.conversationId
+        ? workspaceKeys.conversationGitTree(
+            props.orgSlug,
+            props.conversationId,
+          )
+        : workspaceKeys.gitTree(
+            props.orgSlug,
+            props.workspaceSlug,
+            props.sha,
+          )
       await queryClient.cancelQueries({ queryKey: key })
       const previous = queryClient.getQueryData<WorkspaceGitTreeResponse>(key)
       if (!previous || input.op === "save") return { previous }
@@ -635,7 +754,16 @@ function WorkspaceFilesPaneContent(props: {
       )
       if (context?.previous) {
         queryClient.setQueryData(
-          workspaceKeys.gitTree(props.orgSlug, props.workspaceSlug, props.sha),
+          props.conversationId
+            ? workspaceKeys.conversationGitTree(
+                props.orgSlug,
+                props.conversationId,
+              )
+            : workspaceKeys.gitTree(
+                props.orgSlug,
+                props.workspaceSlug,
+                props.sha,
+              ),
           context.previous,
         )
       }
@@ -689,6 +817,22 @@ function WorkspaceFilesPaneContent(props: {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
     }
   }, [])
+
+  useEffect(() => {
+    if (!writable) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "s") {
+        return
+      }
+      event.preventDefault()
+      const path = pendingSavePathRef.current ?? props.activeFile
+      clearAutosaveTimer()
+      pendingSavePathRef.current = null
+      flushSave(path)
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [props.activeFile, writable])
 
   const submitCreate = () => {
     if (!createDialog) return
@@ -831,6 +975,22 @@ function WorkspaceFilesPaneContent(props: {
               <Button
                 variant="quiet"
                 size="icon-sm"
+                aria-label="Save"
+                isDisabled={!dirty || jobMutation.isPending}
+                preventFocusOnPress
+                onPress={() => {
+                  const path = pendingSavePathRef.current ?? props.activeFile
+                  clearAutosaveTimer()
+                  pendingSavePathRef.current = null
+                  flushSave(path)
+                }}
+                className={FILES_HEADER_ICON_BUTTON_CLASS}
+              >
+                <IconDeviceFloppy className="size-4" stroke={1.6} aria-hidden />
+              </Button>
+              <Button
+                variant="quiet"
+                size="icon-sm"
                 aria-label="Undo"
                 isDisabled={!editorHistory.canUndo}
                 preventFocusOnPress
@@ -870,12 +1030,13 @@ function WorkspaceFilesPaneContent(props: {
               <WorkspaceGitFilePreview
                 orgSlug={props.orgSlug}
                 workspaceSlug={props.workspaceSlug}
+                conversationId={props.conversationId}
                 path={props.activeFile}
                 sha={props.sha || props.tree.sha}
                 remoteBody={
                   gitStatus.find((item) => item.path === props.activeFile)?.body
                 }
-                editable={false}
+                editable={writable}
                 editorHandleRef={fileEditorRef}
                 onHistoryChange={setEditorHistory}
                 onBlur={saveOnBlur}
@@ -982,11 +1143,11 @@ function WorkspaceFilesPaneContent(props: {
                 <IconAlertCircle aria-hidden className="size-6 stroke-2" />
               </div>
               <p className="mt-3 text-sm text-zinc-400">
-                This queues a write job that removes{" "}
+                This removes{" "}
                 <code className="font-mono text-xs text-zinc-200">
                   {deleteItem?.path}
                 </code>{" "}
-                from the Workspace repository.
+                from the conversation sandbox. Commit+Push publishes it.
               </p>
               <div className="mt-6 flex justify-end gap-2">
                 <Button variant="ghost" onPress={close}>
@@ -1018,6 +1179,7 @@ function WorkspaceFilesPaneContent(props: {
 function WorkspaceGitFilePreview(props: {
   orgSlug: string
   workspaceSlug: string
+  conversationId?: string
   path: string
   sha: string
   remoteBody?: string | null
@@ -1027,6 +1189,31 @@ function WorkspaceGitFilePreview(props: {
   onBlur: () => void
   onChange: (body: string, headBody: string | null) => void
 }) {
+  if (props.conversationId) {
+    return (
+      <SandboxGitFilePreview
+        {...props}
+        conversationId={props.conversationId}
+      />
+    )
+  }
+  return <CodesearchGitFilePreview {...props} />
+}
+
+function SandboxGitFilePreview(
+  props: Omit<Parameters<typeof GitFilePreviewBody>[0], "data"> & {
+    conversationId: string
+  },
+) {
+  const { data } = useSuspenseQuery(
+    conversationGitBlobOptions(props.orgSlug, props.conversationId, props.path),
+  )
+  return <GitFilePreviewBody {...props} data={data} />
+}
+
+function CodesearchGitFilePreview(
+  props: Omit<Parameters<typeof GitFilePreviewBody>[0], "data">,
+) {
   const { data } = useSuspenseQuery(
     workspaceGitBlobOptions(
       props.orgSlug,
@@ -1035,6 +1222,38 @@ function WorkspaceGitFilePreview(props: {
       props.path,
     ),
   )
+  return <GitFilePreviewBody {...props} data={data} />
+}
+
+function GitFilePreviewBody(props: {
+  orgSlug: string
+  workspaceSlug: string
+  conversationId?: string
+  path: string
+  sha: string
+  remoteBody?: string | null
+  editable: boolean
+  editorHandleRef: { current: FileEditorHandle | null }
+  onHistoryChange: (history: FileEditorHistory) => void
+  onBlur: () => void
+  onChange: (body: string, headBody: string | null) => void
+  data: { path: string; body: string | null; binary: boolean }
+}) {
+  const { data } = props
+  const [seenBody, setSeenBody] = useState(data.body)
+  const [loadedBody, setLoadedBody] = useState(data.body)
+  const [agentUpdated, setAgentUpdated] = useState(false)
+  const dirtyVsLoaded =
+    props.remoteBody != null && props.remoteBody !== (loadedBody ?? "")
+  if (data.body !== seenBody) {
+    setSeenBody(data.body)
+    if (dirtyVsLoaded && data.body !== loadedBody) {
+      setAgentUpdated(true)
+    } else if (!dirtyVsLoaded) {
+      setLoadedBody(data.body)
+      setAgentUpdated(false)
+    }
+  }
   if (data.binary) {
     return (
       <div className="flex h-full min-h-0 items-center p-4">
@@ -1044,7 +1263,7 @@ function WorkspaceGitFilePreview(props: {
       </div>
     )
   }
-  const headBody = data.body
+  const headBody = agentUpdated ? loadedBody : data.body
   const workingBody = props.remoteBody ?? headBody
   if (workingBody == null && headBody == null) {
     return (
@@ -1056,18 +1275,36 @@ function WorkspaceGitFilePreview(props: {
     )
   }
   return (
-    <div className="h-full min-h-0 min-w-0">
-      <WorkspacePierreFile
-        path={props.path}
-        body={workingBody ?? ""}
-        oldBody={headBody}
-        cacheKey={`${props.sha}:${props.path}`}
-        editable={props.editable}
-        editorHandleRef={props.editorHandleRef}
-        onHistoryChange={props.onHistoryChange}
-        onBlur={props.onBlur}
-        onChange={(body) => props.onChange(body, headBody)}
-      />
+    <div className="flex h-full min-h-0 min-w-0 flex-col">
+      {agentUpdated ? (
+        <div className="flex items-center justify-between gap-2 px-3 py-2">
+          <p className="text-xs text-amber-200">Agent updated this file.</p>
+          <Button
+            variant="ghost"
+            className="h-7 px-2 text-xs"
+            onPress={() => {
+              setLoadedBody(data.body)
+              setAgentUpdated(false)
+              props.onChange(data.body ?? "", data.body)
+            }}
+          >
+            Reload
+          </Button>
+        </div>
+      ) : null}
+      <div className="min-h-0 min-w-0 flex-1">
+        <WorkspacePierreFile
+          path={props.path}
+          body={workingBody ?? ""}
+          oldBody={headBody}
+          cacheKey={`${props.conversationId ?? props.sha}:${props.path}:${agentUpdated ? "held" : "live"}`}
+          editable={props.editable}
+          editorHandleRef={props.editorHandleRef}
+          onHistoryChange={props.onHistoryChange}
+          onBlur={props.onBlur}
+          onChange={(body) => props.onChange(body, headBody)}
+        />
+      </div>
     </div>
   )
 }
@@ -1096,10 +1333,21 @@ function prefetchWorkspacePane(
   orgSlug: string,
   workspace: WorkspaceDetail,
   pane: ParsedPane,
+  conversationId?: string,
 ) {
   const sha =
     workspace.activeProjectionSha?.trim() || workspace.desiredSha?.trim() || ""
   if (pane.kind === "files" || pane.kind === "file") {
+    if (conversationId) {
+      void queryClient.prefetchQuery(
+        conversationGitTreeOptions(orgSlug, conversationId),
+      )
+      if (pane.kind === "file") {
+        void queryClient.prefetchQuery(
+          conversationGitBlobOptions(orgSlug, conversationId, pane.path),
+        )
+      }
+    }
     void queryClient.prefetchQuery(
       workspaceGitTreeOptions(orgSlug, workspace.slug, sha),
     )
@@ -1108,11 +1356,98 @@ function prefetchWorkspacePane(
         workspaceGitBlobOptions(orgSlug, workspace.slug, sha, pane.path),
       )
     }
+  } else if (pane.kind === "diff" && conversationId) {
+    void queryClient.prefetchQuery(
+      conversationGitDiffOptions(orgSlug, conversationId),
+    )
   } else if (pane.kind === "graph") {
     void queryClient.prefetchQuery(
       workspaceGraphOptions(orgSlug, workspace.slug),
     )
   }
+}
+
+function ConversationDiffTab(props: {
+  orgSlug: string
+  conversationId: string
+  workspaceId: string
+  onIntent?: () => void
+}) {
+  const prepareQuery = useQuery({
+    ...workspaceChatPrepareOptions(
+      props.orgSlug,
+      props.conversationId,
+      props.workspaceId,
+    ),
+  })
+  const statusQuery = useQuery({
+    ...conversationGitStatusOptions(props.orgSlug, props.conversationId),
+    enabled: prepareQuery.isSuccess,
+  })
+  if (!statusQuery.data?.differsFromDefault) return null
+  return (
+    <PaneIconTab
+      id="diff"
+      label="Diff"
+      icon={<IconGitCompare stroke={1.6} aria-hidden />}
+      onIntent={props.onIntent}
+    />
+  )
+}
+
+function WorkspaceConversationDiffPane(props: {
+  orgSlug: string
+  conversationId: string
+  onOpenFile: (path: string) => void
+}) {
+  const { data } = useSuspenseQuery(
+    conversationGitDiffOptions(props.orgSlug, props.conversationId),
+  )
+  if (data.items.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <p className="text-sm text-muted-foreground">
+          No changes vs the default branch.
+        </p>
+      </div>
+    )
+  }
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-auto">
+      {data.items.map((item) => (
+        <ConversationDiffFile
+          key={item.path}
+          item={item}
+          onOpen={() => props.onOpenFile(item.path)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ConversationDiffFile(props: {
+  item: ConversationGitDiffItem
+  onOpen: () => void
+}) {
+  return (
+    <div className="border-b border-white/[0.06]">
+      <Button
+        variant="ghost"
+        onPress={props.onOpen}
+        className="h-8 w-full justify-start rounded-none px-3 font-mono text-xs"
+      >
+        {props.item.path}
+      </Button>
+      <div className="h-64 min-h-0">
+        <WorkspacePierreFile
+          path={props.item.path}
+          body={props.item.body ?? ""}
+          oldBody={props.item.oldBody}
+          cacheKey={`diff:${props.item.path}:${props.item.body?.length ?? 0}`}
+        />
+      </div>
+    </div>
+  )
 }
 
 function PaneIconTab(props: {

--- a/apps/ui/src/features/workspaces/WorkspaceSurface.tsx
+++ b/apps/ui/src/features/workspaces/WorkspaceSurface.tsx
@@ -459,6 +459,7 @@ function WorkspaceSurfaceColumns(props: {
         <WorkspacePane
           orgSlug={orgSlug}
           workspace={workspace}
+          conversationId={conversationId}
           pane={shownPane}
           fileTabs={fileTabs}
           previewPath={previewPath}

--- a/apps/ui/src/features/workspaces/conversationFileLive.test.ts
+++ b/apps/ui/src/features/workspaces/conversationFileLive.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import {
+  conversationWriteToolPaths,
+  conversationWriteToolSignature,
+} from "./conversationFileLive"
+
+describe("conversationWriteToolPaths", () => {
+  it("collects write and edit tool paths", () => {
+    expect(
+      conversationWriteToolPaths([
+        {
+          parts: [
+            {
+              type: "tool-call",
+              name: "write",
+              input: { path: "knowledge/billing/ledger.md" },
+            },
+            {
+              type: "tool-call",
+              name: "hybrid_search",
+              input: { query: "billing" },
+            },
+            {
+              type: "tool-call",
+              name: "edit",
+              input: { filePath: "AGENTS.md" },
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["knowledge/billing/ledger.md", "AGENTS.md"])
+  })
+
+  it("fingerprints the write set", () => {
+    expect(
+      conversationWriteToolSignature([
+        {
+          parts: [
+            {
+              type: "tool-call",
+              name: "apply_patch",
+              input: { path: "README.md" },
+            },
+          ],
+        },
+      ]),
+    ).toBe("README.md")
+  })
+})

--- a/apps/ui/src/features/workspaces/conversationFileLive.ts
+++ b/apps/ui/src/features/workspaces/conversationFileLive.ts
@@ -1,0 +1,48 @@
+import type { ChatMessage } from "@/features/chat/types"
+
+const WRITE_TOOL_NAMES = ["write", "edit", "apply_patch", "commit"] as const
+
+function toolNameLooksLikeWrite(name: string): boolean {
+  const lower = name.toLowerCase()
+  return WRITE_TOOL_NAMES.some(
+    (tool) => lower === tool || lower.includes(tool),
+  )
+}
+
+function pathFromUnknown(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null
+  const record = value as Record<string, unknown>
+  for (const key of ["path", "filePath", "file_path", "file"]) {
+    const candidate = record[key]
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim()
+    }
+  }
+  return null
+}
+
+export function conversationWriteToolPaths(
+  messages: readonly Pick<ChatMessage, "parts">[],
+): string[] {
+  const paths = new Set<string>()
+  for (const message of messages) {
+    for (const part of message.parts) {
+      const name = part.name ?? part.type
+      if (!name || !toolNameLooksLikeWrite(name)) continue
+      const path =
+        pathFromUnknown(part.input) ??
+        pathFromUnknown(part.data) ??
+        (typeof part.content === "string" ? part.content : null)
+      if (path?.includes("/") || (path && !path.includes(" "))) {
+        paths.add(path)
+      }
+    }
+  }
+  return [...paths]
+}
+
+export function conversationWriteToolSignature(
+  messages: readonly Pick<ChatMessage, "parts">[],
+): string {
+  return conversationWriteToolPaths(messages).join("\0")
+}

--- a/apps/ui/src/features/workspaces/conversationPublish.test.ts
+++ b/apps/ui/src/features/workspaces/conversationPublish.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import {
+  conversationAllowsEdits,
+  conversationBranchShortName,
+  conversationCommitPushEnabled,
+  conversationGithubTreeHref,
+  conversationPullRequestAction,
+  conversationSessionBranch,
+} from "./conversationPublish"
+
+describe("conversation publish helpers", () => {
+  it("treats only writable as editable", () => {
+    expect(conversationAllowsEdits("writable")).toBe(true)
+    expect(conversationAllowsEdits("read_only")).toBe(false)
+    expect(conversationAllowsEdits("unknown")).toBe(false)
+  })
+
+  it("uses one session branch and a short chrome name", () => {
+    expect(conversationSessionBranch("conv_1")).toBe("ctxpipe/chat/conv_1/1")
+    expect(conversationBranchShortName("ctxpipe/chat/conv_1/1")).toBe("chat/1")
+  })
+
+  it("shows Create PR after merge and Show PR while open", () => {
+    expect(conversationPullRequestAction("open")).toBe("show")
+    expect(conversationPullRequestAction("merged")).toBe("create")
+    expect(conversationPullRequestAction(null)).toBe("create")
+  })
+
+  it("enables Commit+Push when dirty, ahead, or unpushed", () => {
+    expect(
+      conversationCommitPushEnabled({
+        dirty: false,
+        differsFromDefault: false,
+        unpushed: false,
+      }),
+    ).toBe(false)
+    expect(
+      conversationCommitPushEnabled({
+        dirty: true,
+        differsFromDefault: true,
+        unpushed: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("builds a GitHub tree href after the first push", () => {
+    expect(
+      conversationGithubTreeHref(
+        "https://github.com/acme/docs.git",
+        "ctxpipe/chat/conv_1/1",
+      ),
+    ).toBe("https://github.com/acme/docs/tree/ctxpipe/chat/conv_1/1")
+  })
+})

--- a/apps/ui/src/features/workspaces/conversationPublish.ts
+++ b/apps/ui/src/features/workspaces/conversationPublish.ts
@@ -1,0 +1,46 @@
+import type { ConversationPrState } from "@/features/chat/types"
+
+export function conversationSessionBranch(conversationId: string): string {
+  return `ctxpipe/chat/${conversationId}/1`
+}
+
+export function conversationAllowsEdits(writeStatus: string): boolean {
+  return writeStatus === "writable"
+}
+
+export function conversationBranchShortName(branch: string): string {
+  return branch.startsWith("ctxpipe/chat/") ? "chat/1" : branch
+}
+
+export function conversationPullRequestAction(
+  prState: ConversationPrState | string | null | undefined,
+): "create" | "show" {
+  return prState === "open" ? "show" : "create"
+}
+
+export function conversationGithubTreeHref(
+  workspaceRepositoryUrl: string,
+  branch: string,
+): string | null {
+  try {
+    const parsed = new URL(workspaceRepositoryUrl)
+    if (parsed.hostname.toLowerCase() !== "github.com") return null
+    const [owner, repoWithGit] = parsed.pathname
+      .replace(/^\/+|\/+$/g, "")
+      .split("/")
+    const repo = repoWithGit?.replace(/\.git$/, "")
+    if (!owner || !repo) return null
+    return `https://github.com/${owner}/${repo}/tree/${branch}`
+  } catch {
+    return null
+  }
+}
+
+export function conversationCommitPushEnabled(status: {
+  dirty: boolean
+  differsFromDefault: boolean
+  unpushed: boolean
+} | null): boolean {
+  if (!status) return false
+  return status.dirty || status.differsFromDefault || status.unpushed
+}

--- a/apps/ui/src/features/workspaces/pane.test.ts
+++ b/apps/ui/src/features/workspaces/pane.test.ts
@@ -6,6 +6,7 @@ describe("parsePane", () => {
     expect(parsePane("files")).toEqual({ kind: "files" })
     expect(parsePane("graph")).toEqual({ kind: "graph" })
     expect(parsePane("settings")).toEqual({ kind: "settings" })
+    expect(parsePane("diff")).toEqual({ kind: "diff" })
   })
 
   it("decodes file paths", () => {
@@ -34,6 +35,7 @@ describe("landingPane", () => {
   })
 
   it("keeps a visible URL pane", () => {
+    expect(landingPane("diff")).toEqual({ kind: "diff" })
     expect(landingPane("graph")).toEqual({ kind: "graph" })
     expect(landingPane("file:README.md")).toEqual({
       kind: "file",

--- a/apps/ui/src/features/workspaces/pane.ts
+++ b/apps/ui/src/features/workspaces/pane.ts
@@ -1,9 +1,10 @@
-export type PaneKind = "files" | "graph" | "settings" | "file" | "unknown"
+export type PaneKind = "files" | "graph" | "settings" | "file" | "diff" | "unknown"
 
 export type ParsedPane =
   | { kind: "files" }
   | { kind: "graph" }
   | { kind: "settings" }
+  | { kind: "diff" }
   | { kind: "file"; path: string }
   | { kind: "unknown"; id: string }
 
@@ -12,6 +13,7 @@ export function parsePane(raw: string | undefined): ParsedPane | null {
   if (raw === "files") return { kind: "files" }
   if (raw === "graph") return { kind: "graph" }
   if (raw === "settings") return { kind: "settings" }
+  if (raw === "diff") return { kind: "diff" }
   if (raw.startsWith("file:")) {
     const encoded = raw.slice("file:".length)
     let path = encoded

--- a/apps/ui/src/features/workspaces/queries.ts
+++ b/apps/ui/src/features/workspaces/queries.ts
@@ -2,7 +2,13 @@ import { queryOptions } from "@tanstack/react-query"
 import type { ConversationDetail } from "@/features/chat/types"
 import { getApiClient } from "@/lib/api"
 import { readApiJson } from "@/lib/api-result"
+import { destinationAfterMove } from "./fileTreeMutations"
 import type {
+  ConversationFileMutation,
+  ConversationGitDiffResponse,
+  ConversationGitStatusResponse,
+  ConversationPullRequestResponse,
+  ConversationPushResponse,
   Workspace,
   WorkspaceDetail,
   WorkspaceFileJobRequest,
@@ -38,6 +44,19 @@ export const workspaceKeys = {
     ["workspace-graph", orgSlug, slug] as const,
   chatPrepare: (orgSlug: string, conversationId: string, workspaceId: string) =>
     ["workspace-chat-prepare", orgSlug, conversationId, workspaceId] as const,
+  conversationGitTree: (orgSlug: string, conversationId: string) =>
+    ["conversation-git-tree", orgSlug, conversationId] as const,
+  conversationGitBlob: (
+    orgSlug: string,
+    conversationId: string,
+    path: string,
+  ) => ["conversation-git-blob", orgSlug, conversationId, path] as const,
+  conversationGitStatus: (orgSlug: string, conversationId: string) =>
+    ["conversation-git-status", orgSlug, conversationId] as const,
+  conversationGitDiff: (orgSlug: string, conversationId: string) =>
+    ["conversation-git-diff", orgSlug, conversationId] as const,
+  conversationPullRequest: (orgSlug: string, conversationId: string) =>
+    ["conversation-pull-request", orgSlug, conversationId] as const,
 }
 
 export async function fetchWorkspaces(
@@ -68,6 +87,19 @@ export async function fetchConversation(
     emptyOn: [404],
     empty: null,
     message: "Failed to load conversation",
+  })
+}
+
+export function workspaceChatPrepareOptions(
+  orgSlug: string,
+  conversationId: string,
+  workspaceId: string,
+) {
+  return queryOptions({
+    queryKey: workspaceKeys.chatPrepare(orgSlug, conversationId, workspaceId),
+    queryFn: () => prepareWorkspaceChat(orgSlug, conversationId, workspaceId),
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: false,
   })
 }
 
@@ -271,6 +303,224 @@ export function workspaceGraphOptions(orgSlug: string, workspaceSlug: string) {
   return queryOptions({
     queryKey: workspaceKeys.graph(orgSlug, workspaceSlug),
     queryFn: () => fetchWorkspaceGraph(orgSlug, workspaceSlug),
+  })
+}
+
+export async function fetchConversationGitTree(
+  orgSlug: string,
+  conversationId: string,
+): Promise<WorkspaceGitTreeResponse & { branch: string }> {
+  const client = await getApiClient()
+  const res = await client[":orgSlug"].api.v1.conversations[
+    ":conversationId"
+  ].files.tree.$get({
+    param: { orgSlug, conversationId },
+  })
+  return readApiJson(res, { message: "Failed to load conversation files" })
+}
+
+export async function fetchConversationGitBlob(
+  orgSlug: string,
+  conversationId: string,
+  path: string,
+): Promise<WorkspaceGitBlobResponse> {
+  const client = await getApiClient()
+  const res = await client[":orgSlug"].api.v1.conversations[
+    ":conversationId"
+  ].files.blob.$get({
+    param: { orgSlug, conversationId },
+    query: { path },
+  })
+  return readApiJson(res, {
+    emptyOn: [404],
+    empty: { path, body: null, binary: false },
+    message: "Failed to load conversation file",
+  })
+}
+
+export async function fetchConversationGitStatus(
+  orgSlug: string,
+  conversationId: string,
+): Promise<ConversationGitStatusResponse> {
+  const client = await getApiClient()
+  const res = await client[":orgSlug"].api.v1.conversations[
+    ":conversationId"
+  ].files.status.$get({
+    param: { orgSlug, conversationId },
+  })
+  return readApiJson(res, { message: "Failed to load conversation git status" })
+}
+
+export async function fetchConversationGitDiff(
+  orgSlug: string,
+  conversationId: string,
+): Promise<ConversationGitDiffResponse> {
+  const client = await getApiClient()
+  const res = await client[":orgSlug"].api.v1.conversations[
+    ":conversationId"
+  ].files.diff.$get({
+    param: { orgSlug, conversationId },
+  })
+  return readApiJson(res, { message: "Failed to load conversation diff" })
+}
+
+export async function putConversationFile(
+  orgSlug: string,
+  conversationId: string,
+  input: ConversationFileMutation,
+): Promise<WorkspaceGitBlobResponse> {
+  const client = await getApiClient()
+  const res = await client[":orgSlug"].api.v1.conversations[
+    ":conversationId"
+  ].files.blob.$put({
+    param: { orgSlug, conversationId },
+    json: input,
+  })
+  return readApiJson(res, { message: "Failed to save conversation file" })
+}
+
+export async function persistConversationFileMutation(
+  orgSlug: string,
+  conversationId: string,
+  input: WorkspaceFileJobRequest,
+): Promise<void> {
+  if (input.op === "save") {
+    await putConversationFile(orgSlug, conversationId, {
+      path: input.path,
+      body: input.content,
+    })
+    return
+  }
+  if (input.op === "create") {
+    const path =
+      input.kind === "folder" ? `${input.path}/.gitkeep` : input.path
+    await putConversationFile(orgSlug, conversationId, {
+      path,
+      body: input.content ?? "",
+    })
+    return
+  }
+  if (input.op === "delete") {
+    await putConversationFile(orgSlug, conversationId, {
+      path: input.path,
+      deletePath: true,
+    })
+    return
+  }
+  if (input.op === "rename") {
+    await putConversationFile(orgSlug, conversationId, {
+      path: input.to,
+      from: input.from,
+    })
+    return
+  }
+  const to = destinationAfterMove(input.from, input.toDirectory)
+  if (!to) throw new Error("Invalid move destination")
+  await putConversationFile(orgSlug, conversationId, {
+    path: to,
+    from: input.from,
+  })
+}
+
+export async function pushConversationBranch(
+  orgSlug: string,
+  conversationId: string,
+): Promise<ConversationPushResponse> {
+  const client = await getApiClient()
+  const res = await client[":orgSlug"].api.v1.conversations[
+    ":conversationId"
+  ].push.$post({
+    param: { orgSlug, conversationId },
+  })
+  return readApiJson(res, { message: "Failed to push conversation branch" })
+}
+
+export async function fetchConversationPullRequest(
+  orgSlug: string,
+  conversationId: string,
+): Promise<ConversationPullRequestResponse | null> {
+  const client = await getApiClient()
+  const res = await client[":orgSlug"].api.v1.conversations[
+    ":conversationId"
+  ]["pull-request"].$get({
+    param: { orgSlug, conversationId },
+  })
+  return readApiJson(res, {
+    emptyOn: [404],
+    empty: null,
+    message: "Failed to load pull request",
+  })
+}
+
+export async function createConversationPullRequest(
+  orgSlug: string,
+  conversationId: string,
+  input?: { title?: string; body?: string },
+): Promise<ConversationPullRequestResponse> {
+  const client = await getApiClient()
+  const res = await client[":orgSlug"].api.v1.conversations[
+    ":conversationId"
+  ]["pull-request"].$post({
+    param: { orgSlug, conversationId },
+    json: input ?? {},
+  })
+  return readApiJson(res, { message: "Failed to create pull request" })
+}
+
+export function conversationGitTreeOptions(
+  orgSlug: string,
+  conversationId: string,
+) {
+  return queryOptions({
+    queryKey: workspaceKeys.conversationGitTree(orgSlug, conversationId),
+    queryFn: () => fetchConversationGitTree(orgSlug, conversationId),
+    retry: false,
+  })
+}
+
+export function conversationGitBlobOptions(
+  orgSlug: string,
+  conversationId: string,
+  path: string,
+) {
+  return queryOptions({
+    queryKey: workspaceKeys.conversationGitBlob(orgSlug, conversationId, path),
+    queryFn: () => fetchConversationGitBlob(orgSlug, conversationId, path),
+  })
+}
+
+export function conversationGitStatusOptions(
+  orgSlug: string,
+  conversationId: string,
+) {
+  return queryOptions({
+    queryKey: workspaceKeys.conversationGitStatus(orgSlug, conversationId),
+    queryFn: () => fetchConversationGitStatus(orgSlug, conversationId),
+    retry: false,
+  })
+}
+
+export function conversationGitDiffOptions(
+  orgSlug: string,
+  conversationId: string,
+) {
+  return queryOptions({
+    queryKey: workspaceKeys.conversationGitDiff(orgSlug, conversationId),
+    queryFn: () => fetchConversationGitDiff(orgSlug, conversationId),
+    retry: false,
+  })
+}
+
+export function conversationPullRequestOptions(
+  orgSlug: string,
+  conversationId: string,
+  enabled: boolean,
+) {
+  return queryOptions({
+    queryKey: workspaceKeys.conversationPullRequest(orgSlug, conversationId),
+    queryFn: () => fetchConversationPullRequest(orgSlug, conversationId),
+    enabled,
+    retry: false,
   })
 }
 

--- a/apps/ui/src/features/workspaces/types.ts
+++ b/apps/ui/src/features/workspaces/types.ts
@@ -88,6 +88,46 @@ export type WorkspaceGitStatusResponse = {
   items: WorkspaceGitStatusItem[]
 }
 
+export type ConversationGitStatusResponse = {
+  source: "sandbox"
+  dirty: boolean
+  differsFromDefault: boolean
+  unpushed: boolean
+  published: boolean
+  ahead: number
+  behind: number
+  items: WorkspaceGitStatusItem[]
+}
+
+export type ConversationGitDiffItem = {
+  path: string
+  oldBody: string | null
+  body: string | null
+}
+
+export type ConversationGitDiffResponse = {
+  items: ConversationGitDiffItem[]
+}
+
+export type ConversationFileMutation = {
+  path: string
+  body?: string
+  deletePath?: boolean
+  from?: string
+}
+
+export type ConversationPushResponse = {
+  branch: string
+  treeUrl: string
+}
+
+export type ConversationPullRequestResponse = {
+  branch: string
+  prNumber: number
+  pullUrl: string
+  prState: "open" | "closed" | "merged"
+}
+
 export type WorkspaceFileJobRequest =
   | { op: "save"; path: string; content: string }
   | { op: "create"; path: string; kind: "file" | "folder"; content?: string }

--- a/apps/ui/src/features/workspaces/workspace-fixtures.ts
+++ b/apps/ui/src/features/workspaces/workspace-fixtures.ts
@@ -44,6 +44,15 @@ export const readOnlyWorkspace: Workspace = {
   readOnlyReason: "The GitHub App cannot write to this repository.",
 }
 
+export const pendingWriteWorkspace: Workspace = {
+  ...docsWorkspace,
+  id: "ws_pending",
+  slug: "pending",
+  displayName: "Pending",
+  writeStatus: "unknown",
+  readOnlyReason: null,
+}
+
 export const hydratingWorkspace: Workspace = {
   ...docsWorkspace,
   id: "ws_hydrate",
@@ -149,6 +158,11 @@ export const docsConversationDetail: ConversationDetail = {
     orgId: "org_acme",
     userId: "user_storybook",
     workspaceId: docsWorkspace.id,
+    lastBranch: "ctxpipe/chat/conv_1/1",
+    lastChatPrNumber: 41,
+    lastChatPrUrl: "https://github.com/acme/docs/pull/41",
+    prState: "open",
+    branchTreeUrl: "https://github.com/acme/docs/tree/ctxpipe/chat/conv_1/1",
     createdAt: "2026-08-16T09:30:00.000Z",
     updatedAt: "2026-08-16T10:00:00.000Z",
   },

--- a/apps/ui/src/mocks/workspace-handlers.ts
+++ b/apps/ui/src/mocks/workspace-handlers.ts
@@ -5,6 +5,8 @@ import type {
   PageInfo,
 } from "@/features/chat/types"
 import type {
+  ConversationGitDiffResponse,
+  ConversationGitStatusResponse,
   Workspace,
   WorkspaceDetail,
   WorkspaceFileJobRequest,
@@ -229,6 +231,151 @@ export function conversationDetailHandler(detail: ConversationDetail | null) {
       return HttpResponse.json(detail)
     },
   )
+}
+
+export function conversationPrepareHandler() {
+  return http.post(
+    ({ request }) =>
+      /\/api\/v1\/conversations\/[^/]+\/prepare$/.test(pathnameOf(request)),
+    () => new HttpResponse(null, { status: 204 }),
+  )
+}
+
+export function conversationGitTreeHandler(
+  tree: WorkspaceGitTreeResponse & { branch?: string } = {
+    ...docsWorkspaceGitTree,
+    branch: "ctxpipe/chat/conv_1/1",
+  },
+) {
+  return http.get(
+    ({ request }) =>
+      /\/api\/v1\/conversations\/[^/]+\/files\/tree$/.test(pathnameOf(request)),
+    () => HttpResponse.json(tree),
+  )
+}
+
+export function conversationGitTreeMissingHandler() {
+  return http.get(
+    ({ request }) =>
+      /\/api\/v1\/conversations\/[^/]+\/files\/tree$/.test(pathnameOf(request)),
+    () => HttpResponse.json({ error: "missing_sandbox" }, { status: 409 }),
+  )
+}
+
+export function conversationGitBlobHandler(
+  blobs: Record<string, string> = docsWorkspaceGitBlobs,
+) {
+  return http.get(
+    ({ request }) =>
+      /\/api\/v1\/conversations\/[^/]+\/files\/blob$/.test(pathnameOf(request)),
+    ({ request }) => {
+      const path = new URL(request.url).searchParams.get("path") ?? ""
+      const body = blobs[path]
+      if (body === undefined) {
+        return HttpResponse.json({ error: "Not found" }, { status: 404 })
+      }
+      return HttpResponse.json({ path, body, binary: false })
+    },
+  )
+}
+
+export function conversationGitStatusHandler(
+  status: ConversationGitStatusResponse = {
+    source: "sandbox",
+    dirty: true,
+    differsFromDefault: true,
+    unpushed: true,
+    published: false,
+    ahead: 1,
+    behind: 0,
+    items: docsWorkspaceGitStatus.items,
+  },
+) {
+  return http.get(
+    ({ request }) =>
+      /\/api\/v1\/conversations\/[^/]+\/files\/status$/.test(pathnameOf(request)),
+    () => HttpResponse.json(status),
+  )
+}
+
+export function conversationGitDiffHandler(
+  items: ConversationGitDiffResponse["items"] = [
+    {
+      path: "knowledge/billing/ledger.md",
+      oldBody: docsWorkspaceGitBlobs["knowledge/billing/ledger.md"] ?? "",
+      body: `${docsWorkspaceGitBlobs["knowledge/billing/ledger.md"] ?? ""}\nQueued sandbox edit.\n`,
+    },
+  ],
+) {
+  return http.get(
+    ({ request }) =>
+      /\/api\/v1\/conversations\/[^/]+\/files\/diff$/.test(pathnameOf(request)),
+    () => HttpResponse.json({ items }),
+  )
+}
+
+export function conversationFilePutHandler() {
+  return http.put(
+    ({ request }) =>
+      /\/api\/v1\/conversations\/[^/]+\/files\/blob$/.test(pathnameOf(request)),
+    async ({ request }) => {
+      const body = (await request.json()) as {
+        path: string
+        body?: string | null
+      }
+      return HttpResponse.json({
+        path: body.path,
+        body: body.body ?? null,
+        binary: false,
+      })
+    },
+  )
+}
+
+export function conversationPushHandler() {
+  return http.post(
+    ({ request }) =>
+      /\/api\/v1\/conversations\/[^/]+\/push$/.test(pathnameOf(request)),
+    () =>
+      HttpResponse.json({
+        branch: "ctxpipe/chat/conv_1/1",
+        treeUrl: "https://github.com/acme/docs/tree/ctxpipe/chat/conv_1/1",
+      }),
+  )
+}
+
+export function conversationPullRequestHandler(input?: {
+  prState?: "open" | "closed" | "merged"
+  delayMs?: "infinite"
+}) {
+  const payload = {
+    branch: "ctxpipe/chat/conv_1/1",
+    prNumber: 41,
+    pullUrl: "https://github.com/acme/docs/pull/41",
+    prState: input?.prState ?? "open",
+  }
+  return [
+    http.get(
+      ({ request }) =>
+        /\/api\/v1\/conversations\/[^/]+\/pull-request$/.test(
+          pathnameOf(request),
+        ),
+      async () => {
+        if (input?.delayMs === "infinite") await delay("infinite")
+        return HttpResponse.json(payload)
+      },
+    ),
+    http.post(
+      ({ request }) =>
+        /\/api\/v1\/conversations\/[^/]+\/pull-request$/.test(
+          pathnameOf(request),
+        ),
+      async () => {
+        if (input?.delayMs === "infinite") await delay("infinite")
+        return HttpResponse.json(payload)
+      },
+    ),
+  ]
 }
 
 export function conversationDetailLoadingHandler() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Conversation Files now share the chat sandbox on one session branch, `ctxpipe/chat/<conversationId>/1`. Pane edits and agent writes stay in that tree until an explicit brokered publish.

## What changed

- **Write status:** a protected default branch is no longer `read_only`. Jobs still refuse default-branch pushes. Chat may edit and push the session branch when the App has Contents write.
- **Policy:** OpenCode may `git commit` only on the session branch. `git push` stays hard-denied. Read-only conversations deny edit/write/apply_patch/commit.
- **Prepare:** checks out `/1` after warm (restore that ref from the remote when it exists).
- **Conversation file routes:** tree, blob, status, diff, PUT, and Commit+Push on the sandbox. 409 `missing_sandbox` until the handle is ready.
- **Publish:** Commit+Push leftover-commits then `git push --force-with-lease` with a short-lived installation token. Create PR is that push plus `pulls.create` (or reuse an open PR). Merged/closed returns chrome to Create PR on the same `/1` branch.
- **UI:** Pierre Save / ⌘S / 10s autosave and tree mutations write the sandbox. Diff tab (`?pane=diff`) vs the default tip. Branch chrome after prepare; GitHub tree link after first push. Codesearch Files stay the compose / prepare fallback and are not writable. Open tool-calls refetch the path with a dirty-buffer “agent updated” guard.

## Docs

ADR-026 persist path, ticket 14, and the git-backed-projects map now describe sandbox + brokered push instead of `ui_file_edit` / “file-edit later.”

## Tests

- Backend: write-status, policy, lifecycle, conversation-files, conversation-publish, conversations PR/push routes, turn runtime.
- UI: pane `diff`, publish helpers, chrome states, tool-path live updates, existing chat session tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0783ef33-874d-4724-bf09-4d5c82847ef2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0783ef33-874d-4724-bf09-4d5c82847ef2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

