### PR TITLE
Write MCP API-key env references with --api-key-env-variable

### DIFF
--- a/.changeset/mcp-api-key-auth.md
+++ b/.changeset/mcp-api-key-auth.md
@@ -3,4 +3,4 @@
 "@ctxpipe/aws-cdk": patch
 ---
 
-Add user-scope API-key MCP auth as an alternative to OAuth, and raise dashboard API-key rate limits so MCP is usable.
+Add API-key MCP auth as an OAuth alternative: paste a key into user-level client config, or write an environment-variable reference in repo or user config. Raise dashboard API-key rate limits so MCP is usable.

--- a/apps/docs/content/docs/(guide)/git-repositories/install-mcps-via-pr.mdx
+++ b/apps/docs/content/docs/(guide)/git-repositories/install-mcps-via-pr.mdx
@@ -113,10 +113,11 @@ OpenCode uses `mcp`:
 }
 ```
 
-Do not add API keys to repository config. The PR workflow is designed for MCP
+Do not add raw API keys to repository config. The PR workflow is designed for MCP
 clients that can complete OAuth authorization after the config is merged. For a
-machine that cannot complete OAuth, configure API-key auth in user-level client
-config instead. See [API-key auth](/docs/mcp/mcp-docs#api-key-auth-user-level).
+machine that cannot complete OAuth, paste a key into user-level client config or
+write an environment-variable reference with `--api-key-env-variable`. See
+[API-key auth](/docs/mcp/mcp-docs#api-key-auth-user-level).
 
 ## Merge Behavior
 

--- a/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
+++ b/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
@@ -43,7 +43,7 @@ There are four practical ways to install ctx| MCP:
 - **Raise pull requests** - best for enabling a team by committing MCP config files into shared repositories.
 - **Manual config** - useful when you need to paste JSON yourself or use a client the CLI does not fully automate.
 
-The CLI and PR flow both write configuration. They do **not** remove the need for MCP authorization. When a client first uses ctx| MCP, it should still redirect you to ctx| so you can sign in and authorize access. If the client cannot complete OAuth, use [API-key auth](#api-key-auth-user-level) in user-level config instead.
+The CLI and PR flow both write configuration. They do **not** remove the need for MCP authorization. When a client first uses ctx| MCP, it should still redirect you to ctx| so you can sign in and authorize access. If the client cannot complete OAuth, use [API-key auth](#api-key-auth-user-level).
 
 ## CLI installer (`npx ctxpipe`)
 
@@ -85,7 +85,7 @@ npx ctxpipe mcp add --org acme --client opencode --scope user --non-interactive
 npx ctxpipe doctor --json
 ```
 
-Use `npx ctxpipe init --help` and `npx ctxpipe mcp add --help` for the full flag list, including `--base-url`, `--org`, `--scope`, `--agents`, `--client`, `--auth`, `--api-key`, `--non-interactive`, `--json`, and `--dry-run`.
+Use `npx ctxpipe init --help` and `npx ctxpipe mcp add --help` for the full flag list, including `--base-url`, `--org`, `--scope`, `--agents`, `--client`, `--auth`, `--api-key`, `--api-key-env-variable`, `--non-interactive`, `--json`, and `--dry-run`.
 
 Setup sign-in is separate from MCP authorization. The CLI signs you in so it can list organizations and write correct config. It stores setup credentials in the OS keychain when available, with a file fallback under `~/.config/ctxpipe/` when keyring access is not possible.
 
@@ -119,19 +119,23 @@ Read the full guide: [Local memory](/docs/mcp/local-memory).
 
 ## API-key auth (user-level)
 
-OAuth is the default. Use an API key only when a client cannot complete the browser OAuth flow. Keys authenticate MCP with the `x-api-key` header and belong in **user-level** client config only. Never put a key (or a headers block) in a repository file, onboarding paste, or an Install MCP via PRs change.
+OAuth is the default. Use an API key only when a client cannot complete the browser OAuth flow. Keys authenticate MCP with the `x-api-key` header. The CLI never mints keys; create one in the product under **User account → API Keys**. New keys inherit a 30-day default expiry and a plugin limit of 1,000 requests per hour. Recreate a key after it expires; existing keys keep the limit stored when they were minted.
 
-Create a key in the product under **User account → API Keys**. New keys inherit a 30-day default expiry and a plugin limit of 1,000 requests per hour. Recreate a key after it expires; existing keys keep the limit stored when they were minted.
+Choose how the CLI stores the key:
 
-The CLI never mints keys. Pass a key you already created:
+- **`--api-key <key>`** writes the raw secret into **user-level** client config only. `--scope repo` or `both` skips repository MCP writes. Never put the key value in a repository file, onboarding paste, or an Install MCP via PRs change.
+- **`--api-key-env-variable <name>`** writes a **name**, not the secret. That reference is safe in repo or user config (`--scope repo`, `user`, or `both`). Set the variable in the MCP **client process** environment before connecting. GUI apps often do not inherit variables from your interactive shell.
 
 ```bash
-npx ctxpipe mcp add --org acme --client cursor --scope user --auth api-key --api-key "$CTXPIPE_API_KEY" --non-interactive
+npx ctxpipe mcp add --org acme --client cursor --scope user --api-key "$CTXPIPE_API_KEY" --non-interactive
+npx ctxpipe mcp add --org acme --client cursor --scope both --api-key-env-variable CTXPIPE_API_KEY --non-interactive
 ```
 
-`--auth api-key` requires `--api-key <key>` or `CTXPIPE_API_KEY`. `--scope repo` or `both` skips repository MCP writes and says so. The interactive wizard does not offer repo scope for API-key mode.
+`--auth api-key` still accepts `CTXPIPE_API_KEY` as a user-scope literal key. `--api-key` and `--api-key-env-variable` are mutually exclusive and imply `--auth api-key`.
 
-### Cursor (`~/.cursor/mcp.json`)
+### Cursor
+
+Raw key (user config only, `~/.cursor/mcp.json`):
 
 ```json
 {
@@ -147,15 +151,51 @@ npx ctxpipe mcp add --org acme --client cursor --scope user --auth api-key --api
 }
 ```
 
