### PR TITLE
Unblock production Forge deploy after attachment scope bump

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -246,20 +246,22 @@ jobs:
           FORGE_DISABLE_ANALYTICS: "1"
         run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run prepare-forge-cli
 
-      - name: Forge lint
-        env:
-          FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
-          FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
-          FORGE_DISABLE_ANALYTICS: "1"
-          REMOTE_BASE_URL: https://app.ctxpipe.ai/
-        run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run lint:forge
-
+      # deploy:prod already runs `forge lint` and passes `--approve MAJOR_VERSION_RULE`.
+      # A standalone `forge lint -e production` exits 1 on that approval; @forge/cli 13.4
+      # has `--approve` on deploy only, not lint.
       - name: Deploy to Forge production
         env:
           FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
           FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
           FORGE_DISABLE_ANALYTICS: "1"
         run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run deploy:prod
+
+      - name: Upgrade hosted Confluence install
+        env:
+          FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
+          FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
+          FORGE_DISABLE_ANALYTICS: "1"
+        run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run install:prod
 
   prerelease:
     name: Prerelease

--- a/apps/forge-ctxpipe-agent/README.md
+++ b/apps/forge-ctxpipe-agent/README.md
@@ -1,6 +1,6 @@
 # Atlassian ctxpipe Forge app
 
-This directory is a **reference** `manifest.yml` (and `package.json` for Forge tooling) for operators and **CI** (`forge lint` / `forge deploy` in [`.github/workflows/deploy.yaml`](../../.github/workflows/deploy.yaml)). The **product’s provision worker** does not copy this tree: it **generates** `manifest.yml` in a temp workdir (see `apps/backend/src/lib/forge-app-manifest.ts`) with the public API origin **baked into** `remotes.baseUrl`, then runs `forge register` (if needed) → `forge deploy` → `forge install`.
+This directory is a **reference** `manifest.yml` (and `package.json` for Forge tooling) for operators and **CI** (`forge deploy` / `forge install --upgrade` in [`.github/workflows/deploy.yaml`](../../.github/workflows/deploy.yaml)). The **product’s provision worker** does not copy this tree: it **generates** `manifest.yml` in a temp workdir (see `apps/backend/src/lib/forge-app-manifest.ts`) with the public API origin **baked into** `remotes.baseUrl`, then runs `forge register` (if needed) → `forge deploy` → `forge install`.
 
 Atlassian Forge lets ctx| integrate with Confluence via [Forge Remote](https://developer.atlassian.com/platform/forge/remote/). Events and scheduled work are forwarded to your ctx| deployment; business logic stays in the product.
 

--- a/apps/forge-ctxpipe-agent/package.json
+++ b/apps/forge-ctxpipe-agent/package.json
@@ -17,6 +17,7 @@
     "deploy:dev": "REMOTE_BASE_URL=https://flourless-kenisha-overcheaply.ngrok-free.dev forge deploy --environment development",
     "install:dev": "REMOTE_BASE_URL=https://flourless-kenisha-overcheaply.ngrok-free.dev forge install -e development -s ctxpipe.atlassian.net -p Confluence --non-interactive --confirm-scopes",
     "install:upgrade": "REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge install --upgrade",
+    "install:prod": "REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge install --upgrade --non-interactive --confirm-scopes -e production -s ctxpipe.atlassian.net -p Confluence",
     "deploy:prod": "pnpm run prepare-forge-cli && REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge deploy --environment production --non-interactive --approve MAJOR_VERSION_RULE",
     "deploy:pr": "forge deploy --environment \"$FORGE_PR_ENV\" --non-interactive --approve MAJOR_VERSION_RULE",
     "install:pr": "forge install --non-interactive --upgrade --confirm-scopes -e \"$FORGE_PR_ENV\" -s ctxpipe.atlassian.net -p Confluence",


### PR DESCRIPTION
## Summary
- Production Forge deploy failed at `forge lint -e production` because Atlassian treats `read:attachment:confluence` as a major version. `@forge/cli` 13.4 exits 1 on that approval; `--approve` exists on `forge deploy` only, not lint.
- Remove the redundant lint gate. `deploy:prod` already runs lint and passes `--approve MAJOR_VERSION_RULE`.
- After deploy, `forge install --upgrade --confirm-scopes` on `ctxpipe.atlassian.net` so the hosted site actually receives the new scope.

## Test plan
- [ ] Merge to `main` and confirm **Deploy / Deploy Forge app (production)** reaches `deploy:prod` (not lint)
- [ ] Confirm deploy acknowledges `MAJOR_VERSION_RULE`
- [ ] Confirm install upgrade grants `read:attachment:confluence` on `ctxpipe.atlassian.net`
- [ ] Customer / other Confluence sites still need their own admin upgrade in Manage apps