### PR TITLE
Skip SCIP langs on Zoekt memory-fit in legacy POST /index

### DIFF
--- a/apps/codesearch/AGENTS.md
+++ b/apps/codesearch/AGENTS.md
@@ -31,7 +31,7 @@ These instructions supplement the repository-root `AGENTS.md`.
 - Look for `codesearch.index.phase.*` / `codesearch.index.queue.*` in codesearch logs and `repository-index.*` / `repository-ingestion.step.*` on the worker.
 - OpenWorkflow step failures are logged to evlog as `repository-ingestion.step.<name>.attempt_failed` (and orchestrator `…child-failed`) — do not rely on the OpenWorkflow dashboard.
 - Langfuse / LLM work starts at durable extract steps (`identify-roots`, `extract-kind:*`, `identify:*`) after retract (UI badge **`analyzing`** and later).
-- **Zoekt and SCIP optional:** the OW path continues extract after Zoekt and/or SCIP failure (`searchIndexOk: false` and/or `scipIndexOk: false` → `complete_with_issues`). Lexical search and/or graph tools may be empty; checkout and ast-grep still work. Clone failure remains fail-closed. Per-language SCIP failures merge surviving shards. Zoekt memory-fit failure skips SCIP langs to protect extract.
+- **Zoekt and SCIP optional:** the OW path continues extract after Zoekt and/or SCIP failure (`searchIndexOk: false` and/or `scipIndexOk: false` → `complete_with_issues`). Lexical search and/or graph tools may be empty; checkout and ast-grep still work. Clone failure remains fail-closed. Per-language SCIP failures merge surviving shards. Zoekt memory-fit failure skips SCIP langs (OW and legacy `POST /index`) to protect extract.
 
 ## Testing
 

--- a/apps/codesearch/src/domain/indexing/service.composer.test.ts
+++ b/apps/codesearch/src/domain/indexing/service.composer.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { Db } from "../../db/client.js"
+import { CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY } from "./memoryFitError.js"
+
+const phaseCloneCheckoutMock = vi.hoisted(() => vi.fn())
+const phaseZoektMock = vi.hoisted(() => vi.fn())
+const phaseDetectLanguagesMock = vi.hoisted(() => vi.fn())
+const phaseScipLanguageMock = vi.hoisted(() => vi.fn())
+const phaseMergeScipMock = vi.hoisted(() => vi.fn())
+const phaseMarkCheckoutIndexedMock = vi.hoisted(() => vi.fn())
+
+vi.mock("./phases.js", async () => {
+  const actual = await vi.importActual<typeof import("./phases.js")>(
+    "./phases.js",
+  )
+  return {
+    ...actual,
+    phaseCloneCheckout: phaseCloneCheckoutMock,
+    phaseZoekt: phaseZoektMock,
+    phaseDetectLanguages: phaseDetectLanguagesMock,
+    phaseScipLanguage: phaseScipLanguageMock,
+    phaseMergeScip: phaseMergeScipMock,
+    phaseMarkCheckoutIndexed: phaseMarkCheckoutIndexedMock,
+  }
+})
+
+vi.mock("../../observability/logger.js", () => ({
+  log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}))
+
+import { cloneAndIndexRepository } from "./service.js"
+
+const input = {
+  db: {} as Db,
+  orgId: "org_1",
+  repoId: "repo_1",
+  repoGitUrl: "https://github.com/acme/web.git",
+  clonePath: "/tmp/clone",
+  scipIndexPath: "/tmp/index.scip",
+  zoektRepoId: 1,
+  repoName: "acme/web",
+  repoUrl: "https://github.com/acme/web.git",
+}
+
+describe("cloneAndIndexRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    phaseCloneCheckoutMock.mockResolvedValue({
+      targetHash: "abc",
+      ingestMode: "full",
+      changedPaths: [],
+      deletedPaths: [],
+      renames: [],
+    })
+    phaseZoektMock.mockResolvedValue(undefined)
+    phaseDetectLanguagesMock.mockResolvedValue({
+      detectedLanguages: ["go", "typescript"],
+      languagesToIndex: ["go", "typescript"],
+    })
+    phaseScipLanguageMock.mockResolvedValue(undefined)
+    phaseMergeScipMock.mockResolvedValue({ shardCount: 2 })
+    phaseMarkCheckoutIndexedMock.mockResolvedValue(undefined)
+  })
+
+  it("skips SCIP langs after a Zoekt memory-fit failure and merges []", async () => {
+    phaseZoektMock.mockRejectedValue(
+      new Error("Command failed with exit code 137"),
+    )
+
+    const result = await cloneAndIndexRepository(input)
+
+    expect(phaseDetectLanguagesMock).toHaveBeenCalledOnce()
+    expect(phaseScipLanguageMock).not.toHaveBeenCalled()
+    expect(phaseMergeScipMock).toHaveBeenCalledOnce()
+    expect(phaseMergeScipMock).toHaveBeenCalledWith(
+      expect.objectContaining({ repoId: "repo_1" }),
+      {
+        detectedLanguages: ["go", "typescript"],
+        languagesToMerge: [],
+      },
+    )
+    expect(phaseMarkCheckoutIndexedMock).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({ targetHash: "abc", ingestMode: "full" })
+  })
+
+  it("skips SCIP langs when Zoekt throws the canonical memory-fit message", async () => {
+    phaseZoektMock.mockRejectedValue(
+      new Error(CODEBASE_DIDNT_FIT_AVAILABLE_MEMORY),
+    )
+
+    await cloneAndIndexRepository(input)
+
+    expect(phaseScipLanguageMock).not.toHaveBeenCalled()
+    expect(phaseMergeScipMock).toHaveBeenCalledWith(expect.anything(), {
+      detectedLanguages: ["go", "typescript"],
+      languagesToMerge: [],
+    })
+  })
+
+  it("still runs SCIP langs after a non-memory-fit Zoekt failure", async () => {
+    phaseZoektMock.mockRejectedValue(new Error("zoekt crashed"))
+
+    await cloneAndIndexRepository(input)
+
+    expect(phaseScipLanguageMock).toHaveBeenCalledTimes(2)
+    expect(phaseMergeScipMock).toHaveBeenCalledWith(
+      expect.objectContaining({ repoId: "repo_1" }),
+      { detectedLanguages: ["go", "typescript"] },
+    )
+  })
+})