-### Claude Code (user scope)
+Environment-variable reference (repo `.cursor/mcp.json` or user config):
+
+```json
+{
+  "mcpServers": {
+    "ctxpipe": {
+      "type": "streamable-http",
+      "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org",
+      "headers": {
+        "x-api-key": "${env:CTXPIPE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+Raw key, user scope:
 
 ```bash
 claude mcp add --transport http ctxpipe --scope user --header "x-api-key: <your-api-key>" "https://app.ctxpipe.ai/mcp?orgSlug=your-org"
 ```
 
-Do not add that header to project `.mcp.json`.
+Environment-variable reference in project `.mcp.json` (or the same `${CTXPIPE_API_KEY}` form in a user header):
 
-### OpenCode (`~/.config/opencode/opencode.json`)
+```json
+{
+  "mcpServers": {
+    "ctxpipe": {
+      "type": "streamable-http",
+      "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org",
+      "headers": {
+        "x-api-key": "${CTXPIPE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Do not put the raw key in project `.mcp.json`.
+
+### OpenCode
+
+Raw key (user config only, `~/.config/opencode/opencode.json`):
 
 ```json
 {
@@ -173,18 +213,60 @@ Do not add that header to project `.mcp.json`.
 }
 ```
 
+Environment-variable reference (`opencode.json` in the repo, or the user file):
+
+```json
+{
+  "mcp": {
+    "ctxpipe": {
+      "type": "remote",
+      "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org",
+      "enabled": true,
+      "headers": {
+        "x-api-key": "{env:CTXPIPE_API_KEY}"
+      },
+      "oauth": false
+    }
+  }
+}
+```
+
 `oauth: false` stops OpenCode from starting a browser flow after a 401.
 
 ### VS Code / Copilot
 
-Include `headers` in the user-scope `vscode:mcp/install` payload. Repo `.vscode/mcp.json` stays URL-only.
+Raw keys belong in the user-scope `vscode:mcp/install` payload, not in the repo. For an environment variable, repo `.vscode/mcp.json` can include:
+
+```json
+{
+  "servers": {
+    "ctxpipe": {
+      "type": "http",
+      "url": "https://app.ctxpipe.ai/mcp?orgSlug=your-org",
+      "headers": {
+        "x-api-key": "${env:CTXPIPE_API_KEY}"
+      }
+    }
+  }
+}
+```
 
 ### Codex (`~/.codex/config.toml`)
+
+Raw key (user config only):
 
 ```toml
 [mcp_servers.ctxpipe]
 url = "https://app.ctxpipe.ai/mcp?orgSlug=your-org"
 http_headers = { "x-api-key" = "<your-api-key>" }
+```
+
+Environment-variable reference. Codex wants the **variable name**, not `$VAR` or the secret:
+
+```toml
+[mcp_servers.ctxpipe]
+url = "https://app.ctxpipe.ai/mcp?orgSlug=your-org"
+env_http_headers = { "x-api-key" = "CTXPIPE_API_KEY" }
 ```
 
 ## Team Setup Via Pull Requests
@@ -225,7 +307,7 @@ Manual config is the fallback when you do not want to use the CLI, the client is
 Your MCP client should redirect you to ctx| to sign in and authorize access.
 After approval, it returns to the client and the server is ready to use.
 
-No bearer token setup is required when your client supports OAuth redirect for MCP. If it cannot complete OAuth, use [API-key auth](#api-key-auth-user-level) in user-level config.
+No bearer token setup is required when your client supports OAuth redirect for MCP. If it cannot complete OAuth, use [API-key auth](#api-key-auth-user-level).
 
 ## Client-Specific Configuration
 
@@ -317,14 +399,14 @@ If your client's docs only mention `http` or SSE, check the current client docum
 - **OpenCode shows the server but it never connects** - use the top-level `mcp.ctxpipe` shape with `type: "remote"` and `enabled: true`.
 - **`streamable-http` is not recognized** - upgrade the client, or check whether that client expects `http` for its config key while still using a Streamable HTTP remote server.
 - **Team PR flow is unavailable** - confirm GitHub is connected, the repositories are visible to the GitHub App installation, and your ctx| account is an organization admin or owner.
-- **Your client cannot complete OAuth** - use [API-key auth](#api-key-auth-user-level) in user-level client config. Do not put keys in repository files.
+- **Your client cannot complete OAuth** - use [API-key auth](#api-key-auth-user-level). Do not put raw keys in repository files; use `--api-key-env-variable` when the placeholder should live in repo config.
 
 ## Notes
 
 - `orgSlug` is optional for OAuth grants that were bound to an organization
   during authorization. Replace `your-org` with your organization slug when
   configuring a legacy or manual connection explicitly.
-- Do not commit secrets into repository MCP config.
+- Do not commit secrets into repository MCP config. Environment-variable references are safe to commit; the secret stays in the client process environment.
 - For team-wide repo config, prefer [Install MCPs via PR](/docs/git-repositories/install-mcps-via-pr) over asking every developer to copy JSON by hand.
 
 ## Related

--- a/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
+++ b/apps/docs/content/docs/(guide)/mcp/mcp-docs.mdx
@@ -95,7 +95,7 @@ Supported CLI clients:
 - **Claude Code** - repo config in `.mcp.json`; user setup uses `claude mcp add` when the Claude CLI is available.
 - **OpenCode** - repo config in `opencode.json`, user config in `~/.config/opencode/opencode.json`.
 - **VS Code / Copilot** - repo config in `.vscode/mcp.json`; user setup provides the VS Code install link.
-- **Codex** - user setup uses `codex mcp add` when available; otherwise the CLI prints the command to run.
+- **Codex** - repo config in `.codex/config.toml`, user config in `~/.codex/config.toml`. Without an API-key header, user setup uses `codex mcp add` when available; otherwise the CLI prints the command to run.
 
 ## Local memory (Markdown)
 
@@ -251,7 +251,9 @@ Raw keys belong in the user-scope `vscode:mcp/install` payload, not in the repo.
 }
 ```
 
-### Codex (`~/.codex/config.toml`)
+### Codex (`.codex/config.toml` and `~/.codex/config.toml`)
+
+Codex loads MCP servers from both files in trusted projects: project `.codex/config.toml` overrides user `~/.codex/config.toml`. Env-variable references are safe in either file. Raw keys belong in user config only.
 
 Raw key (user config only):
 

--- a/apps/docs/content/docs/self-hosting/(configuration)/authentication.mdx
+++ b/apps/docs/content/docs/self-hosting/(configuration)/authentication.mdx
@@ -75,8 +75,9 @@ Configure the client with:
 
 The user completes OAuth against this deployment and must be a member of the
 requested organization. OAuth is the normal MCP flow. Dashboard API keys are an
-optional header-based alternative for **user-level** client config (`x-api-key`);
-do not put keys in repository MCP files. See [Remote MCP](/docs/mcp/mcp-docs)
+optional header-based alternative (`x-api-key`): paste a key into user-level
+client config, or point MCP config at an environment variable. Do not put the
+key value in repository MCP files. See [Remote MCP](/docs/mcp/mcp-docs)
 for the API-key CLI path, and [MCP diagnostics](/docs/self-hosting/mcp) when
 discovery or authorization fails.
 

--- a/apps/ui/src/routes/[.]auth.account.$accountView.tsx
+++ b/apps/ui/src/routes/[.]auth.account.$accountView.tsx
@@ -24,7 +24,7 @@ function AccountViewRoute() {
             LINK: "Link OAuth",
             UNLINK: "Unlink OAuth",
             API_KEYS_DESCRIPTION:
-              "Create keys to authenticate MCP from user-level client config with the x-api-key header. Keys expire in 30 days by default. Do not put keys in repository files.",
+              "Create keys to authenticate MCP with the x-api-key header. Paste a key into user-level client config, or point MCP config at an environment variable. Keys expire in 30 days by default. Do not put the key value in repository files.",
           }}
           classNames={betterAuthShellClassNames}
         />

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -10,7 +10,7 @@ npx ctxpipe init
 
 This opens an interactive wizard with repo/global setup scope selection, detected agent defaults, multi-select client setup, and a final change summary before anything is written.
 
-If no organization is supplied, the wizard signs you in with a browser/device-code flow, loads your ctx| organizations, and lets you choose one. MCP clients still perform their own OAuth later when they first use ctx|. Pass `--auth api-key` to write an `x-api-key` header to **user-level** client config instead (never repository files).
+If no organization is supplied, the wizard signs you in with a browser/device-code flow, loads your ctx| organizations, and lets you choose one. MCP clients still perform their own OAuth later when they first use ctx|. Pass `--api-key` to write a raw `x-api-key` header to **user-level** client config, or `--api-key-env-variable` to write an environment-variable reference in repo or user config.
 
 **Setup credentials:** the CLI stores setup-auth tokens in the **OS keychain** when available (`@napi-rs/keyring`). If the keychain cannot be used (headless Linux, unsupported environment), it falls back to a file under `~/.config/ctxpipe/` and prints a one-time notice to stderr.
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -13,7 +13,7 @@ import type { Client } from "./constants.js"
 import { CLIENT_COMMANDS, CLIENT_LABELS, CLIENTS } from "./constants.js"
 import type { ApplyOperationResult } from "./fs-operations.js"
 import { applyOperation, applyOperations } from "./fs-operations.js"
-import { resolveMcpAuth } from "./mcp/auth-mode.js"
+import { type McpAuthConfig, resolveMcpAuth } from "./mcp/auth-mode.js"
 import { diagnoseMcpEndpoint, formatMcpDoctorResult } from "./mcp/doctor.js"
 import {
   buildCtxpipeConfigOperation,
@@ -74,29 +74,10 @@ export type McpAddRunOpts = {
   apiKeyEnvVariable?: string
 }
 
-function resolveMcpInstallAuth(opts: {
-  auth: string | null
-  apiKey: string | null
-  apiKeyEnvVariable: string | null
-}): {
-  apiKey?: string
-  apiKeyEnvVariable?: string
-  summary: string
-} {
-  const auth = resolveMcpAuth(opts)
-  if (auth.mode === "oauth") {
-    return { summary: "OAuth" }
-  }
-  if (auth.placement === "literal") {
-    return {
-      apiKey: auth.apiKey,
-      summary: "API key (user-level x-api-key)",
-    }
-  }
-  return {
-    apiKeyEnvVariable: auth.envVariable,
-    summary: `API key (env ${auth.envVariable})`,
-  }
+function describeMcpAuth(auth: McpAuthConfig): string {
+  if (auth.mode === "oauth") return "OAuth"
+  if (auth.placement === "literal") return "API key (user-level x-api-key)"
+  return `API key (env ${auth.envVariable})`
 }
 
 export async function runInit(opts: InitRunOpts): Promise<void> {
@@ -152,13 +133,13 @@ export async function runInit(opts: InitRunOpts): Promise<void> {
   validateClients(agents)
   // In non-interactive mode an unspecified --memory means "do not enable".
   const memoryEnabled = answers.memory === true
-  const mcpAuth = answers.mcp
-    ? resolveMcpInstallAuth({
+  const mcpAuth: McpAuthConfig = answers.mcp
+    ? resolveMcpAuth({
         auth: answers.auth,
         apiKey: answers.apiKey,
         apiKeyEnvVariable: answers.apiKeyEnvVariable,
       })
-    : { summary: "OAuth" }
+    : { mode: "oauth" }
 
   const context = createOperationContext({ commandExists })
   const ctxpipeConfig = buildCtxpipeConfigOperation({
@@ -173,8 +154,7 @@ export async function runInit(opts: InitRunOpts): Promise<void> {
         org,
         scope,
         memory: false,
-        apiKey: mcpAuth.apiKey,
-        apiKeyEnvVariable: mcpAuth.apiKeyEnvVariable,
+        auth: mcpAuth,
         context,
       })
     : []
@@ -206,7 +186,7 @@ export async function runInit(opts: InitRunOpts): Promise<void> {
       `Organization ${org}`,
       `Scope ${scopeLabel(scope)}`,
       `Agents ${agentsLabel(agents, answers.mcp)}`,
-      `MCP auth ${mcpAuth.summary}`,
+      `MCP auth ${describeMcpAuth(mcpAuth)}`,
       `Memory ${memoryEnabled ? "enabled (Markdown .ai/memory + capture hooks)" : "disabled"}`,
     ],
   })
@@ -296,7 +276,7 @@ export async function runMcpAdd(opts: McpAddRunOpts): Promise<void> {
   if (!scope) throw new Error("Missing --scope")
   validateScope(scope)
   validateClients(clients)
-  const mcpAuth = resolveMcpInstallAuth({
+  const mcpAuth = resolveMcpAuth({
     auth: values.auth,
     apiKey: values.apiKey,
     apiKeyEnvVariable: values.apiKeyEnvVariable,
@@ -307,8 +287,7 @@ export async function runMcpAdd(opts: McpAddRunOpts): Promise<void> {
     baseUrl: values.baseUrl,
     org,
     scope,
-    apiKey: mcpAuth.apiKey,
-    apiKeyEnvVariable: mcpAuth.apiKeyEnvVariable,
+    auth: mcpAuth,
     context: createOperationContext({ commandExists }),
   })
   // mcp add does not toggle memory; users opt-in through `ctxpipe memory init`.
@@ -324,7 +303,7 @@ export async function runMcpAdd(opts: McpAddRunOpts): Promise<void> {
       `Organization ${org}`,
       `Scope ${scopeLabel(scope)}`,
       `Agents ${agentsLabel(clients, true)}`,
-      `MCP auth ${mcpAuth.summary}`,
+      `MCP auth ${describeMcpAuth(mcpAuth)}`,
     ],
   })
 }

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -13,8 +13,8 @@ import type { Client } from "./constants.js"
 import { CLIENT_COMMANDS, CLIENT_LABELS, CLIENTS } from "./constants.js"
 import type { ApplyOperationResult } from "./fs-operations.js"
 import { applyOperation, applyOperations } from "./fs-operations.js"
+import { resolveMcpAuth } from "./mcp/auth-mode.js"
 import { diagnoseMcpEndpoint, formatMcpDoctorResult } from "./mcp/doctor.js"
-import { resolveMcpApiKey } from "./mcp/auth-mode.js"
 import {
   buildCtxpipeConfigOperation,
   buildMcpOperations,
@@ -56,6 +56,7 @@ export type InitRunOpts = {
   mcp: boolean
   auth?: string
   apiKey?: string
+  apiKeyEnvVariable?: string
   /** Tri-state: true = always enable, false = always skip, undefined = ask in interactive mode. */
   memory?: boolean
 }
@@ -70,6 +71,32 @@ export type McpAddRunOpts = {
   nonInteractive: boolean
   auth?: string
   apiKey?: string
+  apiKeyEnvVariable?: string
+}
+
+function resolveMcpInstallAuth(opts: {
+  auth: string | null
+  apiKey: string | null
+  apiKeyEnvVariable: string | null
+}): {
+  apiKey?: string
+  apiKeyEnvVariable?: string
+  summary: string
+} {
+  const auth = resolveMcpAuth(opts)
+  if (auth.mode === "oauth") {
+    return { summary: "OAuth" }
+  }
+  if (auth.placement === "literal") {
+    return {
+      apiKey: auth.apiKey,
+      summary: "API key (user-level x-api-key)",
+    }
+  }
+  return {
+    apiKeyEnvVariable: auth.envVariable,
+    summary: `API key (env ${auth.envVariable})`,
+  }
 }
 
 export async function runInit(opts: InitRunOpts): Promise<void> {
@@ -85,6 +112,7 @@ export async function runInit(opts: InitRunOpts): Promise<void> {
     mcp: boolean
     auth: string | null
     apiKey: string | null
+    apiKeyEnvVariable: string | null
     memory: boolean | undefined
   } = {
     org: opts.org ?? null,
@@ -96,7 +124,8 @@ export async function runInit(opts: InitRunOpts): Promise<void> {
     json: opts.json,
     mcp: opts.mcp,
     auth: opts.auth ?? null,
-    apiKey: opts.apiKey ?? process.env.CTXPIPE_API_KEY ?? null,
+    apiKey: opts.apiKey ?? null,
+    apiKeyEnvVariable: opts.apiKeyEnvVariable ?? null,
     memory: opts.memory,
   }
 
@@ -123,12 +152,13 @@ export async function runInit(opts: InitRunOpts): Promise<void> {
   validateClients(agents)
   // In non-interactive mode an unspecified --memory means "do not enable".
   const memoryEnabled = answers.memory === true
-  const apiKey = answers.mcp
-    ? resolveMcpApiKey({
+  const mcpAuth = answers.mcp
+    ? resolveMcpInstallAuth({
         auth: answers.auth,
         apiKey: answers.apiKey,
+        apiKeyEnvVariable: answers.apiKeyEnvVariable,
       })
-    : undefined
+    : { summary: "OAuth" }
 
   const context = createOperationContext({ commandExists })
   const ctxpipeConfig = buildCtxpipeConfigOperation({
@@ -143,7 +173,8 @@ export async function runInit(opts: InitRunOpts): Promise<void> {
         org,
         scope,
         memory: false,
-        apiKey,
+        apiKey: mcpAuth.apiKey,
+        apiKeyEnvVariable: mcpAuth.apiKeyEnvVariable,
         context,
       })
     : []
@@ -175,7 +206,7 @@ export async function runInit(opts: InitRunOpts): Promise<void> {
       `Organization ${org}`,
       `Scope ${scopeLabel(scope)}`,
       `Agents ${agentsLabel(agents, answers.mcp)}`,
-      `MCP auth ${apiKey ? "API key (user-level x-api-key)" : "OAuth"}`,
+      `MCP auth ${mcpAuth.summary}`,
       `Memory ${memoryEnabled ? "enabled (Markdown .ai/memory + capture hooks)" : "disabled"}`,
     ],
   })
@@ -241,7 +272,8 @@ export async function runMcpAdd(opts: McpAddRunOpts): Promise<void> {
     clients: [...opts.clients],
     scope: opts.scope ?? null,
     auth: opts.auth ?? null,
-    apiKey: opts.apiKey ?? process.env.CTXPIPE_API_KEY ?? null,
+    apiKey: opts.apiKey ?? null,
+    apiKeyEnvVariable: opts.apiKeyEnvVariable ?? null,
     dryRun: opts.dryRun,
   }
 
@@ -264,9 +296,10 @@ export async function runMcpAdd(opts: McpAddRunOpts): Promise<void> {
   if (!scope) throw new Error("Missing --scope")
   validateScope(scope)
   validateClients(clients)
-  const apiKey = resolveMcpApiKey({
+  const mcpAuth = resolveMcpInstallAuth({
     auth: values.auth,
     apiKey: values.apiKey,
+    apiKeyEnvVariable: values.apiKeyEnvVariable,
   })
 
   const operations = buildMcpOperations({
@@ -274,7 +307,8 @@ export async function runMcpAdd(opts: McpAddRunOpts): Promise<void> {
     baseUrl: values.baseUrl,
     org,
     scope,
-    apiKey,
+    apiKey: mcpAuth.apiKey,
+    apiKeyEnvVariable: mcpAuth.apiKeyEnvVariable,
     context: createOperationContext({ commandExists }),
   })
   // mcp add does not toggle memory; users opt-in through `ctxpipe memory init`.
@@ -290,7 +324,7 @@ export async function runMcpAdd(opts: McpAddRunOpts): Promise<void> {
       `Organization ${org}`,
       `Scope ${scopeLabel(scope)}`,
       `Agents ${agentsLabel(clients, true)}`,
-      `MCP auth ${apiKey ? "API key (user-level x-api-key)" : "OAuth"}`,
+      `MCP auth ${mcpAuth.summary}`,
     ],
   })
 }

--- a/packages/cli/src/mcp/auth-mode.ts
+++ b/packages/cli/src/mcp/auth-mode.ts
@@ -2,29 +2,69 @@ export const MCP_AUTH_MODES = ["oauth", "api-key"] as const
 
 export type McpAuthMode = (typeof MCP_AUTH_MODES)[number]
 
+export type McpAuthConfig =
+  | { mode: "oauth" }
+  | { mode: "api-key"; placement: "literal"; apiKey: string }
+  | { mode: "api-key"; placement: "env"; envVariable: string }
+
+const ENV_VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
+
 export function validateAuthMode(auth: string): asserts auth is McpAuthMode {
   if (!MCP_AUTH_MODES.includes(auth as McpAuthMode)) {
     throw new Error("--auth must be one of: oauth, api-key")
   }
 }
 
-export function resolveMcpApiKey(opts: {
-  auth?: string | null
-  apiKey?: string | null
-  env?: NodeJS.ProcessEnv
-}): string | undefined {
-  const auth = opts.auth?.trim() || "oauth"
-  validateAuthMode(auth)
-  if (auth !== "api-key") return undefined
-  const fromEnv = (opts.env ?? process.env).CTXPIPE_API_KEY?.trim()
-  const key = opts.apiKey?.trim() || fromEnv
-  if (!key) {
+export function validateEnvVariableName(name: string): void {
+  if (!ENV_VARIABLE_NAME.test(name)) {
     throw new Error(
-      "Missing API key for --auth api-key. Pass --api-key or set CTXPIPE_API_KEY. Keys are written only to user-level client config.",
+      "--api-key-env-variable must be a valid environment variable name (letters, digits, and underscore; cannot start with a digit).",
     )
   }
-  return key
+}
+
+export function resolveMcpAuth(opts: {
+  auth?: string | null
+  apiKey?: string | null
+  apiKeyEnvVariable?: string | null
+  env?: NodeJS.ProcessEnv
+}): McpAuthConfig {
+  const apiKey = opts.apiKey?.trim() || undefined
+  const apiKeyEnvVariable = opts.apiKeyEnvVariable?.trim() || undefined
+  if (apiKey && apiKeyEnvVariable) {
+    throw new Error("Use either --api-key or --api-key-env-variable, not both.")
+  }
+
+  const impliedApiKey = Boolean(apiKey || apiKeyEnvVariable)
+  const auth = opts.auth?.trim() || (impliedApiKey ? "api-key" : "oauth")
+  validateAuthMode(auth)
+  if (auth === "oauth") {
+    if (impliedApiKey) {
+      throw new Error(
+        "Cannot combine --auth oauth with --api-key or --api-key-env-variable",
+      )
+    }
+    return { mode: "oauth" }
+  }
+
+  if (apiKeyEnvVariable) {
+    validateEnvVariableName(apiKeyEnvVariable)
+    return {
+      mode: "api-key",
+      placement: "env",
+      envVariable: apiKeyEnvVariable,
+    }
+  }
+
+  const fromEnv = (opts.env ?? process.env).CTXPIPE_API_KEY?.trim()
+  const key = apiKey || fromEnv
+  if (!key) {
+    throw new Error(
+      "Missing API key for --auth api-key. Pass --api-key <key> to write a user-scope secret, --api-key-env-variable <name> to write an environment-variable reference, or set CTXPIPE_API_KEY for a user-scope literal key.",
+    )
+  }
+  return { mode: "api-key", placement: "literal", apiKey: key }
 }
 
 export const REPO_API_KEY_SKIP_DETAIL =
-  "API keys must not land in committed files. Repo MCP config was not written. Use --scope user with --auth api-key to write an x-api-key header to user-level client config."
+  "API keys must not land in committed files. Repo MCP config was not written. Use --scope user with --api-key to write an x-api-key header to user-level client config, or --api-key-env-variable to write an environment-variable reference in repo or user config."

--- a/packages/cli/src/mcp/mcp-operations.ts
+++ b/packages/cli/src/mcp/mcp-operations.ts
@@ -1,8 +1,8 @@
 import { homedir } from "node:os"
 import { join, resolve } from "node:path"
-import { resolveRepoRoot } from "../memory/paths.js"
 import type { Client, Scope } from "../constants.js"
 import { CLIENTS, DEFAULT_BASE_URL } from "../constants.js"
+import { resolveRepoRoot } from "../memory/paths.js"
 import {
   AI_MEMORY_RULE,
   DECISIONS_INDEX_SEED,
@@ -10,6 +10,7 @@ import {
   LESSONS_SEED,
   MEMORY_INDEX_SEED,
   MEMORY_README_SEED,
+  mergeGitignoreForMemory,
   PRDS_INDEX_SEED,
   PRODUCT_CONTEXT_SEED,
   SESSIONS_INDEX_SEED,
@@ -18,11 +19,10 @@ import {
   SKILL_CAPTURE_GLOSSARY,
   SKILL_CAPTURE_LESSON,
   SKILL_MEMORY_SEARCH,
-  mergeGitignoreForMemory,
 } from "../memory/seed.js"
+import { REPO_API_KEY_SKIP_DETAIL } from "./auth-mode.js"
 import type { JsonObject } from "./json.js"
 import { isObject } from "./json.js"
-import { REPO_API_KEY_SKIP_DETAIL } from "./auth-mode.js"
 import { mcpUrl, normalizeBaseUrl, relativePath, scopesFor } from "./paths.js"
 
 export type WriteJsonOperation = {
@@ -199,7 +199,11 @@ export function buildMemoryArtifactOperations({
     { type: "mkdir", path: events, description: "create events/" },
     seedText(resolve(memoryRoot, "README.md"), context.cwd, MEMORY_README_SEED),
     seedText(resolve(memoryRoot, "index.md"), context.cwd, MEMORY_INDEX_SEED),
-    seedText(resolve(memoryRoot, "lessons-learned.md"), context.cwd, LESSONS_SEED),
+    seedText(
+      resolve(memoryRoot, "lessons-learned.md"),
+      context.cwd,
+      LESSONS_SEED,
+    ),
     seedText(resolve(memoryRoot, "glossary.md"), context.cwd, GLOSSARY_SEED),
     seedText(
       resolve(memoryRoot, "product-context.md"),
@@ -279,6 +283,32 @@ export function buildMemoryMcpOperations(_opts: {
   return []
 }
 
+function interpolateApiKeyEnv(client: Client, envVariable: string): string {
+  switch (client) {
+    case "claude":
+      return `\${${envVariable}}`
+    case "opencode":
+      return `{env:${envVariable}}`
+    case "codex":
+      return envVariable
+    case "cursor":
+    case "vscode":
+      return `\${env:${envVariable}}`
+  }
+}
+
+function mcpHeaderValue(
+  client: Client,
+  scope: "repo" | "user",
+  opts: { apiKey?: string; apiKeyEnvVariable?: string },
+): string | undefined {
+  if (opts.apiKeyEnvVariable) {
+    return interpolateApiKeyEnv(client, opts.apiKeyEnvVariable)
+  }
+  if (opts.apiKey && scope === "user") return opts.apiKey
+  return undefined
+}
+
 export function buildMcpOperations({
   clients,
   baseUrl,
@@ -286,6 +316,7 @@ export function buildMcpOperations({
   scope,
   memory,
   apiKey,
+  apiKeyEnvVariable,
   context = createOperationContext(),
 }: {
   clients: Client[]
@@ -294,12 +325,16 @@ export function buildMcpOperations({
   scope: Scope
   memory?: boolean
   apiKey?: string
+  apiKeyEnvVariable?: string
   context?: OperationContext
 }): Operation[] {
   void memory
   const requested = scopesFor(scope)
-  const skippedRepo = Boolean(apiKey && requested.includes("repo"))
-  const scopes = apiKey ? requested.filter((item) => item === "user") : requested
+  const literalKey = Boolean(apiKey) && !apiKeyEnvVariable
+  const skippedRepo = Boolean(literalKey && requested.includes("repo"))
+  const scopes = literalKey
+    ? requested.filter((item) => item === "user")
+    : requested
   const operations = clients.flatMap((client) =>
     scopes.flatMap((singleScope) =>
       buildClientOperations({
@@ -308,6 +343,7 @@ export function buildMcpOperations({
         org,
         scope: singleScope,
         apiKey,
+        apiKeyEnvVariable,
         context,
       }),
     ),
@@ -329,6 +365,7 @@ export function buildClientOperations({
   org,
   scope,
   apiKey,
+  apiKeyEnvVariable,
   context = createOperationContext(),
 }: {
   client: Client
@@ -336,11 +373,15 @@ export function buildClientOperations({
   org: string
   scope: "repo" | "user"
   apiKey?: string
+  apiKeyEnvVariable?: string
   context?: OperationContext
 }): Operation[] {
-  if (apiKey && scope === "repo") return []
+  if (apiKey && !apiKeyEnvVariable && scope === "repo") return []
   const url = mcpUrl({ baseUrl, org })
-  const userApiKey = scope === "user" ? apiKey : undefined
+  const headerValue = mcpHeaderValue(client, scope, {
+    apiKey,
+    apiKeyEnvVariable,
+  })
   switch (client) {
     case "cursor":
       return [
@@ -352,34 +393,38 @@ export function buildClientOperations({
           url,
           label: "Cursor",
           cwd: context.cwd,
-          apiKey: userApiKey,
+          apiKey: headerValue,
         }),
       ]
     case "claude":
       if (scope === "user" && context.commandExists("claude")) {
-        return [{
-          type: "run",
-          command: [
-            "claude",
-            "mcp",
-            "add",
-            "--transport",
-            "http",
-            "ctxpipe",
-            "--scope",
-            "user",
-            ...(userApiKey ? ["--header", `x-api-key: ${userApiKey}`] : []),
-            url,
-          ],
-          description: "run Claude Code MCP add command",
-        }]
+        return [
+          {
+            type: "run",
+            command: [
+              "claude",
+              "mcp",
+              "add",
+              "--transport",
+              "http",
+              "ctxpipe",
+              "--scope",
+              "user",
+              ...(headerValue ? ["--header", `x-api-key: ${headerValue}`] : []),
+              url,
+            ],
+            description: "run Claude Code MCP add command",
+          },
+        ]
       }
-      if (userApiKey) {
-        return [{
-          type: "manual",
-          description: "show Claude Code user MCP add command",
-          detail: `Run: claude mcp add --transport http ctxpipe --scope user --header "x-api-key: ${userApiKey}" ${url}`,
-        }]
+      if (scope === "user" && headerValue) {
+        return [
+          {
+            type: "manual",
+            description: "show Claude Code user MCP add command",
+            detail: `Run: claude mcp add --transport http ctxpipe --scope user --header "x-api-key: ${headerValue}" ${url}`,
+          },
+        ]
       }
       return [
         writeMcpServersOperation({
@@ -387,6 +432,7 @@ export function buildClientOperations({
           url,
           label: "Claude Code project",
           cwd: context.cwd,
+          apiKey: headerValue,
         }),
       ]
     case "opencode":
@@ -398,59 +444,83 @@ export function buildClientOperations({
               : resolve(context.cwd, "opencode.json"),
           url,
           cwd: context.cwd,
-          apiKey: userApiKey,
+          apiKey: headerValue,
         }),
       ]
     case "vscode":
       if (scope === "user") {
-        return [{
-          type: "manual",
-          description: "open VS Code MCP install link",
-          detail: `Open vscode:mcp/install?${encodeURIComponent(
-            JSON.stringify({
-              name: "ctxpipe",
-              type: "http",
-              url,
-              ...(userApiKey
-                ? { headers: { "x-api-key": userApiKey } }
-                : {}),
-            }),
-          )}`,
-        }]
+        return [
+          {
+            type: "manual",
+            description: "open VS Code MCP install link",
+            detail: `Open vscode:mcp/install?${encodeURIComponent(
+              JSON.stringify({
+                name: "ctxpipe",
+                type: "http",
+                url,
+                ...(headerValue
+                  ? { headers: { "x-api-key": headerValue } }
+                  : {}),
+              }),
+            )}`,
+          },
+        ]
       }
       return [
         writeVsCodeOperation({
           path: resolve(context.cwd, ".vscode", "mcp.json"),
           url,
           cwd: context.cwd,
+          apiKey: headerValue,
         }),
       ]
     case "codex":
-      if (userApiKey) {
-        return [{
-          type: "manual",
-          description: "show Codex user MCP config snippet",
-          detail: [
-            "Add to ~/.codex/config.toml:",
-            "",
-            "[mcp_servers.ctxpipe]",
-            `url = "${url}"`,
-            `http_headers = { "x-api-key" = "${userApiKey}" }`,
-          ].join("\n"),
-        }]
+      if (headerValue && apiKeyEnvVariable) {
+        return [
+          {
+            type: "manual",
+            description: "show Codex MCP config snippet",
+            detail: [
+              "Add to ~/.codex/config.toml:",
+              "",
+              "[mcp_servers.ctxpipe]",
+              `url = "${url}"`,
+              `env_http_headers = { "x-api-key" = "${headerValue}" }`,
+            ].join("\n"),
+          },
+        ]
+      }
+      if (headerValue) {
+        return [
+          {
+            type: "manual",
+            description: "show Codex user MCP config snippet",
+            detail: [
+              "Add to ~/.codex/config.toml:",
+              "",
+              "[mcp_servers.ctxpipe]",
+              `url = "${url}"`,
+              `http_headers = { "x-api-key" = "${headerValue}" }`,
+            ].join("\n"),
+          },
+        ]
       }
       if (scope === "user" && context.commandExists("codex")) {
-        return [{
-          type: "run",
-          command: ["codex", "mcp", "add", "ctxpipe", "--url", url],
-          description: "run Codex MCP add command",
-        }]
+        return [
+          {
+            type: "run",
+            command: ["codex", "mcp", "add", "ctxpipe", "--url", url],
+            description: "run Codex MCP add command",
+          },
+        ]
       }
-      return [{
-        type: "manual",
-        description: "show Codex MCP add command",
-        detail: `Run: codex mcp add ctxpipe --url ${url}`,
-      }]
+      return [
+        {
+          type: "manual",
+          description: "show Codex MCP add command",
+          detail: `Run: codex mcp add ctxpipe --url ${url}`,
+        },
+      ]
   }
 }
 
@@ -511,9 +581,7 @@ export function writeOpenCodeOperation({
         type: "remote",
         url,
         enabled: true,
-        ...(apiKey
-          ? { headers: { "x-api-key": apiKey }, oauth: false }
-          : {}),
+        ...(apiKey ? { headers: { "x-api-key": apiKey }, oauth: false } : {}),
       }
       return {
         ...existing,
@@ -527,10 +595,12 @@ export function writeVsCodeOperation({
   path,
   url,
   cwd,
+  apiKey,
 }: {
   path: string
   url: string
   cwd: string
+  apiKey?: string
 }): WriteJsonOperation {
   return {
     type: "write-json",
@@ -543,6 +613,7 @@ export function writeVsCodeOperation({
       servers.ctxpipe = {
         type: "http",
         url,
+        ...(apiKey ? { headers: { "x-api-key": apiKey } } : {}),
       }
       return {
         ...existing,
@@ -558,10 +629,14 @@ export function validateScope(scope: string): asserts scope is Scope {
   }
 }
 
-export function validateClients(clients: string[]): asserts clients is Client[] {
+export function validateClients(
+  clients: string[],
+): asserts clients is Client[] {
   for (const client of clients) {
     if (!CLIENTS.includes(client as Client)) {
-      throw new Error(`Unsupported client "${client}". Use: ${CLIENTS.join(", ")}`)
+      throw new Error(
+        `Unsupported client "${client}". Use: ${CLIENTS.join(", ")}`,
+      )
     }
   }
 }

--- a/packages/cli/src/mcp/mcp-operations.ts
+++ b/packages/cli/src/mcp/mcp-operations.ts
@@ -20,7 +20,7 @@ import {
   SKILL_CAPTURE_LESSON,
   SKILL_MEMORY_SEARCH,
 } from "../memory/seed.js"
-import { REPO_API_KEY_SKIP_DETAIL } from "./auth-mode.js"
+import { REPO_API_KEY_SKIP_DETAIL, type McpAuthConfig } from "./auth-mode.js"
 import type { JsonObject } from "./json.js"
 import { isObject } from "./json.js"
 import { mcpUrl, normalizeBaseUrl, relativePath, scopesFor } from "./paths.js"
@@ -300,12 +300,13 @@ function interpolateApiKeyEnv(client: Client, envVariable: string): string {
 function mcpHeaderValue(
   client: Client,
   scope: "repo" | "user",
-  opts: { apiKey?: string; apiKeyEnvVariable?: string },
+  auth: McpAuthConfig,
 ): string | undefined {
-  if (opts.apiKeyEnvVariable) {
-    return interpolateApiKeyEnv(client, opts.apiKeyEnvVariable)
+  if (auth.mode === "oauth") return undefined
+  if (auth.placement === "env") {
+    return interpolateApiKeyEnv(client, auth.envVariable)
   }
-  if (opts.apiKey && scope === "user") return opts.apiKey
+  if (scope === "user") return auth.apiKey
   return undefined
 }
 
@@ -315,8 +316,7 @@ export function buildMcpOperations({
   org,
   scope,
   memory,
-  apiKey,
-  apiKeyEnvVariable,
+  auth = { mode: "oauth" },
   context = createOperationContext(),
 }: {
   clients: Client[]
@@ -324,13 +324,12 @@ export function buildMcpOperations({
   org: string
   scope: Scope
   memory?: boolean
-  apiKey?: string
-  apiKeyEnvVariable?: string
+  auth?: McpAuthConfig
   context?: OperationContext
 }): Operation[] {
   void memory
   const requested = scopesFor(scope)
-  const literalKey = Boolean(apiKey) && !apiKeyEnvVariable
+  const literalKey = auth.mode === "api-key" && auth.placement === "literal"
   const skippedRepo = Boolean(literalKey && requested.includes("repo"))
   const scopes = literalKey
     ? requested.filter((item) => item === "user")
@@ -342,8 +341,7 @@ export function buildMcpOperations({
         baseUrl,
         org,
         scope: singleScope,
-        apiKey,
-        apiKeyEnvVariable,
+        auth,
         context,
       }),
     ),
@@ -364,24 +362,20 @@ export function buildClientOperations({
   baseUrl,
   org,
   scope,
-  apiKey,
-  apiKeyEnvVariable,
+  auth = { mode: "oauth" },
   context = createOperationContext(),
 }: {
   client: Client
   baseUrl: string
   org: string
   scope: "repo" | "user"
-  apiKey?: string
-  apiKeyEnvVariable?: string
+  auth?: McpAuthConfig
   context?: OperationContext
 }): Operation[] {
-  if (apiKey && !apiKeyEnvVariable && scope === "repo") return []
+  if (auth.mode === "api-key" && auth.placement === "literal" && scope === "repo")
+    return []
   const url = mcpUrl({ baseUrl, org })
-  const headerValue = mcpHeaderValue(client, scope, {
-    apiKey,
-    apiKeyEnvVariable,
-  })
+  const headerValue = mcpHeaderValue(client, scope, auth)
   switch (client) {
     case "cursor":
       return [
@@ -478,9 +472,10 @@ export function buildClientOperations({
       if (headerValue) {
         const configPath =
           scope === "user" ? "~/.codex/config.toml" : ".codex/config.toml"
-        const headerLine = apiKeyEnvVariable
-          ? `env_http_headers = { "x-api-key" = "${headerValue}" }`
-          : `http_headers = { "x-api-key" = "${headerValue}" }`
+        const headerLine =
+          auth.mode === "api-key" && auth.placement === "env"
+            ? `env_http_headers = { "x-api-key" = "${headerValue}" }`
+            : `http_headers = { "x-api-key" = "${headerValue}" }`
         return [
           {
             type: "manual",

--- a/packages/cli/src/mcp/mcp-operations.ts
+++ b/packages/cli/src/mcp/mcp-operations.ts
@@ -475,32 +475,22 @@ export function buildClientOperations({
         }),
       ]
     case "codex":
-      if (headerValue && apiKeyEnvVariable) {
-        return [
-          {
-            type: "manual",
-            description: "show Codex MCP config snippet",
-            detail: [
-              "Add to ~/.codex/config.toml:",
-              "",
-              "[mcp_servers.ctxpipe]",
-              `url = "${url}"`,
-              `env_http_headers = { "x-api-key" = "${headerValue}" }`,
-            ].join("\n"),
-          },
-        ]
-      }
       if (headerValue) {
+        const configPath =
+          scope === "user" ? "~/.codex/config.toml" : ".codex/config.toml"
+        const headerLine = apiKeyEnvVariable
+          ? `env_http_headers = { "x-api-key" = "${headerValue}" }`
+          : `http_headers = { "x-api-key" = "${headerValue}" }`
         return [
           {
             type: "manual",
-            description: "show Codex user MCP config snippet",
+            description: `show Codex ${scope} MCP config snippet`,
             detail: [
-              "Add to ~/.codex/config.toml:",
+              `Add to ${configPath}:`,
               "",
               "[mcp_servers.ctxpipe]",
               `url = "${url}"`,
-              `http_headers = { "x-api-key" = "${headerValue}" }`,
+              headerLine,
             ].join("\n"),
           },
         ]

--- a/packages/cli/src/mcp/mcp-operations.ts
+++ b/packages/cli/src/mcp/mcp-operations.ts
@@ -422,7 +422,7 @@ export function buildClientOperations({
           {
             type: "manual",
             description: "show Claude Code user MCP add command",
-            detail: `Run: claude mcp add --transport http ctxpipe --scope user --header "x-api-key: ${headerValue}" ${url}`,
+            detail: `Run: claude mcp add --transport http ctxpipe --scope user --header 'x-api-key: ${headerValue}' ${url}`,
           },
         ]
       }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -41,13 +41,16 @@ function addMcpAuthOptions(command: Command): Command {
     .addOption(
       new Option(
         "--auth <oauth|api-key>",
-        "MCP auth: oauth writes URL-only config for any scope (default); api-key writes x-api-key only to user-level client config, never repo files",
-      )
-        .choices(["oauth", "api-key"]),
+        "MCP auth: oauth writes URL-only config for any scope (default). api-key is implied by --api-key or --api-key-env-variable",
+      ).choices(["oauth", "api-key"]),
     )
     .option(
       "--api-key <key>",
-      "API key for --auth api-key (or set CTXPIPE_API_KEY). Written only to user-level client config",
+      "Write the raw API key into user-level client config only (never repo files). Implies --auth api-key",
+    )
+    .option(
+      "--api-key-env-variable <name>",
+      "Write an environment-variable reference (not the secret) into repo and/or user MCP config. Implies --auth api-key. The MCP client must see this variable in its process environment",
     )
 }
 
@@ -78,6 +81,7 @@ Examples (non-interactive):
   npx ctxpipe init --org acme --agents codex,claude --scope repo --non-interactive
   npx ctxpipe mcp add --org acme --client cursor --scope repo --non-interactive
   npx ctxpipe mcp add --org acme --client cursor --scope user --auth api-key --api-key "$CTXPIPE_API_KEY" --non-interactive
+  npx ctxpipe mcp add --org acme --client cursor --scope both --api-key-env-variable CTXPIPE_API_KEY --non-interactive
   npx ctxpipe doctor --json
   npx ctxpipe doctor mcp --url "https://app.example.com/mcp?orgSlug=acme"
 `,
@@ -121,7 +125,11 @@ Examples (non-interactive):
           collectList,
           [] as string[],
         )
-        .option("--dry-run", "Print planned changes without writing files", false)
+        .option(
+          "--dry-run",
+          "Print planned changes without writing files",
+          false,
+        )
         .option(
           "--json",
           "Print machine-readable JSON (use with --non-interactive to apply; init only for apply summary)",
@@ -144,8 +152,9 @@ Examples (non-interactive):
           `
 MCP auth:
   Default is OAuth: URL-only config for repo, user, or both. The client completes browser OAuth.
-  --auth api-key writes the x-api-key header only to user-level client config (never repository files).
-  --scope repo or both with an API key skips repo MCP writes.
+  --api-key writes the raw x-api-key header only to user-level client config (never repository files).
+  --api-key-env-variable writes a client-specific environment-variable reference in the requested scope (repo, user, or both).
+  --auth api-key still accepts CTXPIPE_API_KEY as a user-scope literal key.
 `,
         ),
     ),
@@ -163,6 +172,7 @@ MCP auth:
       memory?: boolean
       auth?: string
       apiKey?: string
+      apiKeyEnvVariable?: string
     }
     const agents = [
       ...(opts.agents ?? []),
@@ -181,6 +191,7 @@ MCP auth:
       memory: opts.memory,
       auth: opts.auth,
       apiKey: opts.apiKey,
+      apiKeyEnvVariable: opts.apiKeyEnvVariable,
     })
   })
 
@@ -266,7 +277,11 @@ result means the endpoint is ready for OAuth, not that authenticated tools work.
           collectList,
           [] as string[],
         )
