### PR TITLE
Consolidate Forge production validation

### DIFF
--- a/.changeset/forge-production-validation.md
+++ b/.changeset/forge-production-validation.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Make Forge production deployment use its built-in pre-deployment lint so scope-driven major versions cannot be blocked by a divergent standalone check.

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -239,20 +239,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Prepare Forge CLI for CI
-        env:
-          FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
-          FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
-          FORGE_DISABLE_ANALYTICS: "1"
-        run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run prepare-forge-cli
-
-      # deploy:prod already runs `forge lint` and passes `--approve MAJOR_VERSION_RULE`.
-      # A standalone `forge lint -e production` exits 1 on that approval; @forge/cli 13.4
-      # has `--approve` on deploy only, not lint.
-      # Do not `forge install --upgrade` here: production is not CLI-installed on
-      # ctxpipe.atlassian.net (that host is development / PR environments).
-      # Site admins accept major-version scope upgrades in Manage apps.
-      - name: Deploy to Forge production
+      # `forge deploy` runs pre-deployment lint and is the command that accepts
+      # MAJOR_VERSION_RULE approvals for scope changes. The package script also
+      # configures the CLI for non-interactive use.
+      - name: Validate and deploy Forge production
         env:
           FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
           FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -249,19 +249,15 @@ jobs:
       # deploy:prod already runs `forge lint` and passes `--approve MAJOR_VERSION_RULE`.
       # A standalone `forge lint -e production` exits 1 on that approval; @forge/cli 13.4
       # has `--approve` on deploy only, not lint.
+      # Do not `forge install --upgrade` here: production is not CLI-installed on
+      # ctxpipe.atlassian.net (that host is development / PR environments).
+      # Site admins accept major-version scope upgrades in Manage apps.
       - name: Deploy to Forge production
         env:
           FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
           FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
           FORGE_DISABLE_ANALYTICS: "1"
         run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run deploy:prod
-
-      - name: Upgrade hosted Confluence install
-        env:
-          FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
-          FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
-          FORGE_DISABLE_ANALYTICS: "1"
-        run: pnpm --filter @ctxpipe/forge-ctxpipe-agent run install:prod
 
   prerelease:
     name: Prerelease

--- a/apps/forge-ctxpipe-agent/README.md
+++ b/apps/forge-ctxpipe-agent/README.md
@@ -1,6 +1,6 @@
 # Atlassian ctxpipe Forge app
 
