### PR TITLE
Stop invite 403 when signed in as a different account

### DIFF
--- a/.changeset/invite-wrong-account-session.md
+++ b/.changeset/invite-wrong-account-session.md
@@ -1,0 +1,5 @@
+---
+"@ctxpipe/aws-cdk": patch
+---
+
+Stop organisation invites from 403ing when the browser is signed in as a different email than the invitation.

--- a/apps/backend/src/auth/config.ts
+++ b/apps/backend/src/auth/config.ts
@@ -18,6 +18,7 @@ import { type Db, initDb } from "../db/client.js"
 import { members } from "../db/schema/auth.js"
 import { schema } from "../db/schema.js"
 import { generateObjectId } from "../lib/id.js"
+import { invitationEmailLink } from "./invitation-email-url.js"
 import {
   getOAuthConsentOrganizationId,
   OAUTH_ORGANIZATION_CLAIM,
@@ -199,8 +200,11 @@ export function createBetterAuth() {
           },
         },
         async sendInvitationEmail(data) {
-          const acceptPath = `/.auth/accept-invitation?invitationId=${encodeURIComponent(data.id)}`
-          const inviteLink = `${env.AUTH_BASE_URL}/.auth/sign-up?redirectTo=${encodeURIComponent(`${acceptPath}&email=${encodeURIComponent(data.email)}`)}`
+          const inviteLink = invitationEmailLink(
+            env.AUTH_BASE_URL,
+            data.id,
+            data.email,
+          )
           const [{ sendEmail }, { InvitationEmail }] = await Promise.all([
             import("../email/index.js"),
             import("../email/templates/invitation.js"),

--- a/apps/backend/src/auth/invitation-email-url.test.ts
+++ b/apps/backend/src/auth/invitation-email-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { invitationEmailLink } from "./invitation-email-url.js"
+
+describe("invitationEmailLink", () => {
+  it("lands on accept-invitation instead of sign-up", () => {
+    expect(
+      invitationEmailLink(
+        "https://app.ctxpipe.ai",
+        "invitation_1",
+        "member@example.com",
+      ),
+    ).toBe(
+      "https://app.ctxpipe.ai/.auth/accept-invitation?invitationId=invitation_1&email=member%40example.com",
+    )
+  })
+})

--- a/apps/backend/src/auth/invitation-email-url.ts
+++ b/apps/backend/src/auth/invitation-email-url.ts
@@ -1,0 +1,12 @@
+export function invitationEmailLink(
+  authBaseUrl: string,
+  invitationId: string,
+  email: string,
+): string {
+  const base = authBaseUrl.replace(/\/$/, "")
+  const params = new URLSearchParams({
+    invitationId,
+    email,
+  })
+  return `${base}/.auth/accept-invitation?${params.toString()}`
+}

--- a/apps/ui/src/components/onboarding/OnboardingPageShell.stories.tsx
+++ b/apps/ui/src/components/onboarding/OnboardingPageShell.stories.tsx
@@ -40,6 +40,11 @@ export const DotNavHidden: Story = {
     showDotNav: false,
     sceneFailed: false,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const signOut = await canvas.findByRole("link", { name: "Sign out" })
+    expect(signOut).toHaveAttribute("href", "/.auth/sign-out")
+  },
 }
 
 export const DotNavVisible: Story = {

--- a/apps/ui/src/components/onboarding/OnboardingPageShell.tsx
+++ b/apps/ui/src/components/onboarding/OnboardingPageShell.tsx
@@ -61,6 +61,13 @@ export function OnboardingPageShell({
         />
       </div>
 
+      <a
+        href="/.auth/sign-out"
+        className="fixed left-4 top-4 z-20 text-xs text-zinc-500 transition-colors hover:text-teal-400 sm:left-6 sm:top-6"
+      >
+        Sign out
+      </a>
+
       <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-6 pb-24 pt-16 text-center">
         <section className="w-full max-w-3xl">
           <div

--- a/apps/ui/src/features/auth/InviteWrongAccountNotice.stories.tsx
+++ b/apps/ui/src/features/auth/InviteWrongAccountNotice.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { InviteWrongAccountNotice } from "./InviteWrongAccountNotice"
+
+const meta = {
+  title: "Components/Auth/InviteWrongAccountNotice",
+  component: InviteWrongAccountNotice,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof InviteWrongAccountNotice>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const WrongAccount: Story = {
+  args: {
+    sessionEmail: "other@example.com",
+    invitationEmail: "member@example.com",
+    signOutHref:
+      "/.auth/sign-out?redirectTo=%2F.auth%2Faccept-invitation%3FinvitationId%3Dinvitation_1",
+  },
+  decorators: [
+    (Story) => (
+      <div className="ctx-border ctx-surface w-[22rem] px-6 py-6">
+        <h2 className="mb-3 text-lg font-semibold text-zinc-100">
+          Join organisation
+        </h2>
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/apps/ui/src/features/auth/InviteWrongAccountNotice.tsx
+++ b/apps/ui/src/features/auth/InviteWrongAccountNotice.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@/components/ui/Button"
+import { InlineAlert } from "@/components/ui/InlineAlert"
+
+export function InviteWrongAccountNotice({
+  sessionEmail,
+  invitationEmail,
+  signOutHref,
+}: {
+  sessionEmail: string
+  invitationEmail: string
+  signOutHref: string
+}) {
+  return (
+    <div className="grid gap-4">
+      <InlineAlert variant="warning" title="Signed in with a different account">
+        <p>
+          This invitation is for{" "}
+          <span className="font-mono">{invitationEmail}</span>. You&apos;re
+          signed in as <span className="font-mono">{sessionEmail}</span>.
+        </p>
+      </InlineAlert>
+      <Button
+        variant="primary"
+        className="w-full rounded-none"
+        onPress={() => {
+          window.location.assign(signOutHref)
+        }}
+      >
+        Sign out to continue
+      </Button>
+    </div>
+  )
+}

--- a/apps/ui/src/features/auth/invite-accept-decision.test.ts
+++ b/apps/ui/src/features/auth/invite-accept-decision.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+import {
+  decideInviteAccept,
+  inviteAcceptPath,
+  inviteSignInHref,
+  inviteSignOutHref,
+} from "./invite-accept-decision"
+
+describe("decideInviteAccept", () => {
+  it("shows the join form when nobody is signed in", () => {
+    expect(
+      decideInviteAccept({
+        sessionEmail: null,
+        invitationEmail: "member@example.com",
+        invitationConfirmed: true,
+      }),
+    ).toEqual({ kind: "join" })
+  })
+
+  it("waits when a session exists but the invite email is still unknown", () => {
+    expect(
+      decideInviteAccept({
+        sessionEmail: "other@example.com",
+        invitationEmail: null,
+        invitationConfirmed: false,
+      }),
+    ).toEqual({ kind: "unknown" })
+  })
+
+  it("does not auto-accept from an unconfirmed URL email hint", () => {
+    expect(
+      decideInviteAccept({
+        sessionEmail: "member@example.com",
+        invitationEmail: "member@example.com",
+        invitationConfirmed: false,
+      }),
+    ).toEqual({ kind: "unknown" })
+  })
+
+  it("accepts when the confirmed invitation email matches the session", () => {
+    expect(
+      decideInviteAccept({
+        sessionEmail: "Member@example.com",
+        invitationEmail: "member@example.com",
+        invitationConfirmed: true,
+      }),
+    ).toEqual({ kind: "accept" })
+  })
+
+  it("blocks auto-accept when the session is a different account", () => {
+    expect(
+      decideInviteAccept({
+        sessionEmail: "other@example.com",
+        invitationEmail: "member@example.com",
+        invitationConfirmed: true,
+      }),
+    ).toEqual({
+      kind: "wrong-account",
+      sessionEmail: "other@example.com",
+      invitationEmail: "member@example.com",
+    })
+  })
+})
+
+describe("invite accept links", () => {
+  it("builds a same-origin accept path", () => {
+    expect(inviteAcceptPath("invitation_1", "member@example.com")).toBe(
+      "/.auth/accept-invitation?invitationId=invitation_1&email=member%40example.com",
+    )
+  })
+
+  it("sends signed-out users through sign-in back to the invite", () => {
+    expect(inviteSignInHref("invitation_1", "member@example.com")).toBe(
+      "/.auth/sign-in?redirectTo=%2F.auth%2Faccept-invitation%3FinvitationId%3Dinvitation_1%26email%3Dmember%2540example.com",
+    )
+  })
+
+  it("clears the wrong session then returns to the invite", () => {
+    expect(inviteSignOutHref("invitation_1", "member@example.com")).toBe(
+      "/.auth/sign-out?redirectTo=%2F.auth%2Faccept-invitation%3FinvitationId%3Dinvitation_1%26email%3Dmember%2540example.com",
+    )
+  })
+})

--- a/apps/ui/src/features/auth/invite-accept-decision.ts
+++ b/apps/ui/src/features/auth/invite-accept-decision.ts
@@ -1,0 +1,65 @@
+export type InviteAcceptDecision =
+  | { kind: "join" }
+  | { kind: "unknown" }
+  | { kind: "accept" }
+  | {
+      kind: "wrong-account"
+      sessionEmail: string
+      invitationEmail: string
+    }
+
+function emailsMatch(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): boolean {
+  if (!left || !right) return false
+  return left.trim().toLowerCase() === right.trim().toLowerCase()
+}
+
+export function decideInviteAccept(input: {
+  sessionEmail: string | null | undefined
+  invitationEmail: string | null | undefined
+  invitationConfirmed: boolean
+}): InviteAcceptDecision {
+  const sessionEmail = input.sessionEmail?.trim() || null
+  const invitationEmail = input.invitationEmail?.trim() || null
+
+  if (!sessionEmail) return { kind: "join" }
+  if (!invitationEmail) return { kind: "unknown" }
+  if (!emailsMatch(sessionEmail, invitationEmail)) {
+    return {
+      kind: "wrong-account",
+      sessionEmail,
+      invitationEmail,
+    }
+  }
+  if (!input.invitationConfirmed) return { kind: "unknown" }
+  return { kind: "accept" }
+}
+
+export function inviteAcceptPath(
+  invitationId: string,
+  email?: string | null,
+): string {
+  const params = new URLSearchParams({ invitationId })
+  if (email) params.set("email", email)
+  return `/.auth/accept-invitation?${params.toString()}`
+}
+
+export function inviteSignInHref(
+  invitationId: string,
+  email?: string | null,
+): string {
+  return `/.auth/sign-in?redirectTo=${encodeURIComponent(
+    inviteAcceptPath(invitationId, email),
+  )}`
+}
+
+export function inviteSignOutHref(
+  invitationId: string,
+  email?: string | null,
+): string {
+  return `/.auth/sign-out?redirectTo=${encodeURIComponent(
+    inviteAcceptPath(invitationId, email),
+  )}`
+}

--- a/apps/ui/src/lib/safe-auth-redirect.test.ts
+++ b/apps/ui/src/lib/safe-auth-redirect.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { safeAuthRedirectPath } from "./safe-auth-redirect"
+
+describe("safeAuthRedirectPath", () => {
+  it("keeps a same-origin auth path", () => {
+    expect(
+      safeAuthRedirectPath(
+        "/.auth/accept-invitation?invitationId=inv_1",
+        "/.auth/sign-in",
+      ),
+    ).toBe("/.auth/accept-invitation?invitationId=inv_1")
+  })
+
+  it("rejects absolute and protocol-relative URLs", () => {
+    expect(
+      safeAuthRedirectPath("https://evil.example/", "/.auth/sign-in"),
+    ).toBe("/.auth/sign-in")
+    expect(safeAuthRedirectPath("//evil.example", "/.auth/sign-in")).toBe(
+      "/.auth/sign-in",
+    )
+    expect(safeAuthRedirectPath("/\\evil.example", "/.auth/sign-in")).toBe(
+      "/.auth/sign-in",
+    )
+  })
+})

--- a/apps/ui/src/lib/safe-auth-redirect.ts
+++ b/apps/ui/src/lib/safe-auth-redirect.ts
@@ -1,0 +1,11 @@
+/** Same-origin relative path only. Rejects protocol-relative and absolute URLs. */
+export function safeAuthRedirectPath(
+  value: string | null | undefined,
+  fallback: string,
+): string {
+  if (!value) return fallback
+  if (!value.startsWith("/")) return fallback
+  if (value.startsWith("//") || value.startsWith("/\\")) return fallback
+  if (value.includes("://")) return fallback
+  return value
+}

--- a/apps/ui/src/routes/[.]auth.$authView.tsx
+++ b/apps/ui/src/routes/[.]auth.$authView.tsx
@@ -3,12 +3,19 @@ import { useMutation, useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import type { FormEvent } from "react"
 import { useEffect, useMemo, useRef, useState } from "react"
-import { betterAuthAuthViewClassNames } from "@/features/auth/betterAuthShellClassNames"
-import { acceptInvitationThenRedirect } from "@/features/auth/accept-invitation"
 import { Button } from "@/components/ui/Button"
 import { Spinner } from "@/components/ui/spinner"
-import { getAuthContinuationProps } from "@/lib/auth-continuation"
+import { acceptInvitationThenRedirect } from "@/features/auth/accept-invitation"
+import { betterAuthAuthViewClassNames } from "@/features/auth/betterAuthShellClassNames"
+import { InviteWrongAccountNotice } from "@/features/auth/InviteWrongAccountNotice"
+import {
+  decideInviteAccept,
+  inviteSignInHref,
+  inviteSignOutHref,
+} from "@/features/auth/invite-accept-decision"
 import { authClient, useSession } from "@/lib/auth-client"
+import { getAuthContinuationProps } from "@/lib/auth-continuation"
+import { safeAuthRedirectPath } from "@/lib/safe-auth-redirect"
 import { useGetAuthConfig } from "@/lib/useGetAuthConfig"
 
 export const Route = createFileRoute("/.auth/$authView")({
@@ -60,8 +67,11 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
     typeof window === "undefined"
       ? "/.auth/accept-invitation"
       : `${window.location.pathname}${window.location.search}`
-  const invitationId = props.invitationId ?? (params.get("invitationId") ?? "")
-  const redirectTo = props.redirectTo ?? (params.get("redirectTo") ?? "/onboarding")
+  const invitationId = props.invitationId ?? params.get("invitationId") ?? ""
+  const redirectTo =
+    props.redirectTo ?? params.get("redirectTo") ?? "/onboarding"
+  const invitationEmailFromUrl =
+    props.invitationEmail ?? params.get("email") ?? null
   const [name, setName] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
@@ -78,7 +88,7 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
       if (!res.ok) throw new Error("Invitation not found or expired")
       const json = (await res.json()) as InvitationDetails
       return {
-        email: props.invitationEmail ?? json.email,
+        email: json.email,
         organizationName: json.organizationName,
       }
     },
@@ -95,14 +105,17 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
   })
 
   const signUpMutation = useMutation({
-    mutationFn: async (input: { email: string; name: string; password: string }) => {
+    mutationFn: async (input: {
+      email: string
+      name: string
+      password: string
+    }) => {
       autoAcceptAttemptedRef.current = true
       await authClient.signUp.email({
         email: input.email,
         password: input.password,
         name: input.name,
-        callbackURL:
-          currentLocation,
+        callbackURL: currentLocation,
         fetchOptions: { throw: true },
       })
       await acceptInvitationThenRedirect(
@@ -113,12 +126,25 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
     onError: (err) => setError(extractErrorMessage(err)),
   })
 
+  const sessionEmail =
+    session && typeof session.user.email === "string"
+      ? session.user.email
+      : null
+  const invitationEmail =
+    invitationEmailQuery.data?.email ?? invitationEmailFromUrl ?? null
+  const decision = decideInviteAccept({
+    sessionEmail,
+    invitationEmail,
+    invitationConfirmed: Boolean(invitationEmailQuery.data?.email),
+  })
+
   useEffect(() => {
-    if (!session || sessionPending) return
-    if (!invitationId) {
+    if (sessionPending) return
+    if (session && !invitationId) {
       window.location.assign(redirectTo)
       return
     }
+    if (decision.kind !== "accept") return
     if (autoAcceptAttemptedRef.current) return
     autoAcceptAttemptedRef.current = true
     void acceptInvitationThenRedirect(
@@ -132,14 +158,40 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
     sessionPending,
     invitationId,
     redirectTo,
+    decision.kind,
     acceptInviteMutation,
   ])
 
   if (sessionPending) return null
+  if (decision.kind === "wrong-account") {
+    return (
+      <InviteWrongAccountNotice
+        sessionEmail={decision.sessionEmail}
+        invitationEmail={decision.invitationEmail}
+        signOutHref={inviteSignOutHref(invitationId, decision.invitationEmail)}
+      />
+    )
+  }
+  if (decision.kind === "unknown" && session) {
+    if (invitationEmailQuery.error) {
+      return (
+        <p className="text-sm text-red-400">
+          {invitationEmailQuery.error instanceof Error
+            ? invitationEmailQuery.error.message
+            : "Invitation not found or expired"}
+        </p>
+      )
+    }
+    return <AuthStatusMessage message="Loading invitation…" />
+  }
   if (session && error) {
     return <p className="text-sm text-red-400">{error}</p>
   }
-  if (session || signUpMutation.isPending || acceptInviteMutation.isPending) {
+  if (
+    decision.kind === "accept" ||
+    signUpMutation.isPending ||
+    acceptInviteMutation.isPending
+  ) {
     return <AuthStatusMessage message="Accepting organisation invite…" />
   }
 
@@ -251,6 +303,15 @@ function InviteAcceptSignUp(props: InviteAcceptSignUpProps = {}) {
           ? "Creating account…"
           : "Create account"}
       </Button>
+      <p className="text-center text-sm text-zinc-400">
+        Already have an account?{" "}
+        <a
+          href={inviteSignInHref(invitationId, invitationEmailQuery.data.email)}
+          className="text-teal-400 hover:text-teal-300 hover:underline"
+        >
+          Sign in
+        </a>
+      </p>
     </form>
   )
 }
@@ -291,6 +352,13 @@ function EmailVerificationSent() {
 
 function SignOutView() {
   const startedRef = useRef(false)
+  const redirectTo = useMemo(() => {
+    if (typeof window === "undefined") return "/.auth/sign-in"
+    return safeAuthRedirectPath(
+      new URLSearchParams(window.location.search).get("redirectTo"),
+      "/.auth/sign-in",
+    )
+  }, [])
 
   useEffect(() => {
     if (startedRef.current) return
@@ -300,24 +368,26 @@ function SignOutView() {
     const finish = () => {
       if (finished) return
       finished = true
-      window.location.replace("/.auth/sign-in")
+      window.location.replace(redirectTo)
     }
 
     const timeoutId = window.setTimeout(() => {
       finish()
     }, 4000)
 
-    void authClient.signOut({
-      fetchOptions: { throw: false },
-    }).finally(() => {
-      window.clearTimeout(timeoutId)
-      finish()
-    })
+    void authClient
+      .signOut({
+        fetchOptions: { throw: false },
+      })
+      .finally(() => {
+        window.clearTimeout(timeoutId)
+        finish()
+      })
 
     return () => {
       window.clearTimeout(timeoutId)
     }
-  }, [])
+  }, [redirectTo])
 
   return (
     <main className="hero-gradient min-h-screen bg-zinc-950 text-foreground">

--- a/apps/ui/src/routes/[.]auth.device.tsx
+++ b/apps/ui/src/routes/[.]auth.device.tsx
@@ -121,6 +121,21 @@ function DeviceAuthorizationPage() {
                 Approve this request to let the CLI load your organizations for
                 setup.
               </p>
+              {session && typeof session.user.email === "string" ? (
+                <p className="text-xs text-zinc-500">
+                  Signed in as{" "}
+                  <span className="font-mono text-zinc-400">
+                    {session.user.email}
+                  </span>
+                  {" · "}
+                  <a
+                    href={`/.auth/sign-out?redirectTo=${encodeURIComponent(currentPath)}`}
+                    className="text-teal-400 hover:text-teal-300 hover:underline"
+                  >
+                    Sign out
+                  </a>
+                </p>
+              ) : null}
             </div>
 
             {hasPrefilledCode ? null : (


### PR DESCRIPTION
## Summary
- Invite accept no longer auto-accepts whatever browser session is already there. A mismatched email shows both addresses and signs out back to the invite, instead of Better Auth's 403.
- Invitation emails now land on `/.auth/accept-invitation` (sign-in available for existing accounts). Onboarding and CLI device authorise expose sign-out so a GitHub/`npx ctxpipe init` session is not a dead end.

## Test plan
- [ ] Signed in as account A, open an invite for account B: see "Signed in with a different account", not a 403
- [ ] Sign out from that screen, sign in as B, invite accepts
- [ ] Logged out, invite shows create-account plus "Already have an account? Sign in"
- [ ] Onboarding shows a Sign out control
- [ ] CLI device page shows "Signed in as … · Sign out" when a session exists
- [ ] `pnpm --filter @ctxpipe/ui test` and `pnpm --filter @ctxpipe/backend exec vitest run src/auth/invitation-email-url.test.ts src/auth/config.test.ts`