-        .option("--dry-run", "Print planned changes without writing files", false)
+        .option(
+          "--dry-run",
+          "Print planned changes without writing files",
+          false,
+        )
         .option(
           "--json",
           "Print machine-readable JSON (use with --non-interactive to apply)",
@@ -277,8 +292,9 @@ result means the endpoint is ready for OAuth, not that authenticated tools work.
           `
 MCP auth:
   Default is OAuth: URL-only config for repo, user, or both. The client completes browser OAuth.
-  --auth api-key writes the x-api-key header only to user-level client config (never repository files).
-  --scope repo or both with an API key skips repo MCP writes.
+  --api-key writes the raw x-api-key header only to user-level client config (never repository files).
+  --api-key-env-variable writes a client-specific environment-variable reference in the requested scope (repo, user, or both).
+  --auth api-key still accepts CTXPIPE_API_KEY as a user-scope literal key.
 `,
         ),
     ),
@@ -293,6 +309,7 @@ MCP auth:
       json: boolean
       auth?: string
       apiKey?: string
+      apiKeyEnvVariable?: string
     }
     const clients = [...(opts.client ?? []), ...(opts.clients ?? [])]
     await runMcpAdd({
@@ -305,6 +322,7 @@ MCP auth:
       nonInteractive: resolveNonInteractive(rawOpts),
       auth: opts.auth,
       apiKey: opts.apiKey,
+      apiKeyEnvVariable: opts.apiKeyEnvVariable,
     })
   })
 

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -9,8 +9,7 @@ import {
   spinner,
   text,
 } from "@clack/prompts"