-This directory is a **reference** `manifest.yml` (and `package.json` for Forge tooling) for operators and **CI** (`forge deploy` / `forge install --upgrade` in [`.github/workflows/deploy.yaml`](../../.github/workflows/deploy.yaml)). The **product’s provision worker** does not copy this tree: it **generates** `manifest.yml` in a temp workdir (see `apps/backend/src/lib/forge-app-manifest.ts`) with the public API origin **baked into** `remotes.baseUrl`, then runs `forge register` (if needed) → `forge deploy` → `forge install`.
+This directory is a **reference** `manifest.yml` (and `package.json` for Forge tooling) for operators and **CI** (`forge deploy`, including its pre-deployment lint, in [`.github/workflows/deploy.yaml`](../../.github/workflows/deploy.yaml)). The **product’s provision worker** does not copy this tree: it **generates** `manifest.yml` in a temp workdir (see `apps/backend/src/lib/forge-app-manifest.ts`) with the public API origin **baked into** `remotes.baseUrl`, then runs `forge register` (if needed) → `forge deploy` → `forge install`.
 
 Atlassian Forge lets ctx| integrate with Confluence via [Forge Remote](https://developer.atlassian.com/platform/forge/remote/). Events and scheduled work are forwarded to your ctx| deployment; business logic stays in the product.
 

--- a/apps/forge-ctxpipe-agent/package.json
+++ b/apps/forge-ctxpipe-agent/package.json
@@ -9,14 +9,13 @@
   },
   "scripts": {
     "lint": "eslint src/**/*",
-    "prepare-forge-cli": "forge settings set usage-analytics false",
     "dev": "pnpm run ngrok:tunnel",
     "dev:forge": "concurrently -n ngrok,forge \"pnpm run ngrok:tunnel\" \"forge tunnel\"",
     "ngrok:tunnel": "bash ./scripts/ngrok-tunnel.sh",
     "deploy:dev": "REMOTE_BASE_URL=https://flourless-kenisha-overcheaply.ngrok-free.dev forge deploy --environment development",
     "install:dev": "REMOTE_BASE_URL=https://flourless-kenisha-overcheaply.ngrok-free.dev forge install -e development -s ctxpipe.atlassian.net -p Confluence --non-interactive --confirm-scopes",
     "install:upgrade": "REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge install --upgrade",
-    "deploy:prod": "pnpm run prepare-forge-cli && REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge deploy --environment production --non-interactive --approve MAJOR_VERSION_RULE",
+    "deploy:prod": "forge settings set usage-analytics false && REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge deploy --environment production --non-interactive --approve MAJOR_VERSION_RULE",
     "deploy:pr": "forge deploy --environment \"$FORGE_PR_ENV\" --non-interactive --approve MAJOR_VERSION_RULE",
     "install:pr": "forge install --non-interactive --upgrade --confirm-scopes -e \"$FORGE_PR_ENV\" -s ctxpipe.atlassian.net -p Confluence",
     "install:pr:first": "forge install --non-interactive --confirm-scopes -e \"$FORGE_PR_ENV\" -s ctxpipe.atlassian.net -p Confluence"

--- a/apps/forge-ctxpipe-agent/package.json
+++ b/apps/forge-ctxpipe-agent/package.json
@@ -17,7 +17,6 @@
     "deploy:dev": "REMOTE_BASE_URL=https://flourless-kenisha-overcheaply.ngrok-free.dev forge deploy --environment development",
     "install:dev": "REMOTE_BASE_URL=https://flourless-kenisha-overcheaply.ngrok-free.dev forge install -e development -s ctxpipe.atlassian.net -p Confluence --non-interactive --confirm-scopes",
     "install:upgrade": "REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge install --upgrade",
-    "install:prod": "REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge install --upgrade --non-interactive --confirm-scopes -e production -s ctxpipe.atlassian.net -p Confluence",
     "deploy:prod": "pnpm run prepare-forge-cli && REMOTE_BASE_URL=https://app.ctxpipe.ai/ forge deploy --environment production --non-interactive --approve MAJOR_VERSION_RULE",
     "deploy:pr": "forge deploy --environment \"$FORGE_PR_ENV\" --non-interactive --approve MAJOR_VERSION_RULE",
     "install:pr": "forge install --non-interactive --upgrade --confirm-scopes -e \"$FORGE_PR_ENV\" -s ctxpipe.atlassian.net -p Confluence",

--- a/apps/forge-ctxpipe-agent/package.json
+++ b/apps/forge-ctxpipe-agent/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "lint": "eslint src/**/*",
     "prepare-forge-cli": "forge settings set usage-analytics false",
-    "lint:forge": "forge lint --environment production",
     "dev": "pnpm run ngrok:tunnel",
     "dev:forge": "concurrently -n ngrok,forge \"pnpm run ngrok:tunnel\" \"forge tunnel\"",
     "ngrok:tunnel": "bash ./scripts/ngrok-tunnel.sh",


### PR DESCRIPTION
## Summary
- The attachment scope correctly triggered Atlassian's `MAJOR_VERSION_RULE`. The regression was a duplicated CI path: standalone `forge lint` ran before `forge deploy`, but only deploy carried the required approval.
- Use `forge deploy` as the single production boundary. Forge runs its normal pre-deployment lint first; `--approve MAJOR_VERSION_RULE` acknowledges only the expected major-version transition and does not bypass other lint failures.
- Remove the invalid site-install side effect and the dead scripts it introduced. Existing Confluence installations remain subject to Atlassian's normal per-site administrator upgrade and consent flow.

## Verification
- Production run [33581178260](https://github.com/ctxpipe-ai/ctxpipe/actions/runs/33581178260) proved the retained command: Forge lint passed and app version `13.0.0` deployed with one approval acknowledged. The later guessed-site install was the only failed step and is removed here.
- `pnpm --filter @ctxpipe/backend exec vitest run src/lib/forge-app-manifest.test.ts` — 8 passed
- Pinned Forge CLI 13.4.0 exposes `deploy --approve <rule...>`
- `pnpm changeset status --since=origin/main` — passes
- Workflow YAML parses; `git diff --check` passes
- Three-axis review: Standards 0 findings; Spec 0 implementation findings; Simplicity 0 remaining findings

## Rollout
- Merge only after required checks pass.
- Confirm the next `Deploy / Deploy Forge app (production)` run is green at `Validate and deploy Forge production`.
- Site administrators accept the new attachment scope separately; CI does not guess customer installation sites.