--- a/apps/codesearch/src/domain/indexing/service.composer.test.ts
+++ b/apps/codesearch/src/domain/indexing/service.composer.test.ts
@@ -10,9 +10,8 @@ const phaseMergeScipMock = vi.hoisted(() => vi.fn())
 const phaseMarkCheckoutIndexedMock = vi.hoisted(() => vi.fn())
 
 vi.mock("./phases.js", async () => {
-  const actual = await vi.importActual<typeof import("./phases.js")>(
-    "./phases.js",
-  )
+  const actual =
+    await vi.importActual<typeof import("./phases.js")>("./phases.js")
   return {
     ...actual,
     phaseCloneCheckout: phaseCloneCheckoutMock,

--- a/apps/codesearch/src/domain/indexing/service.test.ts
+++ b/apps/codesearch/src/domain/indexing/service.test.ts
@@ -12,6 +12,21 @@ import {
 } from "./service.js"
 
 describe("runOptionalIndexPhase", () => {
+  it("returns ok:false so callers can skip later optional work", async () => {
+    const result = await runOptionalIndexPhase(
+      "codesearch.index.zoekt.failed",
+      async () => {
+        throw new Error("Command failed with exit code 137")
+      },
+    )
+    expect(result).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        message: "Command failed with exit code 137",
+      }),
+    })
+  })
+
   it("runs Zoekt before SCIP (sequential) and continues after both failures", async () => {
     const order: string[] = []
     let scipStartedBeforeZoektFinished = false

--- a/apps/codesearch/src/domain/indexing/service.ts
+++ b/apps/codesearch/src/domain/indexing/service.ts
@@ -124,8 +124,7 @@ async function cloneAndIndexRepositoryInner(
     "codesearch.index.zoekt.failed",
     () => phaseZoekt(ctx),
   )
-  const skipScipAfterZoektMemory =
-    !zoekt.ok && isMemoryFitFailure(zoekt.error)
+  const skipScipAfterZoektMemory = !zoekt.ok && isMemoryFitFailure(zoekt.error)
 
   const detectResult = await phaseDetectLanguages(ctx, {
     ingestMode: checkout.ingestMode,
@@ -156,12 +155,15 @@ async function cloneAndIndexRepositoryInner(
       ),
     ),
   )
-  await runOptionalIndexPhase("codesearch.index.scip.merge.failed", async () => {
-    await phaseMergeScip(ctx, {
-      detectedLanguages,
-      ...(skipScipAfterZoektMemory ? { languagesToMerge: [] } : {}),
-    })
-  })
+  await runOptionalIndexPhase(
+    "codesearch.index.scip.merge.failed",
+    async () => {
+      await phaseMergeScip(ctx, {
+        detectedLanguages,
+        ...(skipScipAfterZoektMemory ? { languagesToMerge: [] } : {}),
+      })
+    },
+  )
 
   await phaseMarkCheckoutIndexed(ctx)
 

--- a/apps/codesearch/src/domain/indexing/service.ts
+++ b/apps/codesearch/src/domain/indexing/service.ts
@@ -6,6 +6,7 @@ import {
   withIndexConcurrency,
   withRepositoryIndexOperation,
 } from "./indexConcurrency.js"
+import { isMemoryFitFailure } from "./memoryFitError.js"
 import {
   discardScipShardFiles,
   type IndexPhaseRepoContext,
@@ -46,24 +47,31 @@ type IndexInput = {
 
 export { discardScipShardFiles, publishMergedScipIndex, writeMergedScipIndex }
 
+export type OptionalIndexPhaseResult =
+  | { ok: true }
+  | { ok: false; error: unknown }
+
 /**
  * Run an optional index phase. Failures are warnings so non-OW callers get
  * the same degradation as OpenWorkflow. Clone/detect stay fail-closed at
- * their call sites.
+ * their call sites. Callers inspect the result when a failure changes
+ * later steps (Zoekt memory-fit skips SCIP langs).
  */
 export async function runOptionalIndexPhase(
   step: string,
   fn: () => Promise<void>,
   extra?: Record<string, string>,
-): Promise<void> {
+): Promise<OptionalIndexPhaseResult> {
   try {
     await fn()
+    return { ok: true }
   } catch (reason) {
     log.warn({
       step,
       ...extra,
       error: reason instanceof Error ? reason.message : String(reason),
     })
+    return { ok: false, error: reason }
   }
 }
 
@@ -89,6 +97,7 @@ function toPhaseContext(input: IndexInput): IndexPhaseRepoContext {
 /**
  * Legacy monolithic `POST /:repoId/index` composer.
  * Zoekt and SCIP indexer failures degrade; clone/detect stay fail-closed.
+ * Zoekt memory-fit skips SCIP langs and merges `[]`, matching OpenWorkflow.
  * Durable ingestion uses OpenWorkflow phase endpoints instead.
  */
 export async function cloneAndIndexRepository(
@@ -111,9 +120,12 @@ async function cloneAndIndexRepositoryInner(
     fromHash: input.fromHash,
   })
 
-  await runOptionalIndexPhase("codesearch.index.zoekt.failed", () =>
-    phaseZoekt(ctx),
+  const zoekt = await runOptionalIndexPhase(
+    "codesearch.index.zoekt.failed",
+    () => phaseZoekt(ctx),
   )
+  const skipScipAfterZoektMemory =
+    !zoekt.ok && isMemoryFitFailure(zoekt.error)
 
   const detectResult = await phaseDetectLanguages(ctx, {
     ingestMode: checkout.ingestMode,
@@ -122,8 +134,17 @@ async function cloneAndIndexRepositoryInner(
     renames: checkout.renames,
   })
   const detectedLanguages = detectResult.detectedLanguages
+  const languagesToIndex = skipScipAfterZoektMemory
+    ? []
+    : detectResult.languagesToIndex
+  if (skipScipAfterZoektMemory) {
+    log.warn({
+      step: "codesearch.index.scip.skipped",
+      reason: "zoekt_memory_fit",
+    })
+  }
   await Promise.all(
-    detectResult.languagesToIndex.map((language) =>
+    languagesToIndex.map((language) =>
       runOptionalIndexPhase(
         "codesearch.index.scip.lang.failed",
         () =>
@@ -135,14 +156,12 @@ async function cloneAndIndexRepositoryInner(
       ),
     ),
   )
-  await runOptionalIndexPhase(
-    "codesearch.index.scip.merge.failed",
-    async () => {
-      await phaseMergeScip(ctx, {
-        detectedLanguages,
-      })
-    },
-  )
+  await runOptionalIndexPhase("codesearch.index.scip.merge.failed", async () => {
+    await phaseMergeScip(ctx, {
+      detectedLanguages,
+      ...(skipScipAfterZoektMemory ? { languagesToMerge: [] } : {}),
+    })
+  })
 
   await phaseMarkCheckoutIndexed(ctx)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #290. The spec is “Zoekt memory-fit failure skips SCIP langs.” OpenWorkflow already skips language indexers and merges `[]`. The legacy `POST /:repoId/index` composer swallowed every Zoekt error, then detected languages and ran all SCIP indexers.

- `runOptionalIndexPhase` now returns `{ ok: false, error }` so the composer can inspect Zoekt failures.
- Memory-fit Zoekt failure skips SCIP langs, logs `codesearch.index.scip.skipped`, and calls `phaseMergeScip` with `languagesToMerge: []` (discards leftover shards, same as OW).
- Non-memory-fit Zoekt failures still run SCIP langs.
- Composer tests cover skip vs continue; the helper test covers the returned failure result.

## Testing

Composer + service unit tests: 14 passed.

```
pnpm --filter @ctxpipe/codesearch exec vitest run src/domain/indexing/service.composer.test.ts src/domain/indexing/service.test.ts
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-471a4233-a5de-4435-9d7c-0fc815847f2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-471a4233-a5de-4435-9d7c-0fc815847f2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