-import type { McpAuthMode } from "./mcp/auth-mode.js"
-import { CLIENT_COMMANDS, CLIENT_LABELS, CLIENTS, type Client } from "./constants.js"
+import type { Organization } from "./auth.js"
 import {
   fetchOrganizations,
   fetchSession,
@@ -19,8 +18,15 @@ import {
   readStoredAuth,
   userLabel,
 } from "./auth.js"
-import type { Organization } from "./auth.js"
+import {
+  CLIENT_COMMANDS,
+  CLIENT_LABELS,
+  CLIENTS,
+  type Client,
+} from "./constants.js"
 import { readJsonObject } from "./fs-operations.js"
+import type { McpAuthMode } from "./mcp/auth-mode.js"
+import { validateEnvVariableName } from "./mcp/auth-mode.js"
 import { commandExists } from "./system.js"
 import { muted, printWizardHeader } from "./ui.js"
 
@@ -38,6 +44,7 @@ export type InitPromptState = {
   mcp: boolean
   auth: string | null
   apiKey: string | null
+  apiKeyEnvVariable: string | null
   /** Tri-state from CLI flags. undefined means "ask". */
   memory?: boolean | undefined
 }
@@ -49,6 +56,7 @@ export type InitPromptAnswers = {
   memory?: boolean
   auth?: McpAuthMode
   apiKey?: string
+  apiKeyEnvVariable?: string
 }
 
 export type McpPromptState = {
@@ -57,6 +65,7 @@ export type McpPromptState = {
   scope: string | null
   auth: string | null
   apiKey: string | null
+  apiKeyEnvVariable: string | null
 }
 
 export type McpPromptAnswers = {
@@ -65,6 +74,7 @@ export type McpPromptAnswers = {
   clients?: Client[]
   auth?: McpAuthMode
   apiKey?: string
+  apiKeyEnvVariable?: string
 }
 
 export type MemoryInitPromptState = {
@@ -127,7 +137,9 @@ export async function promptMemoryInitWizard(
 async function promptMemoryAgents(): Promise<Client[]> {
   const detectSpinner = spinner()
   detectSpinner.start("Detecting installed agents")
-  const detected = CLIENTS.filter((client) => commandExists(CLIENT_COMMANDS[client]))
+  const detected = CLIENTS.filter((client) =>
+    commandExists(CLIENT_COMMANDS[client]),
+  )
   detectSpinner.stop(
     detected.length > 0
       ? `Detected ${detected.length} agent${detected.length === 1 ? "" : "s"}`
@@ -172,7 +184,11 @@ async function promptMemoryAuthOrSkip(baseUrl: string): Promise<string | null> {
   })
 
   if (choice === "skip") {
-    log.message(muted("Local-only mode — Markdown memory and capture hooks need no account."))
+    log.message(
+      muted(
+        "Local-only mode — Markdown memory and capture hooks need no account.",
+      ),
+    )
     return null
   }
 
@@ -196,7 +212,9 @@ async function resolveOrgFromAuth(
       fetchOrganizations({ baseUrl, accessToken }).catch(() => []),
       fetchSession({ baseUrl, accessToken }).catch(() => null),
     ])
-    orgSpinner.stop(orgs.length > 0 ? "Loaded ctx| organizations" : "No organizations found")
+    orgSpinner.stop(
+      orgs.length > 0 ? "Loaded ctx| organizations" : "No organizations found",
+    )
   } catch (error) {
     orgSpinner.stop("Could not load ctx| organizations")
     throw error
@@ -258,11 +276,11 @@ export async function promptInitWizard(
     Object.assign(answers, await promptMcpAuth(current))
   }
   if (!current.scope) {
-    if (answers.auth === "api-key" || current.auth === "api-key") {
+    if (usesLiteralApiKey(answers, current)) {
       answers.scope = "user"
       log.message(
         muted(
-          "API-key MCP is user-scope only. Keys are never written to repository files.",
+          "Pasted API keys are written only to user-level client config. Use an environment-variable reference to configure repo scope.",
         ),
       )
     } else {
@@ -273,12 +291,14 @@ export async function promptInitWizard(
           {
             title: "This repo",
             value: "repo",
-            description: "Write project files such as .ctxpipe/config.json and MCP config.",
+            description:
+              "Write project files such as .ctxpipe/config.json and MCP config.",
           },
           {
             title: "Globally",
             value: "user",
-            description: "Configure supported clients for your whole machine when possible.",
+            description:
+              "Configure supported clients for your whole machine when possible.",
           },
           {
             title: "Both",
@@ -304,8 +324,12 @@ async function promptSetupOrg(baseUrl: string): Promise<string> {
     sessionSpinner.start("Checking existing ctx| session")
     try {
       ;[orgs, session] = await Promise.all([
-        fetchOrganizations({ baseUrl, accessToken: auth.accessToken }).catch(() => []),
-        fetchSession({ baseUrl, accessToken: auth.accessToken }).catch(() => null),
+        fetchOrganizations({ baseUrl, accessToken: auth.accessToken }).catch(
+          () => [],
+        ),
+        fetchSession({ baseUrl, accessToken: auth.accessToken }).catch(
+          () => null,
+        ),
       ])
       sessionSpinner.stop(
         orgs.length > 0 ? "Loaded ctx| organizations" : "Sign-in required",
@@ -325,7 +349,9 @@ async function promptSetupOrg(baseUrl: string): Promise<string> {
     try {
       ;[orgs, session] = await Promise.all([
         fetchOrganizations({ baseUrl, accessToken: auth.accessToken }),
-        fetchSession({ baseUrl, accessToken: auth.accessToken }).catch(() => null),
+        fetchSession({ baseUrl, accessToken: auth.accessToken }).catch(
+          () => null,
+        ),
       ])
       orgSpinner.stop("Loaded ctx| organizations")
     } catch (error) {
@@ -370,7 +396,11 @@ export async function promptMcpWizard(
 ): Promise<McpPromptAnswers> {
   printWizardHeader()
   log.step("MCP")
-  log.message(muted("Choose the clients ctxpipe should configure for this machine or repo."))
+  log.message(
+    muted(
+      "Choose the clients ctxpipe should configure for this machine or repo.",
+    ),
+  )
 
   const answers: McpPromptAnswers = {}
   if (!current.org) {
@@ -384,11 +414,11 @@ export async function promptMcpWizard(
   }
   Object.assign(answers, await promptMcpAuth(current))
   if (!current.scope) {
-    if (answers.auth === "api-key" || current.auth === "api-key") {
+    if (usesLiteralApiKey(answers, current)) {
       answers.scope = "user"
       log.message(
         muted(
-          "API-key MCP is user-scope only. Keys are never written to repository files.",
+          "Pasted API keys are written only to user-level client config. Use an environment-variable reference to configure repo scope.",
         ),
       )
     } else {
@@ -409,9 +439,18 @@ export async function promptMcpWizard(
 async function promptMcpAuth(current: {
   auth: string | null
   apiKey: string | null
-}): Promise<{ auth?: McpAuthMode; apiKey?: string }> {
-  const answers: { auth?: McpAuthMode; apiKey?: string } = {}
-  if (!current.auth) {
+  apiKeyEnvVariable: string | null
+}): Promise<{
+  auth?: McpAuthMode
+  apiKey?: string
+  apiKeyEnvVariable?: string
+}> {
+  const answers: {
+    auth?: McpAuthMode
+    apiKey?: string
+    apiKeyEnvVariable?: string
+  } = {}
+  if (!current.auth && !current.apiKey && !current.apiKeyEnvVariable) {
     answers.auth = await promptSelect<McpAuthMode>({
       message: "How should this machine authenticate MCP?",
       initial: "oauth",
@@ -419,28 +458,62 @@ async function promptMcpAuth(current: {
         {
           title: "OAuth (recommended)",
           value: "oauth",
-          description: "URL-only config. The client opens a browser to sign in.",
+          description:
+            "URL-only config. The client opens a browser to sign in.",
         },
         {
           title: "API key",
           value: "api-key",
           description:
-            "Write x-api-key to user-level client config only. Never committed to the repo.",
+            "Use x-api-key. Paste a key into user config, or write an environment-variable reference.",
         },
       ],
     })
   }
-  const auth = answers.auth ?? current.auth
-  if (auth === "api-key" && !current.apiKey) {
-    answers.apiKey = await promptApiKey()
+  const auth =
+    answers.auth ??
+    current.auth ??
+    (current.apiKey || current.apiKeyEnvVariable ? "api-key" : null)
+  if (auth === "api-key" && !current.apiKey && !current.apiKeyEnvVariable) {
+    const placement = await promptSelect<"env" | "literal">({
+      message: "How should the API key be stored?",
+      initial: "env",
+      choices: [
+        {
+          title: "Environment variable",
+          value: "env",
+          description:
+            "Write a placeholder in repo or user MCP config. Set the variable in the client process.",
+        },
+        {
+          title: "Paste key (user config only)",
+          value: "literal",
+          description:
+            "Write the raw key into user-level client config. Never committed to the repo.",
+        },
+      ],
+    })
+    if (placement === "env") {
+      answers.apiKeyEnvVariable = await promptEnvVariableName()
+    } else {
+      answers.apiKey = await promptApiKey()
+    }
   }
   return answers
+}
+
+function usesLiteralApiKey(
+  answers: { apiKey?: string; apiKeyEnvVariable?: string },
+  current: { apiKey: string | null; apiKeyEnvVariable: string | null },
+): boolean {
+  if (answers.apiKeyEnvVariable ?? current.apiKeyEnvVariable) return false
+  return Boolean(answers.apiKey ?? current.apiKey)
 }
 
 async function promptApiKey(): Promise<string> {
   log.message(
     muted(
-      "Create a key under User account → API Keys, then paste it here. Keys are written only to user-level client config.",
+      "Create a key under User account → API Keys, then paste it here. The raw key is written only to user-level client config.",
     ),
   )
   const answer = await password({
@@ -450,10 +523,35 @@ async function promptApiKey(): Promise<string> {
   return String(promptValue(answer)).trim()
 }
 
+async function promptEnvVariableName(): Promise<string> {
+  log.message(
+    muted(
+      "The CLI writes the variable name, not the secret. Set this variable in the MCP client's process environment before connecting.",
+    ),
+  )
+  const answer = await text({
+    message: "Environment variable name",
+    initialValue: "CTXPIPE_API_KEY",
+    validate: (value) => {
+      const name = String(value ?? "").trim()
+      if (!name) return "Required"
+      try {
+        validateEnvVariableName(name)
+        return undefined
+      } catch {
+        return "Use a valid environment variable name (letters, digits, underscore)."
+      }
+    },
+  })
+  return String(promptValue(answer)).trim()
+}
+
 async function promptAgents(): Promise<Client[]> {
   const detectSpinner = spinner()
   detectSpinner.start("Detecting installed agents")
-  const detected = CLIENTS.filter((client) => commandExists(CLIENT_COMMANDS[client]))
+  const detected = CLIENTS.filter((client) =>
+    commandExists(CLIENT_COMMANDS[client]),
+  )
   detectSpinner.stop(
     detected.length > 0
       ? `Detected ${detected.length} agent${detected.length === 1 ? "" : "s"}`
@@ -490,7 +588,9 @@ async function promptText({
 }
 
 export function detectDefaultOrgSlug(): string | undefined {
-  const existing = readJsonObject(resolve(process.cwd(), ".ctxpipe", "config.json"))
+  const existing = readJsonObject(
+    resolve(process.cwd(), ".ctxpipe", "config.json"),
+  )
   if (typeof existing.orgSlug === "string" && existing.orgSlug.trim()) {
     return existing.orgSlug
   }

--- a/packages/cli/test/argv.test.ts
+++ b/packages/cli/test/argv.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process"
-import { mkdtempSync, readFileSync, existsSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -119,7 +119,7 @@ describe("CLI help and argv", () => {
     for (const out of [initHelp, addHelp]) {
       expect(out).toContain("--auth")
       expect(out).toContain("--api-key")
-      expect(out).toContain("user-level")
+      expect(out).toContain("--api-key-env-variable")
       expect(out).toContain("oauth")
       expect(out).toContain("api-key")
     }
@@ -229,5 +229,49 @@ describe("CLI help and argv", () => {
       "ctxp_secret",
     )
     expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(false)
+  })
+
+  it("mcp add --api-key-env-variable writes env references to repo and user Cursor config", () => {
+    const home = mkdtempSync(join(tmpdir(), "ctxpipe-mcp-env-home-"))
+    const cwd = mkdtempSync(join(tmpdir(), "ctxpipe-mcp-env-cwd-"))
+    execFileSync(
+      process.execPath,
+      [
+        bin,
+        "mcp",
+        "add",
+        "--org",
+        "acme",
+        "--client",
+        "cursor",
+        "--scope",
+        "both",
+        "--api-key-env-variable",
+        "CTXPIPE_API_KEY",
+        "--non-interactive",
+      ],
+      {
+        encoding: "utf8",
+        cwd,
+        env: {
+          ...process.env,
+          HOME: home,
+          CTXPIPE_API_KEY: "ctxp_must_not_be_written",
+        },
+      },
+    )
+    const header = { "x-api-key": `\${env:CTXPIPE_API_KEY}` }
+    const repoConfig = JSON.parse(
+      readFileSync(join(cwd, ".cursor", "mcp.json"), "utf8"),
+    ) as {
+      mcpServers: { ctxpipe?: { headers?: { "x-api-key"?: string } } }
+    }
+    const userConfig = JSON.parse(
+      readFileSync(join(home, ".cursor", "mcp.json"), "utf8"),
+    ) as {
+      mcpServers: { ctxpipe?: { headers?: { "x-api-key"?: string } } }
+    }
+    expect(repoConfig.mcpServers.ctxpipe?.headers).toEqual(header)
+    expect(userConfig.mcpServers.ctxpipe?.headers).toEqual(header)
   })
 })

--- a/packages/cli/test/auth-mode.test.ts
+++ b/packages/cli/test/auth-mode.test.ts
@@ -1,32 +1,82 @@
 import { describe, expect, it } from "vitest"
-import { resolveMcpApiKey, validateAuthMode } from "../src/mcp/auth-mode.js"
+import { resolveMcpAuth, validateAuthMode } from "../src/mcp/auth-mode.js"
 
 describe("MCP auth mode", () => {
-  it("defaults missing auth to OAuth and ignores a key", () => {
+  it("defaults missing auth to OAuth and ignores a stray key", () => {
     expect(
-      resolveMcpApiKey({
-        apiKey: "ctxp_ignored",
+      resolveMcpAuth({
         env: { CTXPIPE_API_KEY: "ctxp_env" },
       }),
-    ).toBeUndefined()
+    ).toEqual({ mode: "oauth" })
   })
 
-  it("requires a key for api-key auth", () => {
+  it("treats --api-key as explicit literal API-key auth", () => {
+    expect(resolveMcpAuth({ apiKey: " ctxp_flag " })).toEqual({
+      mode: "api-key",
+      placement: "literal",
+      apiKey: "ctxp_flag",
+    })
+  })
+
+  it("treats --api-key-env-variable as explicit env-reference API-key auth", () => {
+    expect(
+      resolveMcpAuth({
+        apiKeyEnvVariable: " MY_CTXPIPE_KEY ",
+        env: { MY_CTXPIPE_KEY: "ctxp_should_not_be_read" },
+      }),
+    ).toEqual({
+      mode: "api-key",
+      placement: "env",
+      envVariable: "MY_CTXPIPE_KEY",
+    })
+  })
+
+  it("does not require the env variable to be set when writing a reference", () => {
+    expect(
+      resolveMcpAuth({
+        auth: "api-key",
+        apiKeyEnvVariable: "CTXPIPE_API_KEY",
+        env: { CTXPIPE_API_KEY: "" },
+      }),
+    ).toEqual({
+      mode: "api-key",
+      placement: "env",
+      envVariable: "CTXPIPE_API_KEY",
+    })
+  })
+
+  it("rejects combining --api-key and --api-key-env-variable", () => {
     expect(() =>
-      resolveMcpApiKey({ auth: "api-key", env: { CTXPIPE_API_KEY: "" } }),
+      resolveMcpAuth({
+        apiKey: "ctxp_flag",
+        apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      }),
+    ).toThrow("either --api-key or --api-key-env-variable")
+  })
+
+  it("requires a key or env variable name for --auth api-key", () => {
+    expect(() =>
+      resolveMcpAuth({ auth: "api-key", env: { CTXPIPE_API_KEY: "" } }),
     ).toThrow("Missing API key")
   })
 
-  it("accepts --api-key or CTXPIPE_API_KEY", () => {
-    expect(resolveMcpApiKey({ auth: "api-key", apiKey: " ctxp_flag " })).toBe(
-      "ctxp_flag",
-    )
+  it("accepts --auth api-key with CTXPIPE_API_KEY as a literal key", () => {
     expect(
-      resolveMcpApiKey({
+      resolveMcpAuth({
         auth: "api-key",
         env: { CTXPIPE_API_KEY: "ctxp_env" },
       }),
-    ).toBe("ctxp_env")
+    ).toEqual({
+      mode: "api-key",
+      placement: "literal",
+      apiKey: "ctxp_env",
+    })
+  })
+
+  it("rejects an invalid environment variable name", () => {
+    expect(() => resolveMcpAuth({ apiKeyEnvVariable: "ctxpipe-key" })).toThrow(
+      "valid environment variable name",
+    )
   })
 
   it("rejects unknown auth modes", () => {

--- a/packages/cli/test/mcp-operations.test.ts
+++ b/packages/cli/test/mcp-operations.test.ts
@@ -505,11 +505,59 @@ describe("MCP operation builders", () => {
 
     expect(operation).toMatchObject({
       type: "manual",
-      description: "show Codex MCP config snippet",
+      description: "show Codex repo MCP config snippet",
     })
     const detail = operation?.type === "manual" ? operation.detail : ""
+    expect(detail).toContain("Add to .codex/config.toml:")
+    expect(detail).not.toContain("Add to ~/.codex/config.toml:")
     expect(detail).toContain(
       'env_http_headers = { "x-api-key" = "CTXPIPE_API_KEY" }',
     )
+  })
+
+  it("prints Codex user env_http_headers against ~/.codex/config.toml", () => {
+    const [operation] = buildClientOperations({
+      client: "codex",
+      baseUrl: "https://app.ctxpipe.ai",
+      org: "acme",
+      scope: "user",
+      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      context,
+    })
+
+    expect(operation).toMatchObject({
+      type: "manual",
+      description: "show Codex user MCP config snippet",
+    })
+    const detail = operation?.type === "manual" ? operation.detail : ""
+    expect(detail).toContain("Add to ~/.codex/config.toml:")
+    expect(detail).not.toContain("Add to .codex/config.toml:")
+    expect(detail).toContain(
+      'env_http_headers = { "x-api-key" = "CTXPIPE_API_KEY" }',
+    )
+  })
+
+  it("emits distinct Codex repo and user env snippets for both scope", () => {
+    const operations = buildMcpOperations({
+      clients: ["codex"],
+      baseUrl: "https://app.ctxpipe.ai",
+      org: "acme",
+      scope: "both",
+      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      context,
+    })
+
+    expect(operations).toHaveLength(2)
+    const details = operations.map((operation) =>
+      operation.type === "manual" ? operation.detail : "",
+    )
+    expect(details[0]).toContain("Add to .codex/config.toml:")
+    expect(details[1]).toContain("Add to ~/.codex/config.toml:")
+    expect(details[0]).not.toEqual(details[1])
+    for (const detail of details) {
+      expect(detail).toContain(
+        'env_http_headers = { "x-api-key" = "CTXPIPE_API_KEY" }',
+      )
+    }
   })
 })

--- a/packages/cli/test/mcp-operations.test.ts
+++ b/packages/cli/test/mcp-operations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import type { McpAuthConfig } from "../src/mcp/auth-mode.js"
 import {
   buildClientOperations,
   buildCtxpipeConfigOperation,
@@ -17,6 +18,16 @@ const context: OperationContext = createOperationContext({
   homeDir: "/home/alex",
   commandExists: (command) => command === "claude",
 })
+
+const literalApiKey = {
+  mode: "api-key",
+  placement: "literal",
+  apiKey: "ctxp_secret",
+} as const satisfies McpAuthConfig
+
+function envApiKey(envVariable = "CTXPIPE_API_KEY"): McpAuthConfig {
+  return { mode: "api-key", placement: "env", envVariable }
+}
 
 function writeJson(operation: unknown): WriteJsonOperation {
   expect(operation).toMatchObject({ type: "write-json" })
@@ -223,7 +234,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "user",
-      apiKey: "ctxp_secret",
+      auth: literalApiKey,
       context,
     })
     const [repoOp] = buildClientOperations({
@@ -259,7 +270,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "repo",
-      apiKey: "ctxp_secret",
+      auth: literalApiKey,
       context,
     })
 
@@ -278,7 +289,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "both",
-      apiKey: "ctxp_secret",
+      auth: literalApiKey,
       context,
     })
 
@@ -307,7 +318,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "user",
-      apiKey: "ctxp_secret",
+      auth: literalApiKey,
       context,
     })
     const [withoutCli] = buildClientOperations({
@@ -315,7 +326,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "user",
-      apiKey: "ctxp_secret",
+      auth: literalApiKey,
       context: createOperationContext({
         cwd: "/repo",
         homeDir: "/home/alex",
@@ -342,7 +353,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "user",
-      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      auth: envApiKey(),
       context: createOperationContext({
         cwd: "/repo",
         homeDir: "/home/alex",
@@ -365,7 +376,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "user",
-      apiKey: "ctxp_secret",
+      auth: literalApiKey,
       context,
     })
 
@@ -384,7 +395,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "user",
-      apiKey: "ctxp_secret",
+      auth: literalApiKey,
       context: createOperationContext({
         cwd: "/repo",
         homeDir: "/home/alex",
@@ -407,7 +418,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "both",
-      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      auth: envApiKey(),
       context,
     })
 
@@ -432,7 +443,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "repo",
-      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      auth: envApiKey(),
       context,
     })
 
@@ -455,7 +466,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "repo",
-      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      auth: envApiKey(),
       context,
     })
 
@@ -477,7 +488,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "repo",
-      apiKeyEnvVariable: "MY_KEY",
+      auth: envApiKey("MY_KEY"),
       context,
     })
 
@@ -499,7 +510,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "repo",
-      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      auth: envApiKey(),
       context,
     })
 
@@ -521,7 +532,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "user",
-      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      auth: envApiKey(),
       context,
     })
 
@@ -543,7 +554,7 @@ describe("MCP operation builders", () => {
       baseUrl: "https://app.ctxpipe.ai",
       org: "acme",
       scope: "both",
-      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      auth: envApiKey(),
       context,
     })
 

--- a/packages/cli/test/mcp-operations.test.ts
+++ b/packages/cli/test/mcp-operations.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest"
 import {
   buildClientOperations,
   buildCtxpipeConfigOperation,
+  buildMcpOperations,
   buildMemoryConfigOperation,
   buildMemoryMcpOperations,
-  buildMcpOperations,
   createOperationContext,
+  type OperationContext,
   validateClients,
   validateScope,
-  type OperationContext,
   type WriteJsonOperation,
 } from "../src/mcp/mcp-operations.js"
 
@@ -325,10 +325,7 @@ describe("MCP operation builders", () => {
 
     expect(withCli).toMatchObject({
       type: "run",
-      command: expect.arrayContaining([
-        "--header",
-        "x-api-key: ctxp_secret",
-      ]),
+      command: expect.arrayContaining(["--header", "x-api-key: ctxp_secret"]),
     })
     expect(withoutCli).toMatchObject({
       type: "manual",
@@ -378,6 +375,118 @@ describe("MCP operation builders", () => {
     })
     expect(operation?.type === "manual" ? operation.detail : "").toContain(
       'http_headers = { "x-api-key" = "ctxp_secret" }',
+    )
+  })
+
+  it("writes env-variable API-key references to repo and user Cursor config", () => {
+    const operations = buildMcpOperations({
+      clients: ["cursor"],
+      baseUrl: "https://app.ctxpipe.ai",
+      org: "acme",
+      scope: "both",
+      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      context,
+    })
+
+    expect(operations.map((operation) => writeJson(operation).path)).toEqual([
+      "/repo/.cursor/mcp.json",
+      "/home/alex/.cursor/mcp.json",
+    ])
+    expect(writeJson(operations[0]).content({})).toEqual({
+      mcpServers: {
+        ctxpipe: {
+          type: "streamable-http",
+          url: "https://app.ctxpipe.ai/mcp?orgSlug=acme",
+          headers: { "x-api-key": `\${env:CTXPIPE_API_KEY}` },
+        },
+      },
+    })
+  })
+
+  it("writes OpenCode env interpolation and oauth disabled for repo scope", () => {
+    const [operation] = buildClientOperations({
+      client: "opencode",
+      baseUrl: "https://app.ctxpipe.ai",
+      org: "acme",
+      scope: "repo",
+      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      context,
+    })
+
+    expect(writeJson(operation).content({})).toEqual({
+      mcp: {
+        ctxpipe: {
+          type: "remote",
+          url: "https://app.ctxpipe.ai/mcp?orgSlug=acme",
+          enabled: true,
+          headers: { "x-api-key": "{env:CTXPIPE_API_KEY}" },
+          oauth: false,
+        },
+      },
+    })
+  })
+
+  it("writes Claude project config with env-var header interpolation", () => {
+    const [operation] = buildClientOperations({
+      client: "claude",
+      baseUrl: "https://app.ctxpipe.ai",
+      org: "acme",
+      scope: "repo",
+      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      context,
+    })
+
+    expect(writeJson(operation).path).toBe("/repo/.mcp.json")
+    expect(writeJson(operation).content({})).toEqual({
+      mcpServers: {
+        ctxpipe: {
+          type: "streamable-http",
+          url: "https://app.ctxpipe.ai/mcp?orgSlug=acme",
+          headers: { "x-api-key": `\${CTXPIPE_API_KEY}` },
+        },
+      },
+    })
+  })
+
+  it("writes VS Code repo config with env-var headers", () => {
+    const [operation] = buildClientOperations({
+      client: "vscode",
+      baseUrl: "https://app.ctxpipe.ai",
+      org: "acme",
+      scope: "repo",
+      apiKeyEnvVariable: "MY_KEY",
+      context,
+    })
+
+    expect(writeJson(operation).path).toBe("/repo/.vscode/mcp.json")
+    expect(writeJson(operation).content({})).toEqual({
+      servers: {
+        ctxpipe: {
+          type: "http",
+          url: "https://app.ctxpipe.ai/mcp?orgSlug=acme",
+          headers: { "x-api-key": `\${env:MY_KEY}` },
+        },
+      },
+    })
+  })
+
+  it("prints Codex env_http_headers with the variable name", () => {
+    const [operation] = buildClientOperations({
+      client: "codex",
+      baseUrl: "https://app.ctxpipe.ai",
+      org: "acme",
+      scope: "repo",
+      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      context,
+    })
+
+    expect(operation).toMatchObject({
+      type: "manual",
+      description: "show Codex MCP config snippet",
+    })
+    const detail = operation?.type === "manual" ? operation.detail : ""
+    expect(detail).toContain(
+      'env_http_headers = { "x-api-key" = "CTXPIPE_API_KEY" }',
     )
   })
 })

--- a/packages/cli/test/mcp-operations.test.ts
+++ b/packages/cli/test/mcp-operations.test.ts
@@ -332,8 +332,31 @@ describe("MCP operation builders", () => {
       description: "show Claude Code user MCP add command",
     })
     expect(withoutCli?.type === "manual" ? withoutCli.detail : "").toContain(
-      '--header "x-api-key: ctxp_secret"',
+      "--header 'x-api-key: ctxp_secret'",
     )
+  })
+
+  it("prints Claude user env-header commands with single-quoted interpolants", () => {
+    const [operation] = buildClientOperations({
+      client: "claude",
+      baseUrl: "https://app.ctxpipe.ai",
+      org: "acme",
+      scope: "user",
+      apiKeyEnvVariable: "CTXPIPE_API_KEY",
+      context: createOperationContext({
+        cwd: "/repo",
+        homeDir: "/home/alex",
+        commandExists: () => false,
+      }),
+    })
+
+    expect(operation).toMatchObject({
+      type: "manual",
+      description: "show Claude Code user MCP add command",
+    })
+    const detail = operation?.type === "manual" ? operation.detail : ""
+    expect(detail).toContain("--header 'x-api-key: ${CTXPIPE_API_KEY}'")
+    expect(detail).not.toContain('--header "x-api-key:')
   })
 
   it("includes headers in the VS Code user install payload", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to PR 316: API-key MCP install now has two explicit flags.

- `--api-key <key>` still writes the **raw secret** to **user-scope** client config only. `--scope repo` / `both` skip repo writes.
- `--api-key-env-variable <name>` writes a **client-specific environment-variable reference** (not the secret) in the requested scope (`repo`, `user`, or `both`). The client process must have that variable set.
- The two flags are mutually exclusive and imply `--auth api-key`. `--auth api-key` without either flag still accepts `CTXPIPE_API_KEY` as a user-scope literal (PR 316 behavior).
- Wizard asks paste vs env-variable; only paste forces user scope.
- Claude's **manual** user-scope follow-up (when `claude` is not on PATH) single-quotes the header so a copied shell command keeps `${NAME}` literal instead of expanding it.

Header shapes:

| Client | Env reference |
| --- | --- |
| Cursor / VS Code | `${env:NAME}` |
| Claude Code | `${NAME}` |
| OpenCode | `{env:NAME}` |
| Codex | `env_http_headers` with the variable **name** |

GitHub “Install MCP via PRs” stays URL-only OAuth.

## Testing

- `pnpm --filter ctxpipe test` — 121 passed, 1 skipped
- Argv: `--api-key` user-only write; `--api-key-env-variable` writes `${env:CTXPIPE_API_KEY}` to repo and user Cursor config even when `CTXPIPE_API_KEY` is set in the environment
- Claude manual follow-up uses `--header 'x-api-key: ${CTXPIPE_API_KEY}'` so paste-into-shell does not expand the interpolant
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a510c16-f7d0-46f8-8a0a-4ae9eee2823d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a510c16-f7d0-46f8-8a0a-4ae9eee2823d